### PR TITLE
fix: texts in prompts should be relevant and clear

### DIFF
--- a/src/commands/execute_command/mod.rs
+++ b/src/commands/execute_command/mod.rs
@@ -68,9 +68,9 @@ enum CliMethod {
 #[derive(Debug, Clone, EnumDiscriminants)]
 #[strum_discriminants(derive(EnumMessage, EnumIter))]
 enum Method {
-    #[strum_discriminants(strum(message = "Change a method"))]
+    #[strum_discriminants(strum(message = "Execute a changing method (construct a transaction with a function call)"))]
     ChangeMethod(self::change_method::operation_mode::OperationMode),
-    #[strum_discriminants(strum(message = "View a method"))]
+    #[strum_discriminants(strum(message = "Execute a viewing method (read-only call, which does not require a transaction)"))]
     ViewMethod(self::view_method::operation_mode::OperationMode),
 }
 


### PR DESCRIPTION
I only fixed the texts around transaction signing