### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/near/near-cli-rs/compare/v0.3.0...v0.3.1) - 2023-04-06
+
+### Other
+- Use custom GITHUB_TOKEN to be able to trigger follow up CI jobs
+- make a git tag with Release-plz, so it triggers binary release pipeline (#170)
+
 ## [0.3.0] - 2023-04-06
 
 * Renamed `near-cli` binary to `near` as it has special handlers for the commands of near CLI JS, and can be used as a replacement to near CLI JS that will guide users on how to use the new commands when they type the old commands.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1583,7 +1583,7 @@ dependencies = [
 
 [[package]]
 name = "near-cli-rs"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "base64 0.13.1",
  "bip39",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-cli-rs"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["FroVolod <frol_off@meta.ua>", "Near Inc <hello@nearprotocol.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `near-cli-rs`: 0.3.0 -> 0.3.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.1](https://github.com/near/near-cli-rs/compare/v0.3.0...v0.3.1) - 2023-04-06

### Other
- Use custom GITHUB_TOKEN to be able to trigger follow up CI jobs
- make a git tag with Release-plz, so it triggers binary release pipeline (#170)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).