### PR TITLE
VS Code debug setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 .DS_Store
 near-cli
 *.wasm
-*.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,38 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Default debug",
+            "args": [
+                "${input:promptFroCommand}"
+            ],
+            "program": "${workspaceFolder}/target/debug/near-cli",
+            "cwd": "${workspaceFolder}",
+            "stopOnEntry": false,
+            "sourceLanguages": [
+                "rust"
+            ]
+        }
+    ],
+    "inputs": [
+        {
+            "id": "promptFroCommand",
+            "description": "Ask for commands in Terminal",
+            "type": "promptString"
+        },
+        {
+            "id": "pickCommand",
+            "description": "Choose commands from the options list",
+            "type": "pickString",
+            "options": [
+                "transfer",
+                "add"
+            ]
+        },
+    ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -9,7 +9,7 @@
             "request": "launch",
             "name": "Default debug",
             "args": [
-                "${input:promptFroCommand}"
+                "${input:promptForCommand}"
             ],
             "program": "${workspaceFolder}/target/debug/near-cli",
             "cwd": "${workspaceFolder}",
@@ -21,7 +21,7 @@
     ],
     "inputs": [
         {
-            "id": "promptFroCommand",
+            "id": "promptForCommand",
             "description": "Ask for commands in Terminal",
             "type": "promptString"
         },


### PR DESCRIPTION
Working setup for debugging in VS Code.
`promptForCommand` allows entering commands on each debug session
`pickCommand` allows choosing commands from the list (list can be extended locally).