### PR TITLE
Feature/extension system

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -281,6 +281,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28ae2b3dec75a406790005a200b1bd89785afc02517a00ca99ecfe093ee9e6cf"
+
+[[package]]
 name = "arrayref"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -585,6 +591,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo-util"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2bf633f7ad4e022f63c4197085047af9606a08a3df17badbb7bd3644dc7faeb"
+dependencies = [
+ "anyhow",
+ "core-foundation",
+ "crypto-hash",
+ "filetime",
+ "hex 0.4.2",
+ "jobserver",
+ "libc",
+ "log",
+ "miow",
+ "same-file",
+ "shell-escape",
+ "tempfile",
+ "walkdir",
+ "winapi",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -703,6 +731,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "commoncrypto"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d056a8586ba25a1e4d61cb090900e495952c7886786fc55f909ab2f819b69007"
+dependencies = [
+ "commoncrypto-sys",
+]
+
+[[package]]
+name = "commoncrypto-sys"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fed34f46747aa73dfaa578069fd8279d2818ade2b55f38f22a9401c7f4083e2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "console"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -740,6 +786,22 @@ dependencies = [
  "time 0.2.25",
  "version_check",
 ]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a89e2ae426ea83155dccf10c0fa6b1463ef6d5fcb44cee0b224a408fa640a62"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea221b5284a47e40033bf9b66f35f984ec0ea2931eb03505246cd27a963f981b"
 
 [[package]]
 name = "cpuid-bool"
@@ -782,6 +844,18 @@ name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
+name = "crypto-hash"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a77162240fd97248d19a564a565eb563a3f592b386e4136fb300909e67dddca"
+dependencies = [
+ "commoncrypto",
+ "hex 0.3.2",
+ "openssl",
+ "winapi",
+]
 
 [[package]]
 name = "crypto-mac"
@@ -958,6 +1032,18 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "975ccf83d8d9d0d84682850a38c8169027be83368805971cc4f238c2b245bc98"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "redox_syscall 0.2.10",
+ "winapi",
 ]
 
 [[package]]
