### PR TITLE
chore(deps): revert nearcore to upstream repo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,6 +293,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4dc07131ffa69b8072d35f5007352af944213cde02545e2103680baed38fcd"
+
+[[package]]
 name = "async-recursion"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -445,7 +451,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
 dependencies = [
  "arrayref",
- "arrayvec",
+ "arrayvec 0.5.2",
  "constant_time_eq",
 ]
 
@@ -476,7 +482,7 @@ checksum = "b637a47728b78a78cd7f4b85bf06d71ef4221840e059a38f048be2422bf673b2"
 dependencies = [
  "borsh-derive-internal",
  "borsh-schema-derive-internal",
- "proc-macro-crate",
+ "proc-macro-crate 0.1.5",
  "proc-macro2",
  "syn",
 ]
@@ -695,12 +701,6 @@ dependencies = [
  "tracing-core",
  "tracing-error",
 ]
-
-[[package]]
-name = "conqueue"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac4306c796b95d3964b94fa65018a57daee08b45a54b86a4f64910426427b66"
 
 [[package]]
 name = "console"
@@ -926,33 +926,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80df024fbc5ac80f87dfef0d9f5209a252f2a497f7f42944cff24d8253cac065"
 dependencies = [
  "cfg-if 1.0.0",
-]
-
-[[package]]
-name = "ethbloom"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "779864b9c7f7ead1f092972c3257496c6a84b46dba2ce131dd8a282cb2cc5972"
-dependencies = [
- "crunchy",
- "fixed-hash",
- "impl-rlp",
- "impl-serde",
- "tiny-keccak",
-]
-
-[[package]]
-name = "ethereum-types"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f64b5df66a228d85e4b17e5d6c6aa43b0310898ffe8a85988c4c032357aaabfd"
-dependencies = [
- "ethbloom",
- "fixed-hash",
- "impl-rlp",
- "impl-serde",
- "primitive-types",
- "uint",
 ]
 
 [[package]]
