### PR TITLE
refactor: Dedup display functions for view commands

### DIFF
--- a/src/commands/view_command/view_account/block_id/block_id_hash/mod.rs
+++ b/src/commands/view_command/view_account/block_id/block_id_hash/mod.rs
@@ -1,5 +1,9 @@
 use dialoguer::Input;
 
+use crate::common::{display_access_key_list, display_account_info, ConnectionConfig};
+
+use near_primitives::types::{AccountId, BlockId, BlockReference};
+
 /// Specify the block_id hash for this account to view
 #[derive(Debug, Default, Clone, clap::Clap)]
 pub struct CliBlockIdHash {
@@ -47,139 +51,10 @@ impl BlockIdHash {
             .unwrap()
     }
 
-    fn rpc_client(&self, selected_server_url: &str) -> near_jsonrpc_client::JsonRpcClient {
-        near_jsonrpc_client::new_client(&selected_server_url)
-    }
-
-    pub async fn process(
-        self,
-        account_id: near_primitives::types::AccountId,
-        network_connection_config: crate::common::ConnectionConfig,
-    ) -> crate::CliResult {
-        self.display_account_info(account_id.clone(), &network_connection_config)
-            .await?;
-        self.display_access_key_list(account_id.clone(), &network_connection_config)
-            .await?;
-        Ok(())
-    }
-
-    async fn display_account_info(
-        &self,
-        account_id: near_primitives::types::AccountId,
-        network_connection_config: &crate::common::ConnectionConfig,
-    ) -> crate::CliResult {
-        let query_view_method_response = self
-            .rpc_client(network_connection_config.archival_rpc_url().as_str())
-            .query(near_jsonrpc_primitives::types::query::RpcQueryRequest {
-                block_reference: near_primitives::types::BlockReference::BlockId(
-                    near_primitives::types::BlockId::Hash(self.block_id_hash.clone()),
-                ),
-                request: near_primitives::views::QueryRequest::ViewAccount {
-                    account_id: account_id.clone(),
-                },
-            })
-            .await
-            .map_err(|err| {
-                color_eyre::Report::msg(format!(
-                    "Failed to fetch query for view account: {:?}",
-                    err
-                ))
-            })?;
-        let account_view =
-            if let near_jsonrpc_primitives::types::query::QueryResponseKind::ViewAccount(result) =
-                query_view_method_response.kind
-            {
-                result
-            } else {
-                return Err(color_eyre::Report::msg(format!("Error call result")));
-            };
-
-        println!(
-            "Account details for '{}' at block #{} ({})\n\
-            Native account balance: {}\n\
-            Validator stake: {}\n\
-            Storage used by the account: {} bytes",
-            account_id,
-            query_view_method_response.block_height,
-            query_view_method_response.block_hash,
-            crate::common::NearBalance::from_yoctonear(account_view.amount),
-            crate::common::NearBalance::from_yoctonear(account_view.locked),
-            account_view.storage_usage
-        );
-        if account_view.code_hash == near_primitives::hash::CryptoHash::default() {
-            println!("Contract code is not deployed to this account.");
-        } else {
-            println!(
-                "Contract code SHA-256 checksum (hex): {}",
-                hex::encode(account_view.code_hash.as_ref())
-            );
-        }
-        Ok(())
-    }
-
-    async fn display_access_key_list(
-        &self,
-        account_id: near_primitives::types::AccountId,
-        network_connection_config: &crate::common::ConnectionConfig,
-    ) -> crate::CliResult {
-        let query_view_method_response = self
-            .rpc_client(network_connection_config.archival_rpc_url().as_str())
-            .query(near_jsonrpc_primitives::types::query::RpcQueryRequest {
-                block_reference: near_primitives::types::BlockReference::BlockId(
-                    near_primitives::types::BlockId::Hash(self.block_id_hash.clone()),
-                ),
-                request: near_primitives::views::QueryRequest::ViewAccessKeyList {
-                    account_id: account_id.clone(),
-                },
-            })
-            .await
-            .map_err(|err| {
-                color_eyre::Report::msg(format!(
-                    "Failed to fetch query for view key list: {:?}",
-                    err
-                ))
-            })?;
-        let access_key_view =
-            if let near_jsonrpc_primitives::types::query::QueryResponseKind::AccessKeyList(result) =
-                query_view_method_response.kind
-            {
-                result
-            } else {
-                return Err(color_eyre::Report::msg(format!("Error call result")));
-            };
-
-        println!("Number of access keys: {}", access_key_view.keys.len());
-        for (index, access_key) in access_key_view.keys.iter().enumerate() {
-            let permissions_message = match &access_key.access_key.permission {
-                near_primitives::views::AccessKeyPermissionView::FullAccess => {
-                    "full access".to_owned()
-                }
-                near_primitives::views::AccessKeyPermissionView::FunctionCall {
-                    allowance,
-                    receiver_id,
-                    method_names,
-                } => {
-                    let allowance_message = match allowance {
-                        Some(amount) => format!(
-                            "with an allowance of {}",
-                            crate::common::NearBalance::from_yoctonear(*amount)
-                        ),
-                        None => format!("with no limit"),
-                    };
-                    format!(
-                        "only do {:?} function calls on {} {}",
-                        method_names, receiver_id, allowance_message
-                    )
-                }
-            };
-            println!(
-                "{: >4}. {} (nonce: {}) is granted to {}",
-                index + 1,
-                access_key.public_key,
-                access_key.access_key.nonce,
-                permissions_message
-            );
-        }
+    pub async fn process(self, account_id: AccountId, conf: ConnectionConfig) -> crate::CliResult {
+        let block_ref = BlockReference::BlockId(BlockId::Hash(self.block_id_hash.clone()));
+        display_account_info(account_id.clone(), &conf, block_ref.clone()).await?;
+        display_access_key_list(account_id, &conf, block_ref).await?;
         Ok(())
     }
 }

--- a/src/commands/view_command/view_account/block_id/block_id_height/mod.rs
+++ b/src/commands/view_command/view_account/block_id/block_id_height/mod.rs
@@ -1,5 +1,8 @@
 use dialoguer::Input;
 
+use crate::common::{display_access_key_list, display_account_info, ConnectionConfig};
+use near_primitives::types::{AccountId, BlockId, BlockReference};
+
 /// Specify the block_id height for this account to view
 #[derive(Debug, Default, Clone, clap::Clap)]
 pub struct CliBlockIdHeight {
@@ -47,139 +50,10 @@ impl BlockIdHeight {
             .unwrap()
     }
 
-    fn rpc_client(&self, selected_server_url: &str) -> near_jsonrpc_client::JsonRpcClient {
-        near_jsonrpc_client::new_client(&selected_server_url)
-    }
-
-    pub async fn process(
-        self,
-        account_id: near_primitives::types::AccountId,
-        network_connection_config: crate::common::ConnectionConfig,
-    ) -> crate::CliResult {
-        self.display_account_info(account_id.clone(), &network_connection_config)
-            .await?;
-        self.display_access_key_list(account_id.clone(), &network_connection_config)
-            .await?;
-        Ok(())
-    }
-
-    async fn display_account_info(
-        &self,
-        account_id: near_primitives::types::AccountId,
-        network_connection_config: &crate::common::ConnectionConfig,
-    ) -> crate::CliResult {
-        let query_view_method_response = self
-            .rpc_client(network_connection_config.archival_rpc_url().as_str())
-            .query(near_jsonrpc_primitives::types::query::RpcQueryRequest {
-                block_reference: near_primitives::types::BlockReference::BlockId(
-                    near_primitives::types::BlockId::Height(self.block_id_height.clone()),
-                ),
-                request: near_primitives::views::QueryRequest::ViewAccount {
-                    account_id: account_id.clone(),
-                },
-            })
-            .await
-            .map_err(|err| {
-                color_eyre::Report::msg(format!(
-                    "Failed to fetch query for view account: {:?}",
-                    err
-                ))
-            })?;
-        let account_view =
-            if let near_jsonrpc_primitives::types::query::QueryResponseKind::ViewAccount(result) =
-                query_view_method_response.kind
-            {
-                result
-            } else {
-                return Err(color_eyre::Report::msg(format!("Error call result")));
-            };
-
-        println!(
-            "Account details for '{}' at block #{} ({})\n\
-            Native account balance: {}\n\
-            Validator stake: {}\n\
-            Storage used by the account: {} bytes",
-            account_id,
-            query_view_method_response.block_height,
-            query_view_method_response.block_hash,
-            crate::common::NearBalance::from_yoctonear(account_view.amount),
-            crate::common::NearBalance::from_yoctonear(account_view.locked),
-            account_view.storage_usage
-        );
-        if account_view.code_hash == near_primitives::hash::CryptoHash::default() {
-            println!("Contract code is not deployed to this account.");
-        } else {
-            println!(
-                "Contract code SHA-256 checksum (hex): {}",
-                hex::encode(account_view.code_hash.as_ref())
-            );
-        }
-        Ok(())
-    }
-
-    async fn display_access_key_list(
-        &self,
-        account_id: near_primitives::types::AccountId,
-        network_connection_config: &crate::common::ConnectionConfig,
-    ) -> crate::CliResult {
-        let query_view_method_response = self
-            .rpc_client(network_connection_config.archival_rpc_url().as_str())
-            .query(near_jsonrpc_primitives::types::query::RpcQueryRequest {
-                block_reference: near_primitives::types::BlockReference::BlockId(
-                    near_primitives::types::BlockId::Height(self.block_id_height.clone()),
-                ),
-                request: near_primitives::views::QueryRequest::ViewAccessKeyList {
-                    account_id: account_id.clone(),
-                },
-            })
-            .await
-            .map_err(|err| {
-                color_eyre::Report::msg(format!(
-                    "Failed to fetch query for view key list: {:?}",
-                    err
-                ))
-            })?;
-        let access_key_view =
-            if let near_jsonrpc_primitives::types::query::QueryResponseKind::AccessKeyList(result) =
-                query_view_method_response.kind
-            {
-                result
-            } else {
-                return Err(color_eyre::Report::msg(format!("Error call result")));
-            };
-
-        println!("Number of access keys: {}", access_key_view.keys.len());
-        for (index, access_key) in access_key_view.keys.iter().enumerate() {
-            let permissions_message = match &access_key.access_key.permission {
-                near_primitives::views::AccessKeyPermissionView::FullAccess => {
-                    "full access".to_owned()
-                }
-                near_primitives::views::AccessKeyPermissionView::FunctionCall {
-                    allowance,
-                    receiver_id,
-                    method_names,
-                } => {
-                    let allowance_message = match allowance {
-                        Some(amount) => format!(
-                            "with an allowance of {}",
-                            crate::common::NearBalance::from_yoctonear(*amount)
-                        ),
-                        None => format!("with no limit"),
-                    };
-                    format!(
-                        "only do {:?} function calls on {} {}",
-                        method_names, receiver_id, allowance_message
-                    )
-                }
-            };
-            println!(
-                "{: >4}. {} (nonce: {}) is granted to {}",
-                index + 1,
-                access_key.public_key,
-                access_key.access_key.nonce,
-                permissions_message
-            );
-        }
+    pub async fn process(self, account_id: AccountId, conf: ConnectionConfig) -> crate::CliResult {
+        let block_ref = BlockReference::BlockId(BlockId::Height(self.block_id_height));
+        display_account_info(account_id.clone(), &conf, block_ref.clone()).await?;
+        display_access_key_list(account_id, &conf, block_ref).await?;
         Ok(())
     }
 }

--- a/src/commands/view_command/view_account/block_id/mod.rs
+++ b/src/commands/view_command/view_account/block_id/mod.rs
@@ -1,6 +1,9 @@
 use dialoguer::{theme::ColorfulTheme, Select};
 use strum::{EnumDiscriminants, EnumIter, EnumMessage, IntoEnumIterator};
 
+use crate::common::{display_access_key_list, display_account_info, ConnectionConfig};
+use near_primitives::types::{AccountId, Finality};
+
 mod block_id_hash;
 mod block_id_height;
 
@@ -93,150 +96,16 @@ impl BlockId {
         Self::from(cli_block_id)
     }
 
-    pub async fn process(
-        self,
-        sender_account_id: near_primitives::types::AccountId,
-        network_connection_config: crate::common::ConnectionConfig,
-    ) -> crate::CliResult {
+    pub async fn process(self, account_id: AccountId, conf: ConnectionConfig) -> crate::CliResult {
         println!();
         match self {
-            Self::AtBlockHeight(block_id_height) => {
-                block_id_height
-                    .process(sender_account_id, network_connection_config)
-                    .await
-            }
-            Self::AtBlockHash(block_id_hash) => {
-                block_id_hash
-                    .process(sender_account_id, network_connection_config)
-                    .await
-            }
+            Self::AtBlockHeight(block_id_height) => block_id_height.process(account_id, conf).await,
+            Self::AtBlockHash(block_id_hash) => block_id_hash.process(account_id, conf).await,
             Self::AtFinalBlock => {
-                self.display_account_info(sender_account_id.clone(), &network_connection_config)
-                    .await?;
-                self.display_access_key_list(sender_account_id.clone(), &network_connection_config)
-                    .await?;
+                display_account_info(account_id.clone(), &conf, Finality::Final.into()).await?;
+                display_access_key_list(account_id, &conf, Finality::Final.into()).await?;
                 Ok(())
             }
         }
-    }
-
-    fn rpc_client(&self, selected_server_url: &str) -> near_jsonrpc_client::JsonRpcClient {
-        near_jsonrpc_client::new_client(&selected_server_url)
-    }
-
-    async fn display_account_info(
-        &self,
-        account_id: near_primitives::types::AccountId,
-        network_connection_config: &crate::common::ConnectionConfig,
-    ) -> crate::CliResult {
-        let query_view_method_response = self
-            .rpc_client(network_connection_config.rpc_url().as_str())
-            .query(near_jsonrpc_primitives::types::query::RpcQueryRequest {
-                block_reference: near_primitives::types::Finality::Final.into(),
-                request: near_primitives::views::QueryRequest::ViewAccount {
-                    account_id: account_id.clone(),
-                },
-            })
-            .await
-            .map_err(|err| {
-                color_eyre::Report::msg(format!(
-                    "Failed to fetch query for view account: {:?}",
-                    err
-                ))
-            })?;
-        let account_view =
-            if let near_jsonrpc_primitives::types::query::QueryResponseKind::ViewAccount(result) =
-                query_view_method_response.kind
-            {
-                result
-            } else {
-                return Err(color_eyre::Report::msg(format!("Error call result")));
-            };
-
-        println!(
-            "Account details for '{}' at block #{} ({})\n\
-            Native account balance: {}\n\
-            Validator stake: {}\n\
-            Storage used by the account: {} bytes",
-            account_id,
-            query_view_method_response.block_height,
-            query_view_method_response.block_hash,
-            crate::common::NearBalance::from_yoctonear(account_view.amount),
-            crate::common::NearBalance::from_yoctonear(account_view.locked),
-            account_view.storage_usage
-        );
-        if account_view.code_hash == near_primitives::hash::CryptoHash::default() {
-            println!("Contract code is not deployed to this account.");
-        } else {
-            println!(
-                "Contract code SHA-256 checksum (hex): {}",
-                hex::encode(account_view.code_hash.as_ref())
-            );
-        }
-        Ok(())
-    }
-
-    async fn display_access_key_list(
-        &self,
-        account_id: near_primitives::types::AccountId,
-        network_connection_config: &crate::common::ConnectionConfig,
-    ) -> crate::CliResult {
-        let query_view_method_response = self
-            .rpc_client(network_connection_config.rpc_url().as_str())
-            .query(near_jsonrpc_primitives::types::query::RpcQueryRequest {
-                block_reference: near_primitives::types::Finality::Final.into(),
-                request: near_primitives::views::QueryRequest::ViewAccessKeyList {
-                    account_id: account_id.clone(),
-                },
-            })
-            .await
-            .map_err(|err| {
-                color_eyre::Report::msg(format!(
-                    "Failed to fetch query for view key list: {:?}",
-                    err
-                ))
-            })?;
-        let access_key_view =
-            if let near_jsonrpc_primitives::types::query::QueryResponseKind::AccessKeyList(result) =
-                query_view_method_response.kind
-            {
-                result
-            } else {
-                return Err(color_eyre::Report::msg(format!("Error call result")));
-            };
-
-        println!("Number of access keys: {}", access_key_view.keys.len());
-        for (index, access_key) in access_key_view.keys.iter().enumerate() {
-            let permissions_message = match &access_key.access_key.permission {
-                near_primitives::views::AccessKeyPermissionView::FullAccess => {
-                    "full access".to_owned()
-                }
-                near_primitives::views::AccessKeyPermissionView::FunctionCall {
-                    allowance,
-                    receiver_id,
-                    method_names,
-                } => {
-                    let allowance_message = match allowance {
-                        Some(amount) => format!(
-                            "with an allowance of {}",
-                            crate::common::NearBalance::from_yoctonear(*amount)
-                        ),
-                        None => format!("with no limit"),
-                    };
-                    format!(
-                        "only do {:?} function calls on {} {}",
-                        method_names, receiver_id, allowance_message
-                    )
-                }
-            };
-            println!(
-                "{: >4}. {} (nonce: {}) is granted to {}",
-                index + 1,
-                access_key.public_key,
-                access_key.access_key.nonce,
-                permissions_message
-            );
-        }
-        Ok(())
     }
 }


### PR DESCRIPTION
Deduplicates functions like `display_account_info` and `display_access_key_list`, and puts them into `common.rs`.

This is just one part of the cleanup process, and there will be more after this one. Don't want to snowball all of these into one giant PR, since that wouldn't be good for anyone looking at it, nor would it increase the chance of it being looked at. So let's go with integrating cleanups often