### PR TITLE
chore: release v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/near/near-cli-rs/compare/v0.5.0...v0.5.1) - 2023-06-07
+
+### Added
+- New `transaction sign-transaction` command [useful in combination with `... sign-later` and `transaction send-signed-transaction` commands] ([#215](https://github.com/near/near-cli-rs/pull/215))
+
+### Other
+- Upgraded NEAR crates to 0.17.0 release ([#216](https://github.com/near/near-cli-rs/pull/216))
+
 ## [0.5.0](https://github.com/near/near-cli-rs/compare/v0.4.3...v0.5.0) - 2023-06-05
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1779,7 +1779,7 @@ dependencies = [
 
 [[package]]
 name = "near-cli-rs"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "bip39",
  "bs58 0.5.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-cli-rs"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["FroVolod <frol_off@meta.ua>", "Near Inc <hello@nearprotocol.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `near-cli-rs`: 0.5.0 -> 0.5.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.1](https://github.com/near/near-cli-rs/compare/v0.5.0...v0.5.1) - 2023-06-07

### Added
- New `transaction sign-transaction` command [useful in combination with `... sign-later` and `transaction send-signed-transaction` commands] ([#215](https://github.com/near/near-cli-rs/pull/215))

### Other
- Upgraded NEAR crates to 0.17.0 release ([#216](https://github.com/near/near-cli-rs/pull/216))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).