### PR TITLE
chore: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/near/near-cli-rs/compare/v0.4.3...v0.5.0) - 2023-06-05
+
+### Added
+- New offline mode allows to prepare transactions on devices that are not connected to the Internet ([#209](https://github.com/near/near-cli-rs/pull/209))
+
+### Fixed
+- Add support for no-args view-function calls for legacy JS CLI `view` command ([#213](https://github.com/near/near-cli-rs/pull/213))
+
 ## [0.4.3](https://github.com/near/near-cli-rs/compare/v0.4.2...v0.4.3) - 2023-06-02
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1773,7 +1773,7 @@ dependencies = [
 
 [[package]]
 name = "near-cli-rs"
-version = "0.4.3"
+version = "0.5.0"
 dependencies = [
  "bip39",
  "bs58 0.5.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-cli-rs"
-version = "0.4.3"
+version = "0.5.0"
 authors = ["FroVolod <frol_off@meta.ua>", "Near Inc <hello@nearprotocol.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `near-cli-rs`: 0.4.3 -> 0.5.0 (⚠️ API breaking changes)

### ⚠️ `near-cli-rs` breaking changes

```
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-check/tree/v0.20.1/src/lints/constructible_struct_adds_field.ron

Failed in:
  field CliSignKeychain.signer_public_key in /tmp/.tmp5tj8Mk/near-cli-rs/src/transaction_signature_options/sign_with_keychain/mod.rs:11
  field CliSignKeychain.block_height in /tmp/.tmp5tj8Mk/near-cli-rs/src/transaction_signature_options/sign_with_keychain/mod.rs:11
  field CliSignPrivateKey.block_height in /tmp/.tmp5tj8Mk/near-cli-rs/src/transaction_signature_options/sign_with_private_key/mod.rs:7
  field TransactionContext.global_context in /tmp/.tmp5tj8Mk/near-cli-rs/src/commands/mod.rs:78
  field InteractiveClapContextScopeForSignSeedPhrase.block_height in /tmp/.tmp5tj8Mk/near-cli-rs/src/transaction_signature_options/sign_with_seed_phrase/mod.rs:9
  field SubmitContext.global_context in /tmp/.tmp5tj8Mk/near-cli-rs/src/transaction_signature_options/mod.rs:302
  field InteractiveClapContextScopeForSignAccessKeyFile.block_height in /tmp/.tmp5tj8Mk/near-cli-rs/src/transaction_signature_options/sign_with_access_key_file/mod.rs:7
  field CliSignAccessKeyFile.block_height in /tmp/.tmp5tj8Mk/near-cli-rs/src/transaction_signature_options/sign_with_access_key_file/mod.rs:7
  field InteractiveClapContextScopeForSignPrivateKey.block_height in /tmp/.tmp5tj8Mk/near-cli-rs/src/transaction_signature_options/sign_with_private_key/mod.rs:7
  field CliSignSeedPhrase.block_height in /tmp/.tmp5tj8Mk/near-cli-rs/src/transaction_signature_options/sign_with_seed_phrase/mod.rs:9
  field ContractContext.global_context in /tmp/.tmp5tj8Mk/near-cli-rs/src/commands/account/storage_management/mod.rs:19
  field ActionContext.global_context in /tmp/.tmp5tj8Mk/near-cli-rs/src/commands/mod.rs:67
  field InteractiveClapContextScopeForSignKeychain.signer_public_key in /tmp/.tmp5tj8Mk/near-cli-rs/src/transaction_signature_options/sign_with_keychain/mod.rs:11
  field InteractiveClapContextScopeForSignKeychain.block_height in /tmp/.tmp5tj8Mk/near-cli-rs/src/transaction_signature_options/sign_with_keychain/mod.rs:11

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-check/tree/v0.20.1/src/lints/enum_variant_added.ron

Failed in:
  variant SignWith:SignLater in /tmp/.tmp5tj8Mk/near-cli-rs/src/transaction_signature_options/mod.rs:59
  variant SignWithDiscriminants:SignLater in /tmp/.tmp5tj8Mk/near-cli-rs/src/transaction_signature_options/mod.rs:59
  variant SignWithDiscriminants:SignLater in /tmp/.tmp5tj8Mk/near-cli-rs/src/transaction_signature_options/mod.rs:59
  variant CliSignWith:SignLater in /tmp/.tmp5tj8Mk/near-cli-rs/src/transaction_signature_options/mod.rs:18

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-check/tree/v0.20.1/src/lints/inherent_method_missing.ron

Failed in:
  SignLedger::input_nonce, previously in file /tmp/.tmp9KOdC6/near-cli-rs/src/transaction_signature_options/sign_with_ledger/mod.rs:241
  SignLedger::input_block_hash, previously in file /tmp/.tmp9KOdC6/near-cli-rs/src/transaction_signature_options/sign_with_ledger/mod.rs:247

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-check/tree/v0.20.1/src/lints/struct_missing.ron

Failed in:
  struct near_cli_rs::types::transaction::Transaction, previously in file /tmp/.tmp9KOdC6/near-cli-rs/src/types/transaction.rs:2
  struct near_cli_rs::common::TransactionAsBase64, previously in file /tmp/.tmp9KOdC6/near-cli-rs/src/common.rs:43

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-check/tree/v0.20.1/src/lints/struct_pub_field_missing.ron

Failed in:
  field config of struct ActionContext, previously in file /tmp/.tmp9KOdC6/near-cli-rs/src/commands/mod.rs:67
  field config of struct ContractContext, previously in file /tmp/.tmp9KOdC6/near-cli-rs/src/commands/account/storage_management/mod.rs:19
  field config of struct TransactionContext, previously in file /tmp/.tmp9KOdC6/near-cli-rs/src/commands/mod.rs:78
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.0](https://github.com/near/near-cli-rs/compare/v0.4.3...v0.5.0) - 2023-06-05

### Added
- New offline mode allows to prepare transactions on devices that are not connected to the Internet ([#209](https://github.com/near/near-cli-rs/pull/209))

### Fixed
- Add support for no-args view-function calls for legacy JS CLI `view` command ([#213](https://github.com/near/near-cli-rs/pull/213))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).