### PR TITLE
fix: query method reports null on empty result

### DIFF
--- a/src/commands/execute_command/view_method/block_id/block_id_hash/mod.rs
+++ b/src/commands/execute_command/view_method/block_id/block_id_hash/mod.rs
@@ -49,9 +49,12 @@ impl BlockIdHash {
             } else {
                 return Err(color_eyre::Report::msg(format!("Error call result")));
             };
-        let call_result_str = String::from_utf8(call_result)?;
-        let serde_call_result: serde_json::Value = serde_json::from_str(&call_result_str)
-            .map_err(|err| color_eyre::Report::msg(format!("serde json: {:?}", err)))?;
+        let serde_call_result: serde_json::Value = if call_result.is_empty() {
+            serde_json::Value::Null
+        } else {
+            serde_json::from_slice(&call_result)
+                .map_err(|err| color_eyre::Report::msg(format!("serde json: {:?}", err)))?
+        };
         println!("--------------");
         println!();
         println!("{}", serde_json::to_string_pretty(&serde_call_result)?);

--- a/src/commands/execute_command/view_method/block_id/block_id_hash/mod.rs
+++ b/src/commands/execute_command/view_method/block_id/block_id_hash/mod.rs
@@ -49,7 +49,7 @@ impl BlockIdHash {
             } else {
                 return Err(color_eyre::Report::msg(format!("Error call result")));
             };
-        let serde_call_result: serde_json::Value = if call_result.is_empty() {
+        let serde_call_result = if call_result.is_empty() {
             serde_json::Value::Null
         } else {
             serde_json::from_slice(&call_result)

--- a/src/commands/execute_command/view_method/block_id/block_id_height/mod.rs
+++ b/src/commands/execute_command/view_method/block_id/block_id_height/mod.rs
@@ -49,7 +49,7 @@ impl BlockIdHeight {
             } else {
                 return Err(color_eyre::Report::msg(format!("Error call result")));
             };
-        let serde_call_result: serde_json::Value = if call_result.is_empty() {
+        let serde_call_result = if call_result.is_empty() {
             serde_json::Value::Null
         } else {
             serde_json::from_slice(&call_result)

--- a/src/commands/execute_command/view_method/block_id/block_id_height/mod.rs
+++ b/src/commands/execute_command/view_method/block_id/block_id_height/mod.rs
@@ -49,9 +49,12 @@ impl BlockIdHeight {
             } else {
                 return Err(color_eyre::Report::msg(format!("Error call result")));
             };
-        let call_result_str = String::from_utf8(call_result)?;
-        let serde_call_result: serde_json::Value = serde_json::from_str(&call_result_str)
-            .map_err(|err| color_eyre::Report::msg(format!("serde json: {:?}", err)))?;
+        let serde_call_result: serde_json::Value = if call_result.is_empty() {
+            serde_json::Value::Null
+        } else {
+            serde_json::from_slice(&call_result)
+                .map_err(|err| color_eyre::Report::msg(format!("serde json: {:?}", err)))?
+        };
         println!("--------------");
         println!();
         println!("{}", serde_json::to_string_pretty(&serde_call_result)?);

--- a/src/commands/execute_command/view_method/block_id/mod.rs
+++ b/src/commands/execute_command/view_method/block_id/mod.rs
@@ -94,7 +94,7 @@ impl BlockId {
                 return Err(color_eyre::Report::msg(format!("Error call result")));
             };
 
-        let serde_call_result: serde_json::Value = if call_result.is_empty() {
+        let serde_call_result = if call_result.is_empty() {
             serde_json::Value::Null
         } else {
             serde_json::from_slice(&call_result)

--- a/src/commands/execute_command/view_method/block_id/mod.rs
+++ b/src/commands/execute_command/view_method/block_id/mod.rs
@@ -93,9 +93,13 @@ impl BlockId {
             } else {
                 return Err(color_eyre::Report::msg(format!("Error call result")));
             };
-        let call_result_str = String::from_utf8(call_result)?;
-        let serde_call_result: serde_json::Value = serde_json::from_str(&call_result_str)
-            .map_err(|err| color_eyre::Report::msg(format!("serde json: {:?}", err)))?;
+
+        let serde_call_result: serde_json::Value = if call_result.is_empty() {
+            serde_json::Value::Null
+        } else {
+            serde_json::from_slice(&call_result)
+                .map_err(|err| color_eyre::Report::msg(format!("serde json: {:?}", err)))?
+        };
         println!("--------------");
         println!();
         println!("{}", serde_json::to_string_pretty(&serde_call_result)?);


### PR DESCRIPTION
To resolve https://github.com/near/near-cli-rs/issues/104, I vote for defaulting to `null` when the server returns an empty byte array for a view function call.

Note: This doesn't change the behavior for functions that return results.

### Before (function with empty result)

```console
Your console command:
./near-cli execute view-method network testnet contract hello_sat.testnet call hello {} at-final-block
Error:
   0: serde json: Error("EOF while parsing a value", line: 1, column: 0)

Location:
   src/commands/execute_command/view_method/block_id/mod.rs:101
```

### Now (function with empty result)
```console

--------------

null
Your console command:
target/debug/near-cli execute view-method network testnet contract hello_sat.testnet call hello {} at-final-block
```