### PR TITLE
chore: release v0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3](https://github.com/near/near-cli-rs/compare/v0.4.2...v0.4.3) - 2023-06-02
+
+### Added
+- New command to send a signed transaction [potentially constructed offline] ([#206](https://github.com/near/near-cli-rs/pull/206))
+- Extended access-key deletion with an option to delete multiple keys in a single transaction ([#207](https://github.com/near/near-cli-rs/pull/207))
+
+### Other
+- Updated dependencies to the most recent versions
+
 ## [0.4.2](https://github.com/near/near-cli-rs/compare/v0.4.1...v0.4.2) - 2023-05-26
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1773,7 +1773,7 @@ dependencies = [
 
 [[package]]
 name = "near-cli-rs"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "bip39",
  "bs58 0.5.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-cli-rs"
-version = "0.4.2"
+version = "0.4.3"
 authors = ["FroVolod <frol_off@meta.ua>", "Near Inc <hello@nearprotocol.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `near-cli-rs`: 0.4.2 -> 0.4.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.3](https://github.com/near/near-cli-rs/compare/v0.4.2...v0.4.3) - 2023-06-02

### Added
- New command to send a signed transaction [potentially constructed offline] ([#206](https://github.com/near/near-cli-rs/pull/206))
- Extended access-key deletion with an option to delete multiple keys in a single transaction ([#207](https://github.com/near/near-cli-rs/pull/207))

### Other
- Updated dependencies to the most recent versions
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).