### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/near/near-cli-rs/compare/v0.3.5...v0.4.0) - 2023-05-02
+
+### Added
+- Meta-Transactions support (#189)
+- Support for adding key from Ledger hardware wallet (#188)
+
+### Fixed
+- fixed call function with non-JSON arguments being incorrectly displayed as `null` (#187)
+- pass right token to release-plz action (#185)
+
 ## [0.3.5](https://github.com/near/near-cli-rs/compare/v0.3.4...v0.3.5) - 2023-04-21
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1845,7 +1845,7 @@ dependencies = [
 
 [[package]]
 name = "near-cli-rs"
-version = "0.3.5"
+version = "0.4.0"
 dependencies = [
  "base64 0.13.1",
  "bip39",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-cli-rs"
-version = "0.3.5"
+version = "0.4.0"
 authors = ["FroVolod <frol_off@meta.ua>", "Near Inc <hello@nearprotocol.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `near-cli-rs`: 0.3.5 -> 0.4.0 (⚠️ API breaking changes)

### ⚠️ `near-cli-rs` breaking changes

```
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-check/tree/v0.20.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field CliSignPrivateKey.meta_transaction_valid_for in /tmp/.tmpdLarD7/near-cli-rs/src/transaction_signature_options/sign_with_private_key/mod.rs:6
  field NetworkConfig.meta_transaction_relayer_url in /tmp/.tmpdLarD7/near-cli-rs/src/config.rs:17
  field InteractiveClapContextScopeForSignPrivateKey.meta_transaction_valid_for in /tmp/.tmpdLarD7/near-cli-rs/src/transaction_signature_options/sign_with_private_key/mod.rs:6
  field CliSignKeychain.meta_transaction_valid_for in /tmp/.tmpdLarD7/near-cli-rs/src/transaction_signature_options/sign_with_keychain/mod.rs:8
  field InteractiveClapContextScopeForSignSeedPhrase.nonce in /tmp/.tmpdLarD7/near-cli-rs/src/transaction_signature_options/sign_with_seed_phrase/mod.rs:8
  field InteractiveClapContextScopeForSignSeedPhrase.block_hash in /tmp/.tmpdLarD7/near-cli-rs/src/transaction_signature_options/sign_with_seed_phrase/mod.rs:8
  field InteractiveClapContextScopeForSignSeedPhrase.meta_transaction_valid_for in /tmp/.tmpdLarD7/near-cli-rs/src/transaction_signature_options/sign_with_seed_phrase/mod.rs:8
  field CliSignAccessKeyFile.nonce in /tmp/.tmpdLarD7/near-cli-rs/src/transaction_signature_options/sign_with_access_key_file/mod.rs:6
  field CliSignAccessKeyFile.block_hash in /tmp/.tmpdLarD7/near-cli-rs/src/transaction_signature_options/sign_with_access_key_file/mod.rs:6
  field CliSignAccessKeyFile.meta_transaction_valid_for in /tmp/.tmpdLarD7/near-cli-rs/src/transaction_signature_options/sign_with_access_key_file/mod.rs:6
  field InteractiveClapContextScopeForSignAccessKeyFile.nonce in /tmp/.tmpdLarD7/near-cli-rs/src/transaction_signature_options/sign_with_access_key_file/mod.rs:6
  field InteractiveClapContextScopeForSignAccessKeyFile.block_hash in /tmp/.tmpdLarD7/near-cli-rs/src/transaction_signature_options/sign_with_access_key_file/mod.rs:6
  field InteractiveClapContextScopeForSignAccessKeyFile.meta_transaction_valid_for in /tmp/.tmpdLarD7/near-cli-rs/src/transaction_signature_options/sign_with_access_key_file/mod.rs:6
  field SubmitContext.signed_transaction_or_signed_delegate_action in /tmp/.tmpdLarD7/near-cli-rs/src/transaction_signature_options/mod.rs:296
  field CliSignSeedPhrase.nonce in /tmp/.tmpdLarD7/near-cli-rs/src/transaction_signature_options/sign_with_seed_phrase/mod.rs:8
  field CliSignSeedPhrase.block_hash in /tmp/.tmpdLarD7/near-cli-rs/src/transaction_signature_options/sign_with_seed_phrase/mod.rs:8
  field CliSignSeedPhrase.meta_transaction_valid_for in /tmp/.tmpdLarD7/near-cli-rs/src/transaction_signature_options/sign_with_seed_phrase/mod.rs:8
  field InteractiveClapContextScopeForSignKeychain.meta_transaction_valid_for in /tmp/.tmpdLarD7/near-cli-rs/src/transaction_signature_options/sign_with_keychain/mod.rs:8

--- failure constructible_struct_adds_private_field: struct no longer constructible due to new private field ---

Description:
A struct constructible with a struct literal has a new non-public field. It can no longer be constructed using a struct literal outside of its crate.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-check/tree/v0.20.0/src/lints/constructible_struct_adds_private_field.ron

Failed in:
  field SignPrivateKey.meta_transaction_valid_for in /tmp/.tmpdLarD7/near-cli-rs/src/transaction_signature_options/sign_with_private_key/mod.rs:25

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-check/tree/v0.20.0/src/lints/inherent_method_missing.ron

Failed in:
  SignKeychain::input_nonce, previously in file /tmp/.tmpu0wj42/near-cli-rs/src/transaction_signature_options/sign_with_keychain/mod.rs:234
  SignKeychain::input_block_hash, previously in file /tmp/.tmpu0wj42/near-cli-rs/src/transaction_signature_options/sign_with_keychain/mod.rs:240
  SignPrivateKey::input_nonce, previously in file /tmp/.tmpu0wj42/near-cli-rs/src/transaction_signature_options/sign_with_private_key/mod.rs:188
  SignPrivateKey::input_block_hash, previously in file /tmp/.tmpu0wj42/near-cli-rs/src/transaction_signature_options/sign_with_private_key/mod.rs:194

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-check/tree/v0.20.0/src/lints/struct_missing.ron

Failed in:
  struct near_cli_rs::types::signed_transaction::SignedTransaction, previously in file /tmp/.tmpu0wj42/near-cli-rs/src/types/signed_transaction.rs:2
  struct near_cli_rs::common::SignedTransactionAsBase64, previously in file /tmp/.tmpu0wj42/near-cli-rs/src/common.rs:43

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-check/tree/v0.20.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field signed_transaction of struct SubmitContext, previously in file /tmp/.tmpu0wj42/near-cli-rs/src/transaction_signature_options/mod.rs:241
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.0](https://github.com/near/near-cli-rs/compare/v0.3.5...v0.4.0) - 2023-05-02

### Added
- Meta-Transactions support (#189)
- Support for adding key from Ledger hardware wallet (#188)

### Fixed
- fixed call function with non-JSON arguments being incorrectly displayed as `null` (#187)
- pass right token to release-plz action (#185)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).