### PR TITLE
feat: multi public-key for account delete-key command

### DIFF
--- a/src/commands/account/delete_key/mod.rs
+++ b/src/commands/account/delete_key/mod.rs
@@ -26,20 +26,20 @@ impl DeleteKeyCommandContext {
         Ok(Self {
             config: previous_context.0,
             owner_account_id: scope.owner_account_id.clone().into(),
-            public_keys: scope.public_keys.clone().0,
+            public_keys: scope.public_keys.clone().into(),
         })
     }
 }
 
 impl From<DeleteKeyCommandContext> for crate::commands::ActionContext {
     fn from(item: DeleteKeyCommandContext) -> Self {
-        let public_keys = item.public_keys.clone();
         let on_after_getting_network_callback: crate::commands::OnAfterGettingNetworkCallback =
             std::sync::Arc::new(move |_network_config| {
                 Ok(crate::commands::PrepopulatedTransaction {
                     signer_id: item.owner_account_id.clone(),
                     receiver_id: item.owner_account_id.clone(),
-                    actions: public_keys
+                    actions: item
+                        .public_keys
                         .clone()
                         .into_iter()
                         .map(|public_key| {

--- a/src/commands/account/delete_key/mod.rs
+++ b/src/commands/account/delete_key/mod.rs
@@ -6,8 +6,6 @@ mod use_publickeylist_type;
 pub struct DeleteKeyCommand {
     /// Which account should you delete the access key for?
     owner_account_id: crate::types::account_id::AccountId,
-    #[interactive_clap(long)]
-    #[interactive_clap(skip_default_from_cli_arg)]
     /// Enter the public keys you wish to delete (separated by comma):
     public_keys: self::use_publickeylist_type::PublicKeyList,
     #[interactive_clap(named_arg)]
@@ -34,8 +32,7 @@ impl DeleteKeyCommandContext {
                 .public_keys
                 .clone()
                 .0
-                .iter()
-                .cloned()
+                .into_iter()
                 .map(Into::into)
                 .collect(),
         })

--- a/src/commands/account/delete_key/use_publickeylist_type/mod.rs
+++ b/src/commands/account/delete_key/use_publickeylist_type/mod.rs
@@ -1,0 +1,32 @@
+use interactive_clap::ToCli;
+
+#[derive(Debug, Clone)]
+pub struct PublicKeyList(pub Vec<crate::types::public_key::PublicKey>);
+impl std::fmt::Display for PublicKeyList {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let keys: Vec<String> = self.0.iter().map(|key| key.to_string()).collect();
+        write!(f, "{}", keys.join(","))
+    }
+}
+
+impl std::str::FromStr for PublicKeyList {
+    type Err = color_eyre::eyre::ErrReport;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let keys: Vec<crate::types::public_key::PublicKey> = s
+            .split(',')
+            .map(|str| str.trim().parse())
+            .collect::<Result<Vec<crate::types::public_key::PublicKey>, _>>()?;
+        Ok(Self(keys))
+    }
+}
+
+impl From<PublicKeyList> for Vec<crate::types::public_key::PublicKey> {
+    fn from(item: PublicKeyList) -> Self {
+        item.0
+    }
+}
+
+impl ToCli for PublicKeyList {
+    type CliVariant = PublicKeyList;
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -4,6 +4,7 @@ pub mod crypto_hash;
 pub mod json;
 pub mod path_buf;
 pub mod public_key;
+pub mod public_key_list;
 pub mod secret_key;
 pub mod signature;
 pub mod signed_delegate_action;

--- a/src/types/public_key_list.rs
+++ b/src/types/public_key_list.rs
@@ -1,7 +1,7 @@
 use interactive_clap::ToCli;
 
 #[derive(Debug, Clone)]
-pub struct PublicKeyList(pub Vec<crate::types::public_key::PublicKey>);
+pub struct PublicKeyList(pub Vec<near_crypto::PublicKey>);
 impl std::fmt::Display for PublicKeyList {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         let keys: Vec<String> = self.0.iter().map(|key| key.to_string()).collect();
@@ -13,15 +13,15 @@ impl std::str::FromStr for PublicKeyList {
     type Err = color_eyre::eyre::ErrReport;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let keys: Vec<crate::types::public_key::PublicKey> = s
+        let keys: Vec<near_crypto::PublicKey> = s
             .split(',')
             .map(|str| str.trim().parse())
-            .collect::<Result<Vec<crate::types::public_key::PublicKey>, _>>()?;
+            .collect::<Result<Vec<near_crypto::PublicKey>, _>>()?;
         Ok(Self(keys))
     }
 }
 
-impl From<PublicKeyList> for Vec<crate::types::public_key::PublicKey> {
+impl From<PublicKeyList> for Vec<near_crypto::PublicKey> {
     fn from(item: PublicKeyList) -> Self {
         item.0
     }

--- a/src/types/public_key_list.rs
+++ b/src/types/public_key_list.rs
@@ -1,7 +1,8 @@
 use interactive_clap::ToCli;
 
 #[derive(Debug, Clone)]
-pub struct PublicKeyList(pub Vec<near_crypto::PublicKey>);
+pub struct PublicKeyList(Vec<near_crypto::PublicKey>);
+
 impl std::fmt::Display for PublicKeyList {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         let keys: Vec<String> = self.0.iter().map(|key| key.to_string()).collect();


### PR DESCRIPTION
Fixes : #205 
multi public-key for account delete-key command separated  by `,` .