### PR TITLE
feat: Use currently running binary name in "Your console command" output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,8 @@ fn main() -> CliResult {
     let process_result = actix::System::new().block_on(args.process());
 
     println!(
-        "Your console command:\n./near-cli {}",
+        "Your console command:\n{} {}",
+        std::env::args().next().as_deref().unwrap_or("./near_cli"),
         shell_words::join(&completed_cli.to_cli_args())
     );
 


### PR DESCRIPTION
Not sure if the best solution to #54. After requiring the installation of the program maybe replace it with `CARGO_PKG_NAME`.
Also do we need `unwrap_or` here, for cases, when argc==0? I think that most users will use this program normally.