### PR TITLE
Environment variables support

### DIFF
--- a/src/commands/add_command/access_key/operation_mode/online_mode/select_server/server/mod.rs
+++ b/src/commands/add_command/access_key/operation_mode/online_mode/select_server/server/mod.rs
@@ -53,8 +53,12 @@ impl CustomServer {
             Some(url) => Ok(url),
             None => {
                 if let Ok(network) = std::env::var("CUSTOM_NETWORK") {
-                    if let Ok(url) = network.parse() {
-                        return Ok(url);
+                    match network.parse() {
+                        Ok(url) => {
+                            println!("Using the URL address from CUSTOM_NETWORK: {}", network);
+                            return Ok(url)
+                        },
+                        Err(err) => println!("Couldn't use the URL address from CUSTOM_NETWORK: {}. Error: {}", network, err),
                     }
                 }
                 Self::input_url(context)

--- a/src/commands/add_command/access_key/operation_mode/online_mode/select_server/server/mod.rs
+++ b/src/commands/add_command/access_key/operation_mode/online_mode/select_server/server/mod.rs
@@ -12,6 +12,7 @@ pub struct Server {
 #[interactive_clap(input_context = super::SelectServerContext)]
 #[interactive_clap(output_context = super::super::super::AddAccessKeyCommandNetworkContext)]
 pub struct CustomServer {
+    #[interactive_clap(skip_default_from_cli)]
     pub url: crate::common::AvailableRpcServerUrl,
     #[interactive_clap(named_arg)]
     ///Specify a sender
@@ -42,6 +43,25 @@ impl From<CustomServerContext> for super::super::super::AddAccessKeyCommandNetwo
 }
 
 impl CustomServer {
+    fn from_cli_url(
+        optional_cli_url: Option<
+            <crate::common::AvailableRpcServerUrl as interactive_clap::ToCli>::CliVariant,
+        >,
+        context: &super::SelectServerContext,
+    ) -> color_eyre::eyre::Result<crate::common::AvailableRpcServerUrl> {
+        match optional_cli_url {
+            Some(url) => Ok(url),
+            None => {
+                if let Ok(network) = std::env::var("CUSTOM_NETWORK") {
+                    if let Ok(url) = network.parse() {
+                        return Ok(url);
+                    }
+                }
+                Self::input_url(context)
+            }
+        }
+    }
+
     pub fn input_url(
         _context: &super::SelectServerContext,
     ) -> color_eyre::eyre::Result<crate::common::AvailableRpcServerUrl> {

--- a/src/commands/add_command/access_key/operation_mode/online_mode/select_server/server/mod.rs
+++ b/src/commands/add_command/access_key/operation_mode/online_mode/select_server/server/mod.rs
@@ -56,9 +56,12 @@ impl CustomServer {
                     match network.parse() {
                         Ok(url) => {
                             println!("Using the URL address from CUSTOM_NETWORK: {}", network);
-                            return Ok(url)
-                        },
-                        Err(err) => println!("Couldn't use the URL address from CUSTOM_NETWORK: {}. Error: {}", network, err),
+                            return Ok(url);
+                        }
+                        Err(err) => println!(
+                            "Couldn't use the URL address from CUSTOM_NETWORK: {}. Error: {}",
+                            network, err
+                        ),
                     }
                 }
                 Self::input_url(context)

--- a/src/commands/add_command/contract_code/operation_mode/online_mode/select_server/server/mod.rs
+++ b/src/commands/add_command/contract_code/operation_mode/online_mode/select_server/server/mod.rs
@@ -12,6 +12,7 @@ pub struct Server {
 #[interactive_clap(input_context = super::SelectServerContext)]
 #[interactive_clap(output_context = super::super::super::TransferCommandNetworkContext)]
 pub struct CustomServer {
+    #[interactive_clap(skip_default_from_cli)]
     #[interactive_clap(long)]
     pub url: crate::common::AvailableRpcServerUrl,
     #[interactive_clap(named_arg)]
@@ -55,6 +56,25 @@ impl Server {
 }
 
 impl CustomServer {
+    fn from_cli_url(
+        optional_cli_url: Option<
+            <crate::common::AvailableRpcServerUrl as interactive_clap::ToCli>::CliVariant,
+        >,
+        context: &super::SelectServerContext,
+    ) -> color_eyre::eyre::Result<crate::common::AvailableRpcServerUrl> {
+        match optional_cli_url {
+            Some(url) => Ok(url),
+            None => {
+                if let Ok(network) = std::env::var("CUSTOM_NETWORK") {
+                    if let Ok(url) = network.parse() {
+                        return Ok(url);
+                    }
+                }
+                Self::input_url(context)
+            }
+        }
+    }
+
     pub fn input_url(
         _context: &super::SelectServerContext,
     ) -> color_eyre::eyre::Result<crate::common::AvailableRpcServerUrl> {

--- a/src/commands/add_command/contract_code/operation_mode/online_mode/select_server/server/mod.rs
+++ b/src/commands/add_command/contract_code/operation_mode/online_mode/select_server/server/mod.rs
@@ -66,8 +66,12 @@ impl CustomServer {
             Some(url) => Ok(url),
             None => {
                 if let Ok(network) = std::env::var("CUSTOM_NETWORK") {
-                    if let Ok(url) = network.parse() {
-                        return Ok(url);
+                    match network.parse() {
+                        Ok(url) => {
+                            println!("Using the URL address from CUSTOM_NETWORK: {}", network);
+                            return Ok(url)
+                        },
+                        Err(err) => println!("Couldn't use the URL address from CUSTOM_NETWORK: {}. Error: {}", network, err),
                     }
                 }
                 Self::input_url(context)

--- a/src/commands/add_command/contract_code/operation_mode/online_mode/select_server/server/mod.rs
+++ b/src/commands/add_command/contract_code/operation_mode/online_mode/select_server/server/mod.rs
@@ -69,9 +69,12 @@ impl CustomServer {
                     match network.parse() {
                         Ok(url) => {
                             println!("Using the URL address from CUSTOM_NETWORK: {}", network);
-                            return Ok(url)
-                        },
-                        Err(err) => println!("Couldn't use the URL address from CUSTOM_NETWORK: {}. Error: {}", network, err),
+                            return Ok(url);
+                        }
+                        Err(err) => println!(
+                            "Couldn't use the URL address from CUSTOM_NETWORK: {}. Error: {}",
+                            network, err
+                        ),
                     }
                 }
                 Self::input_url(context)

--- a/src/commands/add_command/stake_proposal/operation_mode/online_mode/select_server/server/mod.rs
+++ b/src/commands/add_command/stake_proposal/operation_mode/online_mode/select_server/server/mod.rs
@@ -12,6 +12,7 @@ pub struct Server {
 #[interactive_clap(input_context = super::SelectServerContext)]
 #[interactive_clap(output_context = super::super::super::AddAccessKeyCommandNetworkContext)]
 pub struct CustomServer {
+    #[interactive_clap(skip_default_from_cli)]
     pub url: crate::common::AvailableRpcServerUrl,
     #[interactive_clap(named_arg)]
     ///Specify a validator
@@ -42,6 +43,25 @@ impl From<CustomServerContext> for super::super::super::AddStakeProposalCommandN
 }
 
 impl CustomServer {
+    fn from_cli_url(
+        optional_cli_url: Option<
+            <crate::common::AvailableRpcServerUrl as interactive_clap::ToCli>::CliVariant,
+        >,
+        context: &super::SelectServerContext,
+    ) -> color_eyre::eyre::Result<crate::common::AvailableRpcServerUrl> {
+        match optional_cli_url {
+            Some(url) => Ok(url),
+            None => {
+                if let Ok(network) = std::env::var("CUSTOM_NETWORK") {
+                    if let Ok(url) = network.parse() {
+                        return Ok(url);
+                    }
+                }
+                Self::input_url(context)
+            }
+        }
+    }
+
     pub fn input_url(
         _context: &super::SelectServerContext,
     ) -> color_eyre::eyre::Result<crate::common::AvailableRpcServerUrl> {

--- a/src/commands/add_command/stake_proposal/operation_mode/online_mode/select_server/server/mod.rs
+++ b/src/commands/add_command/stake_proposal/operation_mode/online_mode/select_server/server/mod.rs
@@ -53,8 +53,12 @@ impl CustomServer {
             Some(url) => Ok(url),
             None => {
                 if let Ok(network) = std::env::var("CUSTOM_NETWORK") {
-                    if let Ok(url) = network.parse() {
-                        return Ok(url);
+                    match network.parse() {
+                        Ok(url) => {
+                            println!("Using the URL address from CUSTOM_NETWORK: {}", network);
+                            return Ok(url)
+                        },
+                        Err(err) => println!("Couldn't use the URL address from CUSTOM_NETWORK: {}. Error: {}", network, err),
                     }
                 }
                 Self::input_url(context)

--- a/src/commands/add_command/stake_proposal/operation_mode/online_mode/select_server/server/mod.rs
+++ b/src/commands/add_command/stake_proposal/operation_mode/online_mode/select_server/server/mod.rs
@@ -56,9 +56,12 @@ impl CustomServer {
                     match network.parse() {
                         Ok(url) => {
                             println!("Using the URL address from CUSTOM_NETWORK: {}", network);
-                            return Ok(url)
-                        },
-                        Err(err) => println!("Couldn't use the URL address from CUSTOM_NETWORK: {}. Error: {}", network, err),
+                            return Ok(url);
+                        }
+                        Err(err) => println!(
+                            "Couldn't use the URL address from CUSTOM_NETWORK: {}. Error: {}",
+                            network, err
+                        ),
                     }
                 }
                 Self::input_url(context)

--- a/src/commands/add_command/sub_account/operation_mode/online_mode/select_server/server/mod.rs
+++ b/src/commands/add_command/sub_account/operation_mode/online_mode/select_server/server/mod.rs
@@ -12,6 +12,7 @@ pub struct Server {
 #[interactive_clap(input_context = super::SelectServerContext)]
 #[interactive_clap(output_context = super::super::super::AddAccessKeyCommandNetworkContext)]
 pub struct CustomServer {
+    #[interactive_clap(skip_default_from_cli)]
     pub url: crate::common::AvailableRpcServerUrl,
     #[interactive_clap(named_arg)]
     ///Specify owner account
@@ -42,6 +43,25 @@ impl From<CustomServerContext> for super::super::super::AddSubAccountCommandNetw
 }
 
 impl CustomServer {
+    fn from_cli_url(
+        optional_cli_url: Option<
+            <crate::common::AvailableRpcServerUrl as interactive_clap::ToCli>::CliVariant,
+        >,
+        context: &super::SelectServerContext,
+    ) -> color_eyre::eyre::Result<crate::common::AvailableRpcServerUrl> {
+        match optional_cli_url {
+            Some(url) => Ok(url),
+            None => {
+                if let Ok(network) = std::env::var("CUSTOM_NETWORK") {
+                    if let Ok(url) = network.parse() {
+                        return Ok(url);
+                    }
+                }
+                Self::input_url(context)
+            }
+        }
+    }
+
     pub fn input_url(
         _context: &super::SelectServerContext,
     ) -> color_eyre::eyre::Result<crate::common::AvailableRpcServerUrl> {

--- a/src/commands/add_command/sub_account/operation_mode/online_mode/select_server/server/mod.rs
+++ b/src/commands/add_command/sub_account/operation_mode/online_mode/select_server/server/mod.rs
@@ -53,8 +53,12 @@ impl CustomServer {
             Some(url) => Ok(url),
             None => {
                 if let Ok(network) = std::env::var("CUSTOM_NETWORK") {
-                    if let Ok(url) = network.parse() {
-                        return Ok(url);
+                    match network.parse() {
+                        Ok(url) => {
+                            println!("Using the URL address from CUSTOM_NETWORK: {}", network);
+                            return Ok(url)
+                        },
+                        Err(err) => println!("Couldn't use the URL address from CUSTOM_NETWORK: {}. Error: {}", network, err),
                     }
                 }
                 Self::input_url(context)

--- a/src/commands/add_command/sub_account/operation_mode/online_mode/select_server/server/mod.rs
+++ b/src/commands/add_command/sub_account/operation_mode/online_mode/select_server/server/mod.rs
@@ -56,9 +56,12 @@ impl CustomServer {
                     match network.parse() {
                         Ok(url) => {
                             println!("Using the URL address from CUSTOM_NETWORK: {}", network);
-                            return Ok(url)
-                        },
-                        Err(err) => println!("Couldn't use the URL address from CUSTOM_NETWORK: {}. Error: {}", network, err),
+                            return Ok(url);
+                        }
+                        Err(err) => println!(
+                            "Couldn't use the URL address from CUSTOM_NETWORK: {}. Error: {}",
+                            network, err
+                        ),
                     }
                 }
                 Self::input_url(context)

--- a/src/commands/construct_transaction_command/operation_mode/online_mode/select_server/server/mod.rs
+++ b/src/commands/construct_transaction_command/operation_mode/online_mode/select_server/server/mod.rs
@@ -67,8 +67,12 @@ impl CustomServer {
             Some(url) => Ok(url),
             None => {
                 if let Ok(network) = std::env::var("CUSTOM_NETWORK") {
-                    if let Ok(url) = network.parse() {
-                        return Ok(url);
+                    match network.parse() {
+                        Ok(url) => {
+                            println!("Using the URL address from CUSTOM_NETWORK: {}", network);
+                            return Ok(url)
+                        },
+                        Err(err) => println!("Couldn't use the URL address from CUSTOM_NETWORK: {}. Error: {}", network, err),
                     }
                 }
                 Self::input_url(context)

--- a/src/commands/construct_transaction_command/operation_mode/online_mode/select_server/server/mod.rs
+++ b/src/commands/construct_transaction_command/operation_mode/online_mode/select_server/server/mod.rs
@@ -70,9 +70,12 @@ impl CustomServer {
                     match network.parse() {
                         Ok(url) => {
                             println!("Using the URL address from CUSTOM_NETWORK: {}", network);
-                            return Ok(url)
-                        },
-                        Err(err) => println!("Couldn't use the URL address from CUSTOM_NETWORK: {}. Error: {}", network, err),
+                            return Ok(url);
+                        }
+                        Err(err) => println!(
+                            "Couldn't use the URL address from CUSTOM_NETWORK: {}. Error: {}",
+                            network, err
+                        ),
                     }
                 }
                 Self::input_url(context)

--- a/src/commands/construct_transaction_command/operation_mode/online_mode/select_server/server/mod.rs
+++ b/src/commands/construct_transaction_command/operation_mode/online_mode/select_server/server/mod.rs
@@ -13,6 +13,7 @@ pub struct Server {
 #[interactive_clap(input_context = super::SelectServerContext)]
 #[interactive_clap(output_context = super::super::super::ConstructTransactionNetworkContext)]
 pub struct CustomServer {
+    #[interactive_clap(skip_default_from_cli)]
     #[interactive_clap(long)]
     pub url: crate::common::AvailableRpcServerUrl,
     #[interactive_clap(named_arg)]
@@ -56,6 +57,25 @@ impl Server {
 }
 
 impl CustomServer {
+    fn from_cli_url(
+        optional_cli_url: Option<
+            <crate::common::AvailableRpcServerUrl as interactive_clap::ToCli>::CliVariant,
+        >,
+        context: &super::SelectServerContext,
+    ) -> color_eyre::eyre::Result<crate::common::AvailableRpcServerUrl> {
+        match optional_cli_url {
+            Some(url) => Ok(url),
+            None => {
+                if let Ok(network) = std::env::var("CUSTOM_NETWORK") {
+                    if let Ok(url) = network.parse() {
+                        return Ok(url);
+                    }
+                }
+                Self::input_url(context)
+            }
+        }
+    }
+
     pub fn input_url(
         _context: &super::SelectServerContext,
     ) -> color_eyre::eyre::Result<crate::common::AvailableRpcServerUrl> {

--- a/src/commands/delete_command/access_key/operation_mode/online_mode/select_server/server/mod.rs
+++ b/src/commands/delete_command/access_key/operation_mode/online_mode/select_server/server/mod.rs
@@ -53,8 +53,12 @@ impl CustomServer {
             Some(url) => Ok(url),
             None => {
                 if let Ok(network) = std::env::var("CUSTOM_NETWORK") {
-                    if let Ok(url) = network.parse() {
-                        return Ok(url);
+                    match network.parse() {
+                        Ok(url) => {
+                            println!("Using the URL address from CUSTOM_NETWORK: {}", network);
+                            return Ok(url)
+                        },
+                        Err(err) => println!("Couldn't use the URL address from CUSTOM_NETWORK: {}. Error: {}", network, err),
                     }
                 }
                 Self::input_url(context)

--- a/src/commands/delete_command/access_key/operation_mode/online_mode/select_server/server/mod.rs
+++ b/src/commands/delete_command/access_key/operation_mode/online_mode/select_server/server/mod.rs
@@ -12,6 +12,7 @@ pub struct Server {
 #[interactive_clap(input_context = super::SelectServerContext)]
 #[interactive_clap(output_context = super::super::super::AddAccessKeyCommandNetworkContext)]
 pub struct CustomServer {
+    #[interactive_clap(skip_default_from_cli)]
     pub url: crate::common::AvailableRpcServerUrl,
     #[interactive_clap(named_arg)]
     ///Specify the account to be deleted
@@ -42,6 +43,25 @@ impl From<CustomServerContext> for super::super::super::DeleteAccessKeyCommandNe
 }
 
 impl CustomServer {
+    fn from_cli_url(
+        optional_cli_url: Option<
+            <crate::common::AvailableRpcServerUrl as interactive_clap::ToCli>::CliVariant,
+        >,
+        context: &super::SelectServerContext,
+    ) -> color_eyre::eyre::Result<crate::common::AvailableRpcServerUrl> {
+        match optional_cli_url {
+            Some(url) => Ok(url),
+            None => {
+                if let Ok(network) = std::env::var("CUSTOM_NETWORK") {
+                    if let Ok(url) = network.parse() {
+                        return Ok(url);
+                    }
+                }
+                Self::input_url(context)
+            }
+        }
+    }
+
     pub fn input_url(
         _context: &super::SelectServerContext,
     ) -> color_eyre::eyre::Result<crate::common::AvailableRpcServerUrl> {

--- a/src/commands/delete_command/access_key/operation_mode/online_mode/select_server/server/mod.rs
+++ b/src/commands/delete_command/access_key/operation_mode/online_mode/select_server/server/mod.rs
@@ -56,9 +56,12 @@ impl CustomServer {
                     match network.parse() {
                         Ok(url) => {
                             println!("Using the URL address from CUSTOM_NETWORK: {}", network);
-                            return Ok(url)
-                        },
-                        Err(err) => println!("Couldn't use the URL address from CUSTOM_NETWORK: {}. Error: {}", network, err),
+                            return Ok(url);
+                        }
+                        Err(err) => println!(
+                            "Couldn't use the URL address from CUSTOM_NETWORK: {}. Error: {}",
+                            network, err
+                        ),
                     }
                 }
                 Self::input_url(context)

--- a/src/commands/delete_command/account/operation_mode/online_mode/select_server/server/mod.rs
+++ b/src/commands/delete_command/account/operation_mode/online_mode/select_server/server/mod.rs
@@ -12,6 +12,7 @@ pub struct Server {
 #[interactive_clap(input_context = super::SelectServerContext)]
 #[interactive_clap(output_context = super::super::super::DeleteAccountCommandNetworkContext)]
 pub struct CustomServer {
+    #[interactive_clap(skip_default_from_cli)]
     pub url: crate::common::AvailableRpcServerUrl,
     #[interactive_clap(named_arg)]
     ///Specify the account to be deleted
@@ -42,6 +43,25 @@ impl From<CustomServerContext> for super::super::super::DeleteAccountCommandNetw
 }
 
 impl CustomServer {
+    fn from_cli_url(
+        optional_cli_url: Option<
+            <crate::common::AvailableRpcServerUrl as interactive_clap::ToCli>::CliVariant,
+        >,
+        context: &super::SelectServerContext,
+    ) -> color_eyre::eyre::Result<crate::common::AvailableRpcServerUrl> {
+        match optional_cli_url {
+            Some(url) => Ok(url),
+            None => {
+                if let Ok(network) = std::env::var("CUSTOM_NETWORK") {
+                    if let Ok(url) = network.parse() {
+                        return Ok(url);
+                    }
+                }
+                Self::input_url(context)
+            }
+        }
+    }
+
     pub fn input_url(
         _context: &super::SelectServerContext,
     ) -> color_eyre::eyre::Result<crate::common::AvailableRpcServerUrl> {

--- a/src/commands/delete_command/account/operation_mode/online_mode/select_server/server/mod.rs
+++ b/src/commands/delete_command/account/operation_mode/online_mode/select_server/server/mod.rs
@@ -53,8 +53,12 @@ impl CustomServer {
             Some(url) => Ok(url),
             None => {
                 if let Ok(network) = std::env::var("CUSTOM_NETWORK") {
-                    if let Ok(url) = network.parse() {
-                        return Ok(url);
+                    match network.parse() {
+                        Ok(url) => {
+                            println!("Using the URL address from CUSTOM_NETWORK: {}", network);
+                            return Ok(url)
+                        },
+                        Err(err) => println!("Couldn't use the URL address from CUSTOM_NETWORK: {}. Error: {}", network, err),
                     }
                 }
                 Self::input_url(context)

--- a/src/commands/delete_command/account/operation_mode/online_mode/select_server/server/mod.rs
+++ b/src/commands/delete_command/account/operation_mode/online_mode/select_server/server/mod.rs
@@ -56,9 +56,12 @@ impl CustomServer {
                     match network.parse() {
                         Ok(url) => {
                             println!("Using the URL address from CUSTOM_NETWORK: {}", network);
-                            return Ok(url)
-                        },
-                        Err(err) => println!("Couldn't use the URL address from CUSTOM_NETWORK: {}. Error: {}", network, err),
+                            return Ok(url);
+                        }
+                        Err(err) => println!(
+                            "Couldn't use the URL address from CUSTOM_NETWORK: {}. Error: {}",
+                            network, err
+                        ),
                     }
                 }
                 Self::input_url(context)

--- a/src/commands/execute_command/change_method/operation_mode/online_mode/select_server/server/mod.rs
+++ b/src/commands/execute_command/change_method/operation_mode/online_mode/select_server/server/mod.rs
@@ -12,6 +12,7 @@ pub struct Server {
 #[interactive_clap(input_context = super::SelectServerContext)]
 #[interactive_clap(output_context = super::super::super::TransferCommandNetworkContext)]
 pub struct CustomServer {
+    #[interactive_clap(skip_default_from_cli)]
     #[interactive_clap(long)]
     pub url: crate::common::AvailableRpcServerUrl,
     #[interactive_clap(named_arg)]
@@ -55,6 +56,25 @@ impl Server {
 }
 
 impl CustomServer {
+    fn from_cli_url(
+        optional_cli_url: Option<
+            <crate::common::AvailableRpcServerUrl as interactive_clap::ToCli>::CliVariant,
+        >,
+        context: &super::SelectServerContext,
+    ) -> color_eyre::eyre::Result<crate::common::AvailableRpcServerUrl> {
+        match optional_cli_url {
+            Some(url) => Ok(url),
+            None => {
+                if let Ok(network) = std::env::var("CUSTOM_NETWORK") {
+                    if let Ok(url) = network.parse() {
+                        return Ok(url);
+                    }
+                }
+                Self::input_url(context)
+            }
+        }
+    }
+
     pub fn input_url(
         _context: &super::SelectServerContext,
     ) -> color_eyre::eyre::Result<crate::common::AvailableRpcServerUrl> {

--- a/src/commands/execute_command/change_method/operation_mode/online_mode/select_server/server/mod.rs
+++ b/src/commands/execute_command/change_method/operation_mode/online_mode/select_server/server/mod.rs
@@ -66,8 +66,12 @@ impl CustomServer {
             Some(url) => Ok(url),
             None => {
                 if let Ok(network) = std::env::var("CUSTOM_NETWORK") {
-                    if let Ok(url) = network.parse() {
-                        return Ok(url);
+                    match network.parse() {
+                        Ok(url) => {
+                            println!("Using the URL address from CUSTOM_NETWORK: {}", network);
+                            return Ok(url)
+                        },
+                        Err(err) => println!("Couldn't use the URL address from CUSTOM_NETWORK: {}. Error: {}", network, err),
                     }
                 }
                 Self::input_url(context)

--- a/src/commands/execute_command/change_method/operation_mode/online_mode/select_server/server/mod.rs
+++ b/src/commands/execute_command/change_method/operation_mode/online_mode/select_server/server/mod.rs
@@ -69,9 +69,12 @@ impl CustomServer {
                     match network.parse() {
                         Ok(url) => {
                             println!("Using the URL address from CUSTOM_NETWORK: {}", network);
-                            return Ok(url)
-                        },
-                        Err(err) => println!("Couldn't use the URL address from CUSTOM_NETWORK: {}. Error: {}", network, err),
+                            return Ok(url);
+                        }
+                        Err(err) => println!(
+                            "Couldn't use the URL address from CUSTOM_NETWORK: {}. Error: {}",
+                            network, err
+                        ),
                     }
                 }
                 Self::input_url(context)

--- a/src/commands/execute_command/view_method/operation_mode/online_mode/select_server/server/mod.rs
+++ b/src/commands/execute_command/view_method/operation_mode/online_mode/select_server/server/mod.rs
@@ -63,8 +63,12 @@ impl CustomServer {
             Some(url) => Ok(url),
             None => {
                 if let Ok(network) = std::env::var("CUSTOM_NETWORK") {
-                    if let Ok(url) = network.parse() {
-                        return Ok(url);
+                    match network.parse() {
+                        Ok(url) => {
+                            println!("Using the URL address from CUSTOM_NETWORK: {}", network);
+                            return Ok(url)
+                        },
+                        Err(err) => println!("Couldn't use the URL address from CUSTOM_NETWORK: {}. Error: {}", network, err),
                     }
                 }
                 Self::input_url(context)

--- a/src/commands/execute_command/view_method/operation_mode/online_mode/select_server/server/mod.rs
+++ b/src/commands/execute_command/view_method/operation_mode/online_mode/select_server/server/mod.rs
@@ -66,9 +66,12 @@ impl CustomServer {
                     match network.parse() {
                         Ok(url) => {
                             println!("Using the URL address from CUSTOM_NETWORK: {}", network);
-                            return Ok(url)
-                        },
-                        Err(err) => println!("Couldn't use the URL address from CUSTOM_NETWORK: {}. Error: {}", network, err),
+                            return Ok(url);
+                        }
+                        Err(err) => println!(
+                            "Couldn't use the URL address from CUSTOM_NETWORK: {}. Error: {}",
+                            network, err
+                        ),
                     }
                 }
                 Self::input_url(context)

--- a/src/commands/execute_command/view_method/operation_mode/online_mode/select_server/server/mod.rs
+++ b/src/commands/execute_command/view_method/operation_mode/online_mode/select_server/server/mod.rs
@@ -12,6 +12,7 @@ pub struct Server {
 #[interactive_clap(input_context = super::SelectServerContext)]
 #[interactive_clap(output_context = super::ExecuteViewMethodCommandNetworkContext)]
 pub struct CustomServer {
+    #[interactive_clap(skip_default_from_cli)]
     #[interactive_clap(long)]
     pub url: crate::common::AvailableRpcServerUrl,
     #[interactive_clap(named_arg)]
@@ -52,6 +53,25 @@ impl Server {
 }
 
 impl CustomServer {
+    fn from_cli_url(
+        optional_cli_url: Option<
+            <crate::common::AvailableRpcServerUrl as interactive_clap::ToCli>::CliVariant,
+        >,
+        context: &super::SelectServerContext,
+    ) -> color_eyre::eyre::Result<crate::common::AvailableRpcServerUrl> {
+        match optional_cli_url {
+            Some(url) => Ok(url),
+            None => {
+                if let Ok(network) = std::env::var("CUSTOM_NETWORK") {
+                    if let Ok(url) = network.parse() {
+                        return Ok(url);
+                    }
+                }
+                Self::input_url(context)
+            }
+        }
+    }
+
     pub fn input_url(
         _context: &super::SelectServerContext,
     ) -> color_eyre::eyre::Result<crate::common::AvailableRpcServerUrl> {

--- a/src/commands/login/operation_mode/online_mode/select_server/server/mod.rs
+++ b/src/commands/login/operation_mode/online_mode/select_server/server/mod.rs
@@ -52,9 +52,12 @@ impl CustomServer {
                     match network.parse() {
                         Ok(url) => {
                             println!("Using the URL address from CUSTOM_NETWORK: {}", network);
-                            return Ok(url)
-                        },
-                        Err(err) => println!("Couldn't use the URL address from CUSTOM_NETWORK: {}. Error: {}", network, err),
+                            return Ok(url);
+                        }
+                        Err(err) => println!(
+                            "Couldn't use the URL address from CUSTOM_NETWORK: {}. Error: {}",
+                            network, err
+                        ),
                     }
                 }
                 Self::input_url(context)

--- a/src/commands/login/operation_mode/online_mode/select_server/server/mod.rs
+++ b/src/commands/login/operation_mode/online_mode/select_server/server/mod.rs
@@ -49,8 +49,12 @@ impl CustomServer {
             Some(url) => Ok(url),
             None => {
                 if let Ok(network) = std::env::var("CUSTOM_NETWORK") {
-                    if let Ok(url) = network.parse() {
-                        return Ok(url);
+                    match network.parse() {
+                        Ok(url) => {
+                            println!("Using the URL address from CUSTOM_NETWORK: {}", network);
+                            return Ok(url)
+                        },
+                        Err(err) => println!("Couldn't use the URL address from CUSTOM_NETWORK: {}. Error: {}", network, err),
                     }
                 }
                 Self::input_url(context)

--- a/src/commands/login/operation_mode/online_mode/select_server/server/mod.rs
+++ b/src/commands/login/operation_mode/online_mode/select_server/server/mod.rs
@@ -10,6 +10,7 @@ pub struct Server {}
 #[interactive_clap(input_context = super::SelectServerContext)]
 #[interactive_clap(output_context = super::LoginCommandNetworkContext)]
 pub struct CustomServer {
+    #[interactive_clap(skip_default_from_cli)]
     #[interactive_clap(long)]
     pub url: crate::common::AvailableRpcServerUrl,
 }
@@ -38,6 +39,25 @@ impl From<CustomServerContext> for super::LoginCommandNetworkContext {
 }
 
 impl CustomServer {
+    fn from_cli_url(
+        optional_cli_url: Option<
+            <crate::common::AvailableRpcServerUrl as interactive_clap::ToCli>::CliVariant,
+        >,
+        context: &super::SelectServerContext,
+    ) -> color_eyre::eyre::Result<crate::common::AvailableRpcServerUrl> {
+        match optional_cli_url {
+            Some(url) => Ok(url),
+            None => {
+                if let Ok(network) = std::env::var("CUSTOM_NETWORK") {
+                    if let Ok(url) = network.parse() {
+                        return Ok(url);
+                    }
+                }
+                Self::input_url(context)
+            }
+        }
+    }
+
     pub fn input_url(
         _context: &super::SelectServerContext,
     ) -> color_eyre::eyre::Result<crate::common::AvailableRpcServerUrl> {

--- a/src/commands/transfer_command/operation_mode/online_mode/select_server/server/mod.rs
+++ b/src/commands/transfer_command/operation_mode/online_mode/select_server/server/mod.rs
@@ -12,6 +12,7 @@ pub struct Server {
 #[interactive_clap(input_context = super::SelectServerContext)]
 #[interactive_clap(output_context = super::super::super::TransferCommandNetworkContext)]
 pub struct CustomServer {
+    #[interactive_clap(skip_default_from_cli)]
     #[interactive_clap(long)]
     pub url: crate::common::AvailableRpcServerUrl,
     #[interactive_clap(named_arg)]
@@ -55,6 +56,25 @@ impl Server {
 }
 
 impl CustomServer {
+    fn from_cli_url(
+        optional_cli_url: Option<
+            <crate::common::AvailableRpcServerUrl as interactive_clap::ToCli>::CliVariant,
+        >,
+        context: &super::SelectServerContext,
+    ) -> color_eyre::eyre::Result<crate::common::AvailableRpcServerUrl> {
+        match optional_cli_url {
+            Some(url) => Ok(url),
+            None => {
+                if let Ok(network) = std::env::var("CUSTOM_NETWORK") {
+                    if let Ok(url) = network.parse() {
+                        return Ok(url);
+                    }
+                }
+                Self::input_url(context)
+            }
+        }
+    }
+
     pub fn input_url(
         _context: &super::SelectServerContext,
     ) -> color_eyre::eyre::Result<crate::common::AvailableRpcServerUrl> {

--- a/src/commands/transfer_command/operation_mode/online_mode/select_server/server/mod.rs
+++ b/src/commands/transfer_command/operation_mode/online_mode/select_server/server/mod.rs
@@ -66,8 +66,12 @@ impl CustomServer {
             Some(url) => Ok(url),
             None => {
                 if let Ok(network) = std::env::var("CUSTOM_NETWORK") {
-                    if let Ok(url) = network.parse() {
-                        return Ok(url);
+                    match network.parse() {
+                        Ok(url) => {
+                            println!("Using the URL address from CUSTOM_NETWORK: {}", network);
+                            return Ok(url)
+                        },
+                        Err(err) => println!("Couldn't use the URL address from CUSTOM_NETWORK: {}. Error: {}", network, err),
                     }
                 }
                 Self::input_url(context)

--- a/src/commands/transfer_command/operation_mode/online_mode/select_server/server/mod.rs
+++ b/src/commands/transfer_command/operation_mode/online_mode/select_server/server/mod.rs
@@ -69,9 +69,12 @@ impl CustomServer {
                     match network.parse() {
                         Ok(url) => {
                             println!("Using the URL address from CUSTOM_NETWORK: {}", network);
-                            return Ok(url)
-                        },
-                        Err(err) => println!("Couldn't use the URL address from CUSTOM_NETWORK: {}. Error: {}", network, err),
+                            return Ok(url);
+                        }
+                        Err(err) => println!(
+                            "Couldn't use the URL address from CUSTOM_NETWORK: {}. Error: {}",
+                            network, err
+                        ),
                     }
                 }
                 Self::input_url(context)

--- a/src/commands/utils_command/send_signed_transaction/operation_mode/online_mode/select_server/server/mod.rs
+++ b/src/commands/utils_command/send_signed_transaction/operation_mode/online_mode/select_server/server/mod.rs
@@ -86,10 +86,28 @@ impl CliCustomServer {
     pub fn into_server(self) -> Server {
         let url: crate::common::AvailableRpcServerUrl = match self.url {
             Some(url) => url,
-            None => Input::new()
-                .with_prompt("What is the RPC endpoint?")
-                .interact_text()
-                .unwrap(),
+            None => {
+                if let Ok(network) = std::env::var("CUSTOM_NETWORK") {
+                    match network.parse() {
+                        Ok(url) => {
+                            println!("Using the URL address from CUSTOM_NETWORK: {}", network);
+                            url
+                        },
+                        Err(err) => {
+                            println!("Couldn't use the URL address from CUSTOM_NETWORK: {}. Error: {}", network, err);
+                            Input::new()
+                                .with_prompt("What is the RPC endpoint?")
+                                .interact_text()
+                                .unwrap()
+                        },
+                    }
+                } else {
+                    Input::new()
+                        .with_prompt("What is the RPC endpoint?")
+                        .interact_text()
+                        .unwrap()
+                }
+            },
         };
         let send = match self.send {
             Some(cli_send) => Send::from(cli_send),

--- a/src/commands/utils_command/send_signed_transaction/operation_mode/online_mode/select_server/server/mod.rs
+++ b/src/commands/utils_command/send_signed_transaction/operation_mode/online_mode/select_server/server/mod.rs
@@ -92,14 +92,17 @@ impl CliCustomServer {
                         Ok(url) => {
                             println!("Using the URL address from CUSTOM_NETWORK: {}", network);
                             url
-                        },
+                        }
                         Err(err) => {
-                            println!("Couldn't use the URL address from CUSTOM_NETWORK: {}. Error: {}", network, err);
+                            println!(
+                                "Couldn't use the URL address from CUSTOM_NETWORK: {}. Error: {}",
+                                network, err
+                            );
                             Input::new()
                                 .with_prompt("What is the RPC endpoint?")
                                 .interact_text()
                                 .unwrap()
-                        },
+                        }
                     }
                 } else {
                     Input::new()
@@ -107,7 +110,7 @@ impl CliCustomServer {
                         .interact_text()
                         .unwrap()
                 }
-            },
+            }
         };
         let send = match self.send {
             Some(cli_send) => Send::from(cli_send),

--- a/src/commands/view_command/view_account/operation_mode/online_mode/select_server/server/mod.rs
+++ b/src/commands/view_command/view_account/operation_mode/online_mode/select_server/server/mod.rs
@@ -63,8 +63,12 @@ impl CustomServer {
             Some(url) => Ok(url),
             None => {
                 if let Ok(network) = std::env::var("CUSTOM_NETWORK") {
-                    if let Ok(url) = network.parse() {
-                        return Ok(url);
+                    match network.parse() {
+                        Ok(url) => {
+                            println!("Using the URL address from CUSTOM_NETWORK: {}", network);
+                            return Ok(url)
+                        },
+                        Err(err) => println!("Couldn't use the URL address from CUSTOM_NETWORK: {}. Error: {}", network, err),
                     }
                 }
                 Self::input_url(context)

--- a/src/commands/view_command/view_account/operation_mode/online_mode/select_server/server/mod.rs
+++ b/src/commands/view_command/view_account/operation_mode/online_mode/select_server/server/mod.rs
@@ -66,9 +66,12 @@ impl CustomServer {
                     match network.parse() {
                         Ok(url) => {
                             println!("Using the URL address from CUSTOM_NETWORK: {}", network);
-                            return Ok(url)
-                        },
-                        Err(err) => println!("Couldn't use the URL address from CUSTOM_NETWORK: {}. Error: {}", network, err),
+                            return Ok(url);
+                        }
+                        Err(err) => println!(
+                            "Couldn't use the URL address from CUSTOM_NETWORK: {}. Error: {}",
+                            network, err
+                        ),
                     }
                 }
                 Self::input_url(context)

--- a/src/commands/view_command/view_account/operation_mode/online_mode/select_server/server/mod.rs
+++ b/src/commands/view_command/view_account/operation_mode/online_mode/select_server/server/mod.rs
@@ -12,6 +12,7 @@ pub struct Server {
 #[interactive_clap(input_context = super::SelectServerContext)]
 #[interactive_clap(output_context = super::ViewAccountSummaryCommandNetworkContext)]
 pub struct CustomServer {
+    #[interactive_clap(skip_default_from_cli)]
     #[interactive_clap(long)]
     pub url: crate::common::AvailableRpcServerUrl,
     #[interactive_clap(named_arg)]
@@ -52,6 +53,25 @@ impl Server {
 }
 
 impl CustomServer {
+    fn from_cli_url(
+        optional_cli_url: Option<
+            <crate::common::AvailableRpcServerUrl as interactive_clap::ToCli>::CliVariant,
+        >,
+        context: &super::SelectServerContext,
+    ) -> color_eyre::eyre::Result<crate::common::AvailableRpcServerUrl> {
+        match optional_cli_url {
+            Some(url) => Ok(url),
+            None => {
+                if let Ok(network) = std::env::var("CUSTOM_NETWORK") {
+                    if let Ok(url) = network.parse() {
+                        return Ok(url);
+                    }
+                }
+                Self::input_url(context)
+            }
+        }
+    }
+
     pub fn input_url(
         _context: &super::SelectServerContext,
     ) -> color_eyre::eyre::Result<crate::common::AvailableRpcServerUrl> {

--- a/src/commands/view_command/view_contract_code/operation_mode/online_mode/select_server/server/mod.rs
+++ b/src/commands/view_command/view_contract_code/operation_mode/online_mode/select_server/server/mod.rs
@@ -63,8 +63,12 @@ impl CustomServer {
             Some(url) => Ok(url),
             None => {
                 if let Ok(network) = std::env::var("CUSTOM_NETWORK") {
-                    if let Ok(url) = network.parse() {
-                        return Ok(url);
+                    match network.parse() {
+                        Ok(url) => {
+                            println!("Using the URL address from CUSTOM_NETWORK: {}", network);
+                            return Ok(url)
+                        },
+                        Err(err) => println!("Couldn't use the URL address from CUSTOM_NETWORK: {}. Error: {}", network, err),
                     }
                 }
                 Self::input_url(context)

--- a/src/commands/view_command/view_contract_code/operation_mode/online_mode/select_server/server/mod.rs
+++ b/src/commands/view_command/view_contract_code/operation_mode/online_mode/select_server/server/mod.rs
@@ -12,6 +12,7 @@ pub struct Server {
 #[interactive_clap(input_context = super::SelectServerContext)]
 #[interactive_clap(output_context = super::ViewContractCodeCommandNetworkContext)]
 pub struct CustomServer {
+    #[interactive_clap(skip_default_from_cli)]
     #[interactive_clap(long)]
     pub url: crate::common::AvailableRpcServerUrl,
     #[interactive_clap(named_arg)]
@@ -52,6 +53,25 @@ impl Server {
 }
 
 impl CustomServer {
+    fn from_cli_url(
+        optional_cli_url: Option<
+            <crate::common::AvailableRpcServerUrl as interactive_clap::ToCli>::CliVariant,
+        >,
+        context: &super::SelectServerContext,
+    ) -> color_eyre::eyre::Result<crate::common::AvailableRpcServerUrl> {
+        match optional_cli_url {
+            Some(url) => Ok(url),
+            None => {
+                if let Ok(network) = std::env::var("CUSTOM_NETWORK") {
+                    if let Ok(url) = network.parse() {
+                        return Ok(url);
+                    }
+                }
+                Self::input_url(context)
+            }
+        }
+    }
+
     pub fn input_url(
         _context: &super::SelectServerContext,
     ) -> color_eyre::eyre::Result<crate::common::AvailableRpcServerUrl> {

--- a/src/commands/view_command/view_contract_code/operation_mode/online_mode/select_server/server/mod.rs
+++ b/src/commands/view_command/view_contract_code/operation_mode/online_mode/select_server/server/mod.rs
@@ -66,9 +66,12 @@ impl CustomServer {
                     match network.parse() {
                         Ok(url) => {
                             println!("Using the URL address from CUSTOM_NETWORK: {}", network);
-                            return Ok(url)
-                        },
-                        Err(err) => println!("Couldn't use the URL address from CUSTOM_NETWORK: {}. Error: {}", network, err),
+                            return Ok(url);
+                        }
+                        Err(err) => println!(
+                            "Couldn't use the URL address from CUSTOM_NETWORK: {}. Error: {}",
+                            network, err
+                        ),
                     }
                 }
                 Self::input_url(context)

--- a/src/commands/view_command/view_contract_state/operation_mode/online_mode/select_server/server/mod.rs
+++ b/src/commands/view_command/view_contract_state/operation_mode/online_mode/select_server/server/mod.rs
@@ -63,8 +63,12 @@ impl CustomServer {
             Some(url) => Ok(url),
             None => {
                 if let Ok(network) = std::env::var("CUSTOM_NETWORK") {
-                    if let Ok(url) = network.parse() {
-                        return Ok(url);
+                    match network.parse() {
+                        Ok(url) => {
+                            println!("Using the URL address from CUSTOM_NETWORK: {}", network);
+                            return Ok(url)
+                        },
+                        Err(err) => println!("Couldn't use the URL address from CUSTOM_NETWORK: {}. Error: {}", network, err),
                     }
                 }
                 Self::input_url(context)

--- a/src/commands/view_command/view_contract_state/operation_mode/online_mode/select_server/server/mod.rs
+++ b/src/commands/view_command/view_contract_state/operation_mode/online_mode/select_server/server/mod.rs
@@ -12,6 +12,7 @@ pub struct Server {
 #[interactive_clap(input_context = super::SelectServerContext)]
 #[interactive_clap(output_context = super::ViewContractCodeCommandNetworkContext)]
 pub struct CustomServer {
+    #[interactive_clap(skip_default_from_cli)]
     #[interactive_clap(long)]
     pub url: crate::common::AvailableRpcServerUrl,
     #[interactive_clap(named_arg)]
@@ -52,6 +53,25 @@ impl Server {
 }
 
 impl CustomServer {
+    fn from_cli_url(
+        optional_cli_url: Option<
+            <crate::common::AvailableRpcServerUrl as interactive_clap::ToCli>::CliVariant,
+        >,
+        context: &super::SelectServerContext,
+    ) -> color_eyre::eyre::Result<crate::common::AvailableRpcServerUrl> {
+        match optional_cli_url {
+            Some(url) => Ok(url),
+            None => {
+                if let Ok(network) = std::env::var("CUSTOM_NETWORK") {
+                    if let Ok(url) = network.parse() {
+                        return Ok(url);
+                    }
+                }
+                Self::input_url(context)
+            }
+        }
+    }
+
     pub fn input_url(
         _context: &super::SelectServerContext,
     ) -> color_eyre::eyre::Result<crate::common::AvailableRpcServerUrl> {

--- a/src/commands/view_command/view_contract_state/operation_mode/online_mode/select_server/server/mod.rs
+++ b/src/commands/view_command/view_contract_state/operation_mode/online_mode/select_server/server/mod.rs
@@ -66,9 +66,12 @@ impl CustomServer {
                     match network.parse() {
                         Ok(url) => {
                             println!("Using the URL address from CUSTOM_NETWORK: {}", network);
-                            return Ok(url)
-                        },
-                        Err(err) => println!("Couldn't use the URL address from CUSTOM_NETWORK: {}. Error: {}", network, err),
+                            return Ok(url);
+                        }
+                        Err(err) => println!(
+                            "Couldn't use the URL address from CUSTOM_NETWORK: {}. Error: {}",
+                            network, err
+                        ),
                     }
                 }
                 Self::input_url(context)

--- a/src/commands/view_command/view_nonce/operation_mode/online_mode/select_server/server/mod.rs
+++ b/src/commands/view_command/view_nonce/operation_mode/online_mode/select_server/server/mod.rs
@@ -63,8 +63,12 @@ impl CustomServer {
             Some(url) => Ok(url),
             None => {
                 if let Ok(network) = std::env::var("CUSTOM_NETWORK") {
-                    if let Ok(url) = network.parse() {
-                        return Ok(url);
+                    match network.parse() {
+                        Ok(url) => {
+                            println!("Using the URL address from CUSTOM_NETWORK: {}", network);
+                            return Ok(url)
+                        },
+                        Err(err) => println!("Couldn't use the URL address from CUSTOM_NETWORK: {}. Error: {}", network, err),
                     }
                 }
                 Self::input_url(context)

--- a/src/commands/view_command/view_nonce/operation_mode/online_mode/select_server/server/mod.rs
+++ b/src/commands/view_command/view_nonce/operation_mode/online_mode/select_server/server/mod.rs
@@ -12,6 +12,7 @@ pub struct Server {
 #[interactive_clap(input_context = super::SelectServerContext)]
 #[interactive_clap(output_context = super::ViewContractCodeCommandNetworkContext)]
 pub struct CustomServer {
+    #[interactive_clap(skip_default_from_cli)]
     #[interactive_clap(long)]
     pub url: crate::common::AvailableRpcServerUrl,
     #[interactive_clap(named_arg)]
@@ -52,6 +53,25 @@ impl Server {
 }
 
 impl CustomServer {
+    fn from_cli_url(
+        optional_cli_url: Option<
+            <crate::common::AvailableRpcServerUrl as interactive_clap::ToCli>::CliVariant,
+        >,
+        context: &super::SelectServerContext,
+    ) -> color_eyre::eyre::Result<crate::common::AvailableRpcServerUrl> {
+        match optional_cli_url {
+            Some(url) => Ok(url),
+            None => {
+                if let Ok(network) = std::env::var("CUSTOM_NETWORK") {
+                    if let Ok(url) = network.parse() {
+                        return Ok(url);
+                    }
+                }
+                Self::input_url(context)
+            }
+        }
+    }
+
     pub fn input_url(
         _context: &super::SelectServerContext,
     ) -> color_eyre::eyre::Result<crate::common::AvailableRpcServerUrl> {

--- a/src/commands/view_command/view_nonce/operation_mode/online_mode/select_server/server/mod.rs
+++ b/src/commands/view_command/view_nonce/operation_mode/online_mode/select_server/server/mod.rs
@@ -66,9 +66,12 @@ impl CustomServer {
                     match network.parse() {
                         Ok(url) => {
                             println!("Using the URL address from CUSTOM_NETWORK: {}", network);
-                            return Ok(url)
-                        },
-                        Err(err) => println!("Couldn't use the URL address from CUSTOM_NETWORK: {}. Error: {}", network, err),
+                            return Ok(url);
+                        }
+                        Err(err) => println!(
+                            "Couldn't use the URL address from CUSTOM_NETWORK: {}. Error: {}",
+                            network, err
+                        ),
                     }
                 }
                 Self::input_url(context)

--- a/src/commands/view_command/view_recent_block_hash/operation_mode/online_mode/select_server/server/mod.rs
+++ b/src/commands/view_command/view_recent_block_hash/operation_mode/online_mode/select_server/server/mod.rs
@@ -8,6 +8,7 @@ pub struct Server {}
 #[interactive_clap(input_context = super::SelectServerContext)]
 #[interactive_clap(output_context = super::ViewRecentBlockHashCommandNetworkContext)]
 pub struct CustomServer {
+    #[interactive_clap(skip_default_from_cli)]
     #[interactive_clap(long)]
     pub url: crate::common::AvailableRpcServerUrl,
 }
@@ -45,6 +46,25 @@ impl Server {
 }
 
 impl CustomServer {
+    fn from_cli_url(
+        optional_cli_url: Option<
+            <crate::common::AvailableRpcServerUrl as interactive_clap::ToCli>::CliVariant,
+        >,
+        context: &super::SelectServerContext,
+    ) -> color_eyre::eyre::Result<crate::common::AvailableRpcServerUrl> {
+        match optional_cli_url {
+            Some(url) => Ok(url),
+            None => {
+                if let Ok(network) = std::env::var("CUSTOM_NETWORK") {
+                    if let Ok(url) = network.parse() {
+                        return Ok(url);
+                    }
+                }
+                Self::input_url(context)
+            }
+        }
+    }
+
     pub fn input_url(
         _context: &super::SelectServerContext,
     ) -> color_eyre::eyre::Result<crate::common::AvailableRpcServerUrl> {

--- a/src/commands/view_command/view_recent_block_hash/operation_mode/online_mode/select_server/server/mod.rs
+++ b/src/commands/view_command/view_recent_block_hash/operation_mode/online_mode/select_server/server/mod.rs
@@ -56,8 +56,12 @@ impl CustomServer {
             Some(url) => Ok(url),
             None => {
                 if let Ok(network) = std::env::var("CUSTOM_NETWORK") {
-                    if let Ok(url) = network.parse() {
-                        return Ok(url);
+                    match network.parse() {
+                        Ok(url) => {
+                            println!("Using the URL address from CUSTOM_NETWORK: {}", network);
+                            return Ok(url)
+                        },
+                        Err(err) => println!("Couldn't use the URL address from CUSTOM_NETWORK: {}. Error: {}", network, err),
                     }
                 }
                 Self::input_url(context)

--- a/src/commands/view_command/view_recent_block_hash/operation_mode/online_mode/select_server/server/mod.rs
+++ b/src/commands/view_command/view_recent_block_hash/operation_mode/online_mode/select_server/server/mod.rs
@@ -59,9 +59,12 @@ impl CustomServer {
                     match network.parse() {
                         Ok(url) => {
                             println!("Using the URL address from CUSTOM_NETWORK: {}", network);
-                            return Ok(url)
-                        },
-                        Err(err) => println!("Couldn't use the URL address from CUSTOM_NETWORK: {}. Error: {}", network, err),
+                            return Ok(url);
+                        }
+                        Err(err) => println!(
+                            "Couldn't use the URL address from CUSTOM_NETWORK: {}. Error: {}",
+                            network, err
+                        ),
                     }
                 }
                 Self::input_url(context)

--- a/src/commands/view_command/view_transaction_status/operation_mode/online_mode/select_server/server/mod.rs
+++ b/src/commands/view_command/view_transaction_status/operation_mode/online_mode/select_server/server/mod.rs
@@ -63,8 +63,12 @@ impl CustomServer {
             Some(url) => Ok(url),
             None => {
                 if let Ok(network) = std::env::var("CUSTOM_NETWORK") {
-                    if let Ok(url) = network.parse() {
-                        return Ok(url);
+                    match network.parse() {
+                        Ok(url) => {
+                            println!("Using the URL address from CUSTOM_NETWORK: {}", network);
+                            return Ok(url)
+                        },
+                        Err(err) => println!("Couldn't use the URL address from CUSTOM_NETWORK: {}. Error: {}", network, err),
                     }
                 }
                 Self::input_url(context)

--- a/src/commands/view_command/view_transaction_status/operation_mode/online_mode/select_server/server/mod.rs
+++ b/src/commands/view_command/view_transaction_status/operation_mode/online_mode/select_server/server/mod.rs
@@ -66,9 +66,12 @@ impl CustomServer {
                     match network.parse() {
                         Ok(url) => {
                             println!("Using the URL address from CUSTOM_NETWORK: {}", network);
-                            return Ok(url)
-                        },
-                        Err(err) => println!("Couldn't use the URL address from CUSTOM_NETWORK: {}. Error: {}", network, err),
+                            return Ok(url);
+                        }
+                        Err(err) => println!(
+                            "Couldn't use the URL address from CUSTOM_NETWORK: {}. Error: {}",
+                            network, err
+                        ),
                     }
                 }
                 Self::input_url(context)

--- a/src/commands/view_command/view_transaction_status/operation_mode/online_mode/select_server/server/mod.rs
+++ b/src/commands/view_command/view_transaction_status/operation_mode/online_mode/select_server/server/mod.rs
@@ -12,6 +12,7 @@ pub struct Server {
 #[interactive_clap(input_context = super::SelectServerContext)]
 #[interactive_clap(output_context = super::ViewTransactionCommandNetworkContext)]
 pub struct CustomServer {
+    #[interactive_clap(skip_default_from_cli)]
     #[interactive_clap(long)]
     pub url: crate::common::AvailableRpcServerUrl,
     #[interactive_clap(named_arg)]
@@ -52,6 +53,25 @@ impl Server {
 }
 
 impl CustomServer {
+    fn from_cli_url(
+        optional_cli_url: Option<
+            <crate::common::AvailableRpcServerUrl as interactive_clap::ToCli>::CliVariant,
+        >,
+        context: &super::SelectServerContext,
+    ) -> color_eyre::eyre::Result<crate::common::AvailableRpcServerUrl> {
+        match optional_cli_url {
+            Some(url) => Ok(url),
+            None => {
+                if let Ok(network) = std::env::var("CUSTOM_NETWORK") {
+                    if let Ok(url) = network.parse() {
+                        return Ok(url);
+                    }
+                }
+                Self::input_url(context)
+            }
+        }
+    }
+
     pub fn input_url(
         _context: &super::SelectServerContext,
     ) -> color_eyre::eyre::Result<crate::common::AvailableRpcServerUrl> {


### PR DESCRIPTION
I suggest these changes regarding #57.

It allows creating the environment variable, which stores the URL of the custom network, for example
```
export CUSTOM_NETWORK=http://localhost:3030
```
After that the app doesn't ask to enter the URL each time the user chooses to use custom network. The value of `CUSTOM_NETWORK` is set as a default network URL if it is possible. Otherwise (if connection fails), the user is asked to enter another URL network.