### PR TITLE
chore: update release-plz-action to v0.5

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -24,9 +24,7 @@ jobs:
         if: runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install --assume-yes libudev-dev
       - name: Run release-plz
-        uses: MarcoIeni/release-plz-action@v0.4
-        with:
-          git_release: false
+        uses: MarcoIeni/release-plz-action@v0.5
         env:
           # https://marcoieni.github.io/release-plz/github-action.html#triggering-further-workflow-runs
           GITHUB_TOKEN: ${{ secrets.CUSTOM_GITHUB_TOKEN }}

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,2 @@
+[workspace]
+git_release_enable = false


### PR DESCRIPTION
The latest release of release-plz removes the `git_release` github action argument.
I disabled github releases with the config file 👍 