### PR TITLE
[Proposal] Extend the list of transaction singing options to be able to use access-key file or plain-text seed-phrase

### DIFF
--- a/docs/NEW_NEAR_CLI_INTERFACE.md
+++ b/docs/NEW_NEAR_CLI_INTERFACE.md
@@ -145,8 +145,11 @@ local-keys
 ```
 
 Transaction signature options:
+  * `sign-with-macos-keychain`
   * `sign-with-keychain`
   * `sign-with-ledger`
+  * `sign-with-access-key-file <path.json>`
+  * `sign-with-seed-phrase <seed-phrase> --hd-path "m/44'/397'/0'"`
   * `sign-with-plaintext-private-key "ed25519:..."`
 
 ### Top-level `Core NEAR CLI` flags


### PR DESCRIPTION
Currently, we allow using a plain-text private key, but there are occasions where it would be handy to use seed-phrase (usually these are one-off operations and #138 should address other use-cases where an account needs to be used regularly)

P.S. `macos-keychain` is already supported, so I just reflected that in this doc