@@ -1211,6 +1297,12 @@ dependencies = [
 
 [[package]]
 name = "hex"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
+
+[[package]]
+name = "hex"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
@@ -1337,6 +1429,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "jobserver"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1390,7 +1491,7 @@ checksum = "a5e8d803d3bdaef18320bc87ef178d36b955e42823b78343cfed5d88daa19b99"
 dependencies = [
  "byteorder",
  "cfg-if 0.1.10",
- "hex",
+ "hex 0.4.2",
  "hidapi",
  "lazy_static",
  "ledger-apdu",
@@ -1556,6 +1657,7 @@ dependencies = [
  "base64 0.12.3",
  "bip39",
  "bs58 0.3.1",
+ "cargo-util",
  "clap",
  "clap_generate",
  "color-eyre",
@@ -1563,7 +1665,7 @@ dependencies = [
  "dialoguer",
  "dirs",
  "ed25519-dalek",
- "hex",
+ "hex 0.4.2",
  "near-crypto",
  "near-jsonrpc-client",
  "near-jsonrpc-primitives",
@@ -1713,7 +1815,7 @@ dependencies = [
  "chrono",
  "derive_more",
  "easy-ext",
- "hex",
+ "hex 0.4.2",
  "jemallocator",
  "near-crypto",
  "near-primitives-core",
@@ -1740,7 +1842,7 @@ dependencies = [
  "borsh",
  "bs58 0.4.0",
  "derive_more",
- "hex",
+ "hex 0.4.2",
  "lazy_static",
  "near-account-id",
  "num-rational",
@@ -1779,7 +1881,7 @@ version = "3.0.0"
 source = "git+https://github.com/near/nearcore?rev=e242f71400111fe99a825fd8f5e53a82802c98b7#e242f71400111fe99a825fd8f5e53a82802c98b7"
 dependencies = [
  "borsh",
- "hex",
+ "hex 0.4.2",
  "near-account-id",
  "near-rpc-error-macro",
  "serde",
@@ -1981,7 +2083,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "instant",
  "libc",
- "redox_syscall 0.2.5",
+ "redox_syscall 0.2.10",
  "smallvec 1.6.1",
  "winapi",
 ]
@@ -2357,9 +2459,9 @@ checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.5"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
 dependencies = [
  "bitflags",
 ]
@@ -2449,6 +2551,15 @@ name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d301d4193d031abdd79ff7e3dd721168a9572ef3fe51a1517aba235bd8f86e"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scopeguard"
@@ -2555,6 +2666,12 @@ checksum = "79c719719ee05df97490f80a45acfc99e5a30ce98a1e4fb67aee422745ae14e3"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shell-escape"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f"
 
 [[package]]
 name = "shell-words"
@@ -2795,7 +2912,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "rand 0.8.3",
- "redox_syscall 0.2.5",
+ "redox_syscall 0.2.10",
  "remove_dir_all",
  "winapi",
 ]
@@ -3049,7 +3166,7 @@ checksum = "e11fe9a9348741cf134085ad57c249508345fe16411b3d7fb4ff2da2f1d6382e"
 dependencies = [
  "byteorder",
  "crunchy",
- "hex",
+ "hex 0.4.2",
  "static_assertions",
 ]
 
@@ -3166,6 +3283,17 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "walkdir"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808cf2735cd4b6866113f648b791c6adc5714537bc222d9347bb203386ffda56"
+dependencies = [
+ "same-file",
+ "winapi",
+ "winapi-util",
+]
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ slip10 = "0.4.3"
 url = { version = "2", features = ["serde"] }
 url_open = "0.0.1"
 shell-words = "1.0.0"
+cargo-util = "0.1.1"
 
 color-eyre = "0.5"
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,13 +1,14 @@
-use cargo_util::{ProcessBuilder, ProcessError};
 use std::convert::{TryFrom, TryInto};
 use std::env;
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
-pub type CliResult = color_eyre::eyre::Result<()>;
+use cargo_util::{ProcessBuilder, ProcessError};
 
 use near_primitives::borsh::BorshDeserialize;
+
+pub type CliResult = color_eyre::eyre::Result<()>;
 
 #[derive(
     Debug,

--- a/src/common.rs
+++ b/src/common.rs
@@ -883,6 +883,62 @@ pub async fn save_access_key_to_keychain(
     Ok(())
 }
 
+pub fn try_external_subcommand_execution() -> CliResult {
+    let mut args: Vec<String> = env::args().skip(1).collect();
+    if args.is_empty() || args[0].is_empty() {
+        return Err(color_eyre::eyre::eyre!("subcommand is not provided"));
+    }
+
+    let subcommand = args.remove(0);
+    let subcommand_exe = format!("near-cli-{}{}", subcommand, env::consts::EXE_SUFFIX);
+
+    let path = path_directories()
+        .iter()
+        .map(|dir| dir.join(&subcommand_exe))
+        .find(|file| is_executable(file));
+
+    let command = path.ok_or_else(|| {
+        color_eyre::eyre::eyre!(
+            "{} command or {} extension does not exist",
+            subcommand,
+            subcommand_exe
+        )
+    })?;
+
+    let err = match ProcessBuilder::new(&command).args(&args).exec_replace() {
+        Ok(()) => return Ok(()),
+        Err(e) => e,
+    };
+
+    if let Some(perr) = err.downcast_ref::<ProcessError>() {
+        if let Some(code) = perr.code {
+            return Err(color_eyre::eyre::eyre!("perror occured, code: {}", code));
+        }
+    }
+    return Err(color_eyre::eyre::eyre!(err));
+}
+
+fn is_executable<P: AsRef<Path>>(path: P) -> bool {
+    if cfg!(target_family = "unix") {
+        use std::os::unix::prelude::*;
+        fs::metadata(path)
+            .map(|metadata| metadata.is_file() && metadata.permissions().mode() & 0o111 != 0)
+            .unwrap_or(false)
+    } else if cfg!(target_family = "windows") {
+        path.as_ref().is_file()
+    } else {
+        panic!("Unsupported for wasm");
+    }
+}
+
+fn path_directories() -> Vec<PathBuf> {
+    let mut dirs = vec![];
+    if let Some(val) = env::var_os("PATH") {
+        dirs.extend(env::split_paths(&val));
+    }
+    dirs
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1238,58 +1294,4 @@ mod tests {
             Err("Near Gas: invalid digit found in string".to_string())
         );
     }
-}
-
-pub fn try_external_subcommand_execution() -> CliResult {
-    let mut args: Vec<String> = env::args().skip(1).collect();
-    if args.is_empty() || args[0].is_empty() {
-        return Err(color_eyre::eyre::eyre!("subcommand is not provided"));
-    }
-
-    let subcommand = args.remove(0);
-    let subcommand_exe = format!("near-cli-{}{}", subcommand, env::consts::EXE_SUFFIX);
-
-    let path = get_path_directories()
-        .iter()
-        .map(|dir| dir.join(&subcommand_exe))
-        .find(|file| is_executable(file));
-
-    let command = path.ok_or_else(|| color_eyre::eyre::eyre!(
-        "{} command or {} extension does not exist",
-        subcommand,
-        subcommand_exe
-    ))?;
-
-    let err = match ProcessBuilder::new(&command).args(&args).exec_replace() {
-        Ok(()) => return Ok(()),
-        Err(e) => e,
-    };
-
-    if let Some(perr) = err.downcast_ref::<ProcessError>() {
-        if let Some(code) = perr.code {
-            return Err(color_eyre::eyre::eyre!("perror occured, code: {}", code));
-        }
-    }
-    return Err(color_eyre::eyre::eyre!(err));
-}
-
-fn is_executable<P: AsRef<Path>>(path: P) -> bool {
-    if cfg!(target_family = "unix") {
-         use std::os::unix::prelude::*;
-         fs::metadata(path)
-             .map(|metadata| metadata.is_file() && metadata.permissions().mode() & 0o111 != 0)
-             .unwrap_or(false)
-    } else if cfg!(target_family = "windows") {
-         path.as_ref().is_file()
-    } else {
-        panic!("Unsupported for wasm");
-    }
- }
-
-fn path_directories() -> Vec<PathBuf> {
-    let mut dirs = vec![];
-    if let Some(val) = env::var_os("PATH") {
-        dirs.extend(env::split_paths(&val));
-    }
-    dirs
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -884,12 +884,13 @@ pub async fn save_access_key_to_keychain(
 }
 
 pub fn try_external_subcommand_execution() -> CliResult {
-    let mut args: Vec<String> = env::args().skip(1).collect();
-    if args.is_empty() || args[0].is_empty() {
-        return Err(color_eyre::eyre::eyre!("subcommand is not provided"));
-    }
-
-    let subcommand = args.remove(0);
+    let (subcommand, args) = {
+        let mut args = env::args().skip(1);
+        let subcommand = args
+            .next()
+            .ok_or_else(|| color_eyre::eyre::eyre!("subcommand is not provided"))?;
+        (subcommand, args.collect::<Vec<String>>())
+    };
     let subcommand_exe = format!("near-cli-{}{}", subcommand, env::consts::EXE_SUFFIX);
 
     let path = path_directories()

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use clap::Clap;
-extern crate shell_words;
+use shell_words;
+
 use common::{try_external_subcommand_execution, CliResult};
 
 mod commands;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,15 +1,10 @@
-use cargo_util::{ProcessBuilder, ProcessError};
 use clap::Clap;
-use std::env;
-use std::fs;
-use std::path::{Path, PathBuf};
 extern crate shell_words;
+use common::{try_external_subcommand_execution, CliResult};
 
 mod commands;
 mod common;
 mod consts;
-
-type CliResult = color_eyre::eyre::Result<()>;
 
 /// near-cli is a toolbox for interacting with NEAR protocol
 #[derive(Debug, Clap)]
@@ -103,62 +98,4 @@ fn main() -> CliResult {
     );
 
     process_result
-}
-
-fn try_external_subcommand_execution() -> CliResult {
-    let mut args: Vec<String> = env::args().skip(1).collect();
-    if args.is_empty() || args[0].is_empty() {
-        return Err(color_eyre::eyre::eyre!("subcommand is not provided"));
-    }
-
-    let subcommand = args.remove(0);
-    let subcommand_exe = format!("near-cli-{}{}", subcommand, env::consts::EXE_SUFFIX);
-
-    let path = get_path_directories()
-        .iter()
-        .map(|dir| dir.join(&subcommand_exe))
-        .find(|file| is_executable(file));
-
-    let command = match path {
-        Some(command) => command,
-        None => {
-            return Err(color_eyre::eyre::eyre!(
-                "{} command or {} extension does not exist",
-                subcommand,
-                subcommand_exe
-            ));
-        }
-    };
-
-    let err = match ProcessBuilder::new(&command).args(&args).exec_replace() {
-        Ok(()) => return Ok(()),
-        Err(e) => e,
-    };
-
-    if let Some(perr) = err.downcast_ref::<ProcessError>() {
-        if let Some(code) = perr.code {
-            return Err(color_eyre::eyre::eyre!("perror occured, code: {}", code));
-        }
-    }
-    return Err(color_eyre::eyre::eyre!(err));
-}
-
-#[cfg(unix)]
-fn is_executable<P: AsRef<Path>>(path: P) -> bool {
-    use std::os::unix::prelude::*;
-    fs::metadata(path)
-        .map(|metadata| metadata.is_file() && metadata.permissions().mode() & 0o111 != 0)
-        .unwrap_or(false)
-}
-#[cfg(windows)]
-fn is_executable<P: AsRef<Path>>(path: P) -> bool {
-    path.as_ref().is_file()
-}
-
-fn get_path_directories() -> Vec<PathBuf> {
-    let mut dirs = vec![];
-    if let Some(val) = env::var_os("PATH") {
-        dirs.extend(env::split_paths(&val));
-    }
-    dirs
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -107,16 +107,9 @@ fn main() -> CliResult {
 
 fn try_external_subcommand_execution() -> CliResult {
     let mut args: Vec<String> = env::args().skip(1).collect();
-    match args.first() {
-        Some(subcommand) => {
-            if subcommand.is_empty() {
-                return Err(color_eyre::eyre::eyre!("subcommand is empty"));
-            }
-        }
-        None => {
-            return Err(color_eyre::eyre::eyre!("subcommand is not provided"));
-        }
-    };
+    if args.is_empty() || args[0].is_empty() {
+        return Err(color_eyre::eyre::eyre!("subcommand is not provided"));
+    }
 
     let subcommand = args.remove(0);
     let subcommand_exe = format!("near-cli-{}{}", subcommand, env::consts::EXE_SUFFIX);
@@ -137,10 +130,7 @@ fn try_external_subcommand_execution() -> CliResult {
         }
     };
 
-    let err = match ProcessBuilder::new(&command)
-        .args(&args)
-        .exec_replace()
-    {
+    let err = match ProcessBuilder::new(&command).args(&args).exec_replace() {
         Ok(()) => return Ok(()),
         Err(e) => e,
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -137,9 +137,7 @@ fn try_external_subcommand_execution() -> CliResult {
         }
     };
 
-    // let cargo_exe = config.cargo_exe()?;
     let err = match ProcessBuilder::new(&command)
-        // .env(cargo::CARGO_ENV, cargo_exe)
         .args(&args)
         .exec_replace()
     {

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,7 +76,6 @@ fn main() -> CliResult {
                 error.kind,
                 clap::ErrorKind::UnknownArgument | clap::ErrorKind::InvalidSubcommand
             ) {
-                //TODO: does not work good when arguments are not provided
                 return try_external_subcommand_execution();
             }
             return Err(color_eyre::eyre::eyre!(error));
@@ -108,9 +107,17 @@ fn main() -> CliResult {
 
 fn try_external_subcommand_execution() -> CliResult {
     let mut args: Vec<String> = env::args().skip(1).collect();
-    if args.len() < 1 {
-        return Err(color_eyre::eyre::eyre!("subcommand is not provided"));
-    }
+    match args.first() {
+        Some(subcommand) => {
+            if subcommand.is_empty() {
+                return Err(color_eyre::eyre::eyre!("subcommand is empty"));
+            }
+        }
+        None => {
+            return Err(color_eyre::eyre::eyre!("subcommand is not provided"));
+        }
+    };
+
     let subcommand = args.remove(0);
     let subcommand_exe = format!("near-cli-{}{}", subcommand, env::consts::EXE_SUFFIX);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,6 +76,7 @@ fn main() -> CliResult {
                 error.kind,
                 clap::ErrorKind::UnknownArgument | clap::ErrorKind::InvalidSubcommand
             ) {
+                //TODO: does not work good when arguments are not provided
                 return try_external_subcommand_execution();
             }
             return Err(color_eyre::eyre::eyre!(error));
@@ -106,15 +107,12 @@ fn main() -> CliResult {
 }
 
 fn try_external_subcommand_execution() -> CliResult {
-    let args: Vec<String> = env::args().collect();
-    let subcommand = match args.get(1) {
-        Some(subcommand) => subcommand,
-        None => {
-            return Err(color_eyre::eyre::eyre!("subcommand is not provided"));
-        }
-    };
-
-    let subcommand_exe = format!("near-{}{}", subcommand, env::consts::EXE_SUFFIX);
+    let mut args: Vec<String> = env::args().skip(1).collect();
+    if args.len() < 1 {
+        return Err(color_eyre::eyre::eyre!("subcommand is not provided"));
+    }
+    let subcommand = args.remove(0);
+    let subcommand_exe = format!("near-cli-{}{}", subcommand, env::consts::EXE_SUFFIX);
 
     let path = get_path_directories()
         .iter()


### PR DESCRIPTION
This code is searching for executables in $PATH if provided subcommand is not found and tries to execute it.
It allows us to build extensions.
Here are some examples of such extensions:
- [Rust + Clap](https://github.com/volovyk-s/near-cli-extension-example)
- [JS + Yargs](https://github.com/volovyk-s/near-cli-extension-example-js) (cool option, but Rust will be the main one)

To try it out:
Rust extension:
```bash
cargo run extension-example rust Cargo.lock
```
This command will search for `rust` word in `Cargo.lock` file

JS Extension:
```bash
cargo run extension-example-js say NEEEAR!
```
This command will print NEEEAR! :)

In the future, we will move helper functions to a separate crate. It will help developers to build good quality extensions and follow our "CLI style" at the same time.