### PR TITLE
fixed issue call function with file args shows wrong log

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -738,17 +738,19 @@ pub fn print_unsigned_transaction(transaction: &crate::commands::PrepopulatedTra
                     "{:>18} {:<13} {}",
                     "",
                     "args:",
-                    serde_json::to_string_pretty(
-                        &serde_json::from_slice::<serde_json::Value>(&function_call_action.args)
-                            .unwrap_or_else(|_| {
-                                serde_json::Value::String(format!(
-                                    "<non-printable data ({} bytes)>",
-                                    function_call_action.args.len()
-                                ))
-                            }),
-                    )
-                    .unwrap_or_else(|_| "".to_string())
-                    .replace('\n', "\n                                 ")
+                    match serde_json::from_slice::<serde_json::Value>(&function_call_action.args) {
+                        Ok(parsed_args) => {
+                            serde_json::to_string_pretty(&parsed_args)
+                                .unwrap_or_else(|_| "".to_string())
+                                .replace('\n', "\n                                 ")
+                        }
+                        Err(_) => {
+                            format!(
+                                "<non-printable data ({})>",
+                                bytesize::ByteSize(function_call_action.args.len() as u64)
+                            )
+                        }
+                    }
                 );
                 eprintln!(
                     "{:>18} {:<13} {}",

--- a/src/common.rs
+++ b/src/common.rs
@@ -740,7 +740,12 @@ pub fn print_unsigned_transaction(transaction: &crate::commands::PrepopulatedTra
                     "args:",
                     serde_json::to_string_pretty(
                         &serde_json::from_slice::<serde_json::Value>(&function_call_action.args)
-                            .unwrap_or_default()
+                            .unwrap_or_else(|_| {
+                                serde_json::Value::String(format!(
+                                    "<non-printable data ({} bytes)>",
+                                    function_call_action.args.len()
+                                ))
+                            }),
                     )
                     .unwrap_or_else(|_| "".to_string())
                     .replace('\n', "\n                                 ")


### PR DESCRIPTION
This PR resolves https://github.com/near/near-cli-rs/issues/186 by replacing the default unwrap function with a logical alternative and adding a formatted error message for better clarity.