@@ -1293,29 +1266,22 @@ dependencies = [
 
 [[package]]
 name = "impl-codec"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df170efa359aebdd5cb7fe78edcc67107748e4737bdca8a8fb40d15ea7a877ed"
+checksum = "161ebdfec3c8e3b52bf61c4f3550a1eea4f9579d10dc1b936f3171ebdcd6c443"
 dependencies = [
  "parity-scale-codec",
 ]
 
 [[package]]
-name = "impl-rlp"
-version = "0.3.0"
+name = "impl-trait-for-tuples"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f28220f89297a075ddc7245cd538076ee98b01f2a9c23a53a4f1105d5a322808"
+checksum = "d5dacb10c5b3bb92d46ba347505a9041e676bb20ad220101326bffb0c93031ee"
 dependencies = [
- "rlp",
-]
-
-[[package]]
-name = "impl-serde"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b47ca4d2b6931707a55fce5cf66aff80e2178c8b63bbb4ecb5695cbc870ddf6f"
-dependencies = [
- "serde",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1536,7 +1502,7 @@ dependencies = [
 [[package]]
 name = "near-account-id"
 version = "0.1.0"
-source = "git+https://github.com/miraclx/nearcore?rev=be74434190ac20231c6f86599ee790c6e38724dd#be74434190ac20231c6f86599ee790c6e38724dd"
+source = "git+https://github.com/near/nearcore?rev=e242f71400111fe99a825fd8f5e53a82802c98b7#e242f71400111fe99a825fd8f5e53a82802c98b7"
 dependencies = [
  "borsh",
  "serde",
@@ -1545,7 +1511,7 @@ dependencies = [
 [[package]]
 name = "near-chain-configs"
 version = "0.1.0"
-source = "git+https://github.com/miraclx/nearcore?rev=be74434190ac20231c6f86599ee790c6e38724dd#be74434190ac20231c6f86599ee790c6e38724dd"
+source = "git+https://github.com/near/nearcore?rev=e242f71400111fe99a825fd8f5e53a82802c98b7#e242f71400111fe99a825fd8f5e53a82802c98b7"
 dependencies = [
  "chrono",
  "derive_more",
@@ -1561,7 +1527,7 @@ dependencies = [
 [[package]]
 name = "near-chain-primitives"
 version = "0.1.0"
-source = "git+https://github.com/miraclx/nearcore?rev=be74434190ac20231c6f86599ee790c6e38724dd#be74434190ac20231c6f86599ee790c6e38724dd"
+source = "git+https://github.com/near/nearcore?rev=e242f71400111fe99a825fd8f5e53a82802c98b7#e242f71400111fe99a825fd8f5e53a82802c98b7"
 dependencies = [
  "chrono",
  "failure",
@@ -1575,7 +1541,7 @@ dependencies = [
 [[package]]
 name = "near-chunks-primitives"
 version = "0.1.0"
-source = "git+https://github.com/miraclx/nearcore?rev=be74434190ac20231c6f86599ee790c6e38724dd#be74434190ac20231c6f86599ee790c6e38724dd"
+source = "git+https://github.com/near/nearcore?rev=e242f71400111fe99a825fd8f5e53a82802c98b7#e242f71400111fe99a825fd8f5e53a82802c98b7"
 dependencies = [
  "near-chain-primitives",
 ]
@@ -1618,7 +1584,7 @@ dependencies = [
 [[package]]
 name = "near-client-primitives"
 version = "0.1.0"
-source = "git+https://github.com/miraclx/nearcore?rev=be74434190ac20231c6f86599ee790c6e38724dd#be74434190ac20231c6f86599ee790c6e38724dd"
+source = "git+https://github.com/near/nearcore?rev=e242f71400111fe99a825fd8f5e53a82802c98b7#e242f71400111fe99a825fd8f5e53a82802c98b7"
 dependencies = [
  "actix",
  "chrono",
@@ -1636,7 +1602,7 @@ dependencies = [
 [[package]]
 name = "near-crypto"
 version = "0.1.0"
-source = "git+https://github.com/miraclx/nearcore?rev=be74434190ac20231c6f86599ee790c6e38724dd#be74434190ac20231c6f86599ee790c6e38724dd"
+source = "git+https://github.com/near/nearcore?rev=e242f71400111fe99a825fd8f5e53a82802c98b7#e242f71400111fe99a825fd8f5e53a82802c98b7"
 dependencies = [
  "arrayref",
  "blake2",
@@ -1646,11 +1612,11 @@ dependencies = [
  "curve25519-dalek",
  "derive_more",
  "ed25519-dalek",
- "ethereum-types",
  "lazy_static",
  "libc",
  "near-account-id",
  "parity-secp256k1",
+ "primitive-types",
  "rand 0.7.3",
  "rand_core 0.5.1",
  "serde",
@@ -1662,7 +1628,7 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc-client"
 version = "0.1.0"
-source = "git+https://github.com/miraclx/nearcore?rev=be74434190ac20231c6f86599ee790c6e38724dd#be74434190ac20231c6f86599ee790c6e38724dd"
+source = "git+https://github.com/near/nearcore?rev=e242f71400111fe99a825fd8f5e53a82802c98b7#e242f71400111fe99a825fd8f5e53a82802c98b7"
 dependencies = [
  "actix-http",
  "actix-web",
@@ -1678,7 +1644,7 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc-primitives"
 version = "0.2.0"
-source = "git+https://github.com/miraclx/nearcore?rev=be74434190ac20231c6f86599ee790c6e38724dd#be74434190ac20231c6f86599ee790c6e38724dd"
+source = "git+https://github.com/near/nearcore?rev=e242f71400111fe99a825fd8f5e53a82802c98b7#e242f71400111fe99a825fd8f5e53a82802c98b7"
 dependencies = [
  "actix",
  "lazy_static",
@@ -1712,7 +1678,7 @@ dependencies = [
 [[package]]
 name = "near-metrics"
 version = "0.1.0"
-source = "git+https://github.com/miraclx/nearcore?rev=be74434190ac20231c6f86599ee790c6e38724dd#be74434190ac20231c6f86599ee790c6e38724dd"
+source = "git+https://github.com/near/nearcore?rev=e242f71400111fe99a825fd8f5e53a82802c98b7#e242f71400111fe99a825fd8f5e53a82802c98b7"
 dependencies = [
  "lazy_static",
  "log",
@@ -1722,20 +1688,14 @@ dependencies = [
 [[package]]
 name = "near-network-primitives"
 version = "0.1.0"
-source = "git+https://github.com/miraclx/nearcore?rev=be74434190ac20231c6f86599ee790c6e38724dd#be74434190ac20231c6f86599ee790c6e38724dd"
+source = "git+https://github.com/near/nearcore?rev=e242f71400111fe99a825fd8f5e53a82802c98b7#e242f71400111fe99a825fd8f5e53a82802c98b7"
 dependencies = [
  "actix",
  "borsh",
- "byteorder",
  "chrono",
- "conqueue",
- "futures",
- "lazy_static",
  "near-crypto",
- "near-metrics",
  "near-primitives",
  "serde",
- "serde_json",
  "strum 0.20.0",
  "tokio",
  "tracing",
@@ -1744,7 +1704,7 @@ dependencies = [
 [[package]]
 name = "near-primitives"
 version = "0.1.0"
-source = "git+https://github.com/miraclx/nearcore?rev=be74434190ac20231c6f86599ee790c6e38724dd#be74434190ac20231c6f86599ee790c6e38724dd"
+source = "git+https://github.com/near/nearcore?rev=e242f71400111fe99a825fd8f5e53a82802c98b7#e242f71400111fe99a825fd8f5e53a82802c98b7"
 dependencies = [
  "base64 0.13.0",
  "borsh",
@@ -1774,7 +1734,7 @@ dependencies = [
 [[package]]
 name = "near-primitives-core"
 version = "0.1.0"
-source = "git+https://github.com/miraclx/nearcore?rev=be74434190ac20231c6f86599ee790c6e38724dd#be74434190ac20231c6f86599ee790c6e38724dd"
+source = "git+https://github.com/near/nearcore?rev=e242f71400111fe99a825fd8f5e53a82802c98b7#e242f71400111fe99a825fd8f5e53a82802c98b7"
 dependencies = [
  "base64 0.11.0",
  "borsh",
@@ -1792,7 +1752,7 @@ dependencies = [
 [[package]]
 name = "near-rpc-error-core"
 version = "0.1.0"
-source = "git+https://github.com/miraclx/nearcore?rev=be74434190ac20231c6f86599ee790c6e38724dd#be74434190ac20231c6f86599ee790c6e38724dd"
+source = "git+https://github.com/near/nearcore?rev=e242f71400111fe99a825fd8f5e53a82802c98b7#e242f71400111fe99a825fd8f5e53a82802c98b7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1803,7 +1763,7 @@ dependencies = [
 [[package]]
 name = "near-rpc-error-macro"
 version = "0.1.0"
-source = "git+https://github.com/miraclx/nearcore?rev=be74434190ac20231c6f86599ee790c6e38724dd#be74434190ac20231c6f86599ee790c6e38724dd"
+source = "git+https://github.com/near/nearcore?rev=e242f71400111fe99a825fd8f5e53a82802c98b7#e242f71400111fe99a825fd8f5e53a82802c98b7"
 dependencies = [
  "near-rpc-error-core",
  "proc-macro2",
@@ -1816,7 +1776,7 @@ dependencies = [
 [[package]]
 name = "near-vm-errors"
 version = "3.0.0"
-source = "git+https://github.com/miraclx/nearcore?rev=be74434190ac20231c6f86599ee790c6e38724dd#be74434190ac20231c6f86599ee790c6e38724dd"
+source = "git+https://github.com/near/nearcore?rev=e242f71400111fe99a825fd8f5e53a82802c98b7#e242f71400111fe99a825fd8f5e53a82802c98b7"
 dependencies = [
  "borsh",
  "hex",
@@ -1965,14 +1925,28 @@ checksum = "2386b4ebe91c2f7f51082d4cefa145d030e33a1842a96b12e4885cc3c01f7a55"
 
 [[package]]
 name = "parity-scale-codec"
-version = "2.0.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75c823fdae1bb5ff5708ee61a62697e6296175dc671710876871c853f48592b3"
+checksum = "8975095a2a03bbbdc70a74ab11a4f76a6d0b84680d87c68d722531b0ac28e8a9"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.7.1",
  "bitvec",
  "byte-slice-cast",
+ "impl-trait-for-tuples",
+ "parity-scale-codec-derive",
  "serde",
+]
+
+[[package]]
+name = "parity-scale-codec-derive"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40dbbfef7f0a1143c5b06e0d76a6278e25dac0bc1af4be51a0fbb73f07e7ad09"
+dependencies = [
+ "proc-macro-crate 1.0.0",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1981,7 +1955,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fca4f82fccae37e8bbdaeb949a4a218a1bbc485d11598f193d2a908042e5fc1"
 dependencies = [
- "arrayvec",
+ "arrayvec 0.5.2",
  "cc",
  "cfg-if 0.1.10",
  "rand 0.7.3",
@@ -2070,14 +2044,12 @@ checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "primitive-types"
-version = "0.9.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2415937401cb030a2a0a4d922483f945fa068f52a7dbb22ce0fe5f2b6f6adace"
+checksum = "05e4722c697a58a99d5d06a08c30821d7c082a4632198de1eaa5a6c22ef42373"
 dependencies = [
  "fixed-hash",
  "impl-codec",
- "impl-rlp",
- "impl-serde",
  "uint",
 ]
 
@@ -2087,6 +2059,16 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
 dependencies = [
+ "toml",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fdbd1df62156fbc5945f4762632564d7d038153091c3fcf1067f6aef7cff92"
+dependencies = [
+ "thiserror",
  "toml",
 ]
 
@@ -2427,16 +2409,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
  "winapi",
-]
-
-[[package]]
-name = "rlp"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "999508abb0ae792aabed2460c45b89106d97fe4adac593bdaef433c2605847b5"
-dependencies = [
- "bytes",
- "rustc-hex",
 ]
 
 [[package]]
@@ -2931,15 +2903,6 @@ dependencies = [
  "quote",
  "standback",
  "syn",
-]
-
-[[package]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
-dependencies = [
- "crunchy",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ color-eyre = "0.5"
 
 near-ledger = "0.1.1"
 
-near-crypto = { git = "https://github.com/miraclx/nearcore", rev="be74434190ac20231c6f86599ee790c6e38724dd" }
-near-primitives = { git = "https://github.com/miraclx/nearcore", rev="be74434190ac20231c6f86599ee790c6e38724dd" }
-near-jsonrpc-client = { git = "https://github.com/miraclx/nearcore", rev="be74434190ac20231c6f86599ee790c6e38724dd" }
-near-jsonrpc-primitives = { git = "https://github.com/miraclx/nearcore", rev="be74434190ac20231c6f86599ee790c6e38724dd" }
+near-crypto = { git = "https://github.com/near/nearcore", rev="e242f71400111fe99a825fd8f5e53a82802c98b7" }
+near-primitives = { git = "https://github.com/near/nearcore", rev="e242f71400111fe99a825fd8f5e53a82802c98b7" }
+near-jsonrpc-client = { git = "https://github.com/near/nearcore", rev="e242f71400111fe99a825fd8f5e53a82802c98b7" }
+near-jsonrpc-primitives = { git = "https://github.com/near/nearcore", rev="e242f71400111fe99a825fd8f5e53a82802c98b7" }


### PR DESCRIPTION
https://github.com/near/nearcore/pull/4651 was merged, we can revert to nearcore master.