### PR TITLE
[Proposal] Design proposal to extend import-account command to import by seed-phrase or private-key

### DIFF
--- a/docs/NEW_NEAR_CLI_INTERFACE.md
+++ b/docs/NEW_NEAR_CLI_INTERFACE.md
@@ -41,6 +41,17 @@ account
         - transaction signature options here (see below)
     - fund-later <initial-balance>  (implicit account creation)
 
+  - import-account (a.k.a "log in" / "sign in")
+    - from-web-wallet
+      - save-access-key-to-macos-keychain network <"mainnet"|"testnet">
+      - save-access-key-to-keychain network <"mainnet"|"testnet">
+    - from-seed-phrase <seed-phrase> --hd-path "m/44'/397'/0'"
+      - save-access-key-to-macos-keychain network <"mainnet"|"testnet">
+      - save-access-key-to-keychain network <"mainnet"|"testnet">
+    - from-private-key <private-key>
+      - save-access-key-to-macos-keychain network <"mainnet"|"testnet">
+      - save-access-key-to-keychain network <"mainnet"|"testnet">
+
   - delete-account <account-id> beneficiary <beneficiary-account-id> network <"mainnet"|"testnet"|...>
     - transaction signature options here (see below)
 
@@ -59,9 +70,6 @@ account
         - transaction signature options here (see below)
     - grant-function-call-access --receiver-account-id <account-id> --method-names 'comma,separated,list' --allowance '0.25NEAR'
       - (use the same follow-up parameters as for `grant-full-access`)
-
-  - import-account (a.k.a "log in" / "sign in")
-    - network <"mainnet"|"testnet">
 
   - delete-key <account-id> <public-key> network <"mainnet"|"testnet"|...>
     - transaction signature options here (see below)


### PR DESCRIPTION
Currently, there are basically four ways to "add accounts":

* Import it from the web wallet
* Create a named account by sending a transaction signed by some existing account
* Create a new implicit account (and later fund it from somewhere else)
* Manually add a new file to `~/.near-credentials/*/` keychain

While it is not required to add an account before signing a transaction since we allow signing transactions with a plain-text private key (and I will create a new proposal to enable signing by providing a seed phrase), it is far more convenient and secure if one uses macOS keychain to access the account than pasting seed-phrase or private key over and over again (not to mention that it is not convenient to do).

All these import-account commands will need to have the account id, but if we want to streamline the process, we want to get it from the user at the very end or (better) derive it, e.g. web-wallet can redirect to localhost:xxxx (as it is implemented in near-cli-js) and when we know the seed-phrase/private-key we can derive public-key and search the blockchain for the corresponding account ids (as web wallet does). The downside of this is that it requires to have access to the Internet and specifically, to some additional Wallet APIs.