### PR TITLE
"Failed to open file" error is more understandable

### DIFF
--- a/src/commands/add_command/contract_code/contract/mod.rs
+++ b/src/commands/add_command/contract_code/contract/mod.rs
@@ -26,10 +26,13 @@ impl ContractFile {
         prepopulated_unsigned_transaction: near_primitives::transaction::Transaction,
         network_connection_config: Option<crate::common::ConnectionConfig>,
     ) -> crate::CliResult {
-        let code = std::fs::read(&self.file_path.0.clone())
-            .map_err(|err| color_eyre::Report::msg(
-                format!("Failed to open or read the file: {:?}.\nError: {:?}", &self.file_path.0.clone(), err)
-            ))?;
+        let code = std::fs::read(&self.file_path.0.clone()).map_err(|err| {
+            color_eyre::Report::msg(format!(
+                "Failed to open or read the file: {:?}.\nError: {:?}",
+                &self.file_path.0.clone(),
+                err
+            ))
+        })?;
         let action = near_primitives::transaction::Action::DeployContract(
             near_primitives::transaction::DeployContractAction { code },
         );

--- a/src/commands/add_command/contract_code/contract/mod.rs
+++ b/src/commands/add_command/contract_code/contract/mod.rs
@@ -27,7 +27,9 @@ impl ContractFile {
         network_connection_config: Option<crate::common::ConnectionConfig>,
     ) -> crate::CliResult {
         let code = std::fs::read(&self.file_path.0.clone())
-            .map_err(|err| color_eyre::Report::msg(format!("Failed to open file: {:?}", err)))?;
+            .map_err(|err| color_eyre::Report::msg(
+                format!("Failed to open or read the file: {:?}.\nError: {:?}", &self.file_path.0.clone(), err)
+            ))?;
         let action = near_primitives::transaction::Action::DeployContract(
             near_primitives::transaction::DeployContractAction { code },
         );

--- a/src/commands/construct_transaction_command/transaction_actions/add_contract_code_type/mod.rs
+++ b/src/commands/construct_transaction_command/transaction_actions/add_contract_code_type/mod.rs
@@ -92,10 +92,13 @@ impl ContractFile {
         prepopulated_unsigned_transaction: near_primitives::transaction::Transaction,
         network_connection_config: Option<crate::common::ConnectionConfig>,
     ) -> crate::CliResult {
-        let code = std::fs::read(&self.file_path.clone())
-            .map_err(|err| color_eyre::Report::msg(
-                format!("Failed to open or read the file: {:?}.\nError: {:?}", &self.file_path.clone(), err)
-            ))?;
+        let code = std::fs::read(&self.file_path.clone()).map_err(|err| {
+            color_eyre::Report::msg(format!(
+                "Failed to open or read the file: {:?}.\nError: {:?}",
+                &self.file_path.clone(),
+                err
+            ))
+        })?;
         let action = near_primitives::transaction::Action::DeployContract(
             near_primitives::transaction::DeployContractAction { code },
         );

--- a/src/commands/construct_transaction_command/transaction_actions/add_contract_code_type/mod.rs
+++ b/src/commands/construct_transaction_command/transaction_actions/add_contract_code_type/mod.rs
@@ -93,7 +93,9 @@ impl ContractFile {
         network_connection_config: Option<crate::common::ConnectionConfig>,
     ) -> crate::CliResult {
         let code = std::fs::read(&self.file_path.clone())
-            .map_err(|err| color_eyre::Report::msg(format!("Failed to open file: {:?}", err)))?;
+            .map_err(|err| color_eyre::Report::msg(
+                format!("Failed to open or read the file: {:?}.\nError: {:?}", &self.file_path.clone(), err)
+            ))?;
         let action = near_primitives::transaction::Action::DeployContract(
             near_primitives::transaction::DeployContractAction { code },
         );


### PR DESCRIPTION
Fixes #55.

If you try to deploy a contract and enter a wrong path, the error appears :
```
Error: 
   0: Failed to open file: Os { code: 2, kind: NotFound, message: "No such file or directory" }

Location:
   src/commands/add_command/contract_code/contract/mod.rs:30
```
I propose to change it to:
```
Error: 
   0: Failed to open or read the file: "~/projects/near/contract/res/contract.was".
      Error: Os { code: 2, kind: NotFound, message: "No such file or directory" }

Location:
   src/commands/add_command/contract_code/contract/mod.rs:30

```

