### PR TITLE
chore: release v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.2](https://github.com/near/near-cli-rs/compare/v0.5.1...v0.5.2) - 2023-08-17
+
+### Added
+- Select your account when prompted interactively ([#224](https://github.com/near/near-cli-rs/pull/224))
+- Allow to specify a custom Web Wallet URL when importing account (default to MyNearWallet) ([#218](https://github.com/near/near-cli-rs/pull/218))
+
+### Other
+- Upgrade cargo-dist to 0.1.0 release ([#229](https://github.com/near/near-cli-rs/pull/229))
+
 ## [0.5.1](https://github.com/near/near-cli-rs/compare/v0.5.0...v0.5.1) - 2023-06-07
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1779,7 +1779,7 @@ dependencies = [
 
 [[package]]
 name = "near-cli-rs"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "bip39",
  "bs58 0.5.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-cli-rs"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["FroVolod <frol_off@meta.ua>", "Near Inc <hello@nearprotocol.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `near-cli-rs`: 0.5.1 -> 0.6.0 (⚠️ API breaking changes)

### ⚠️ `near-cli-rs` breaking changes

```
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-check/tree/v0.22.1/src/lints/constructible_struct_adds_field.ron

Failed in:
  field CliNetwork.wallet_url in /tmp/.tmpPJTc3v/near-cli-rs/src/network/mod.rs:1
  field InteractiveClapContextScopeForNetwork.wallet_url in /tmp/.tmpPJTc3v/near-cli-rs/src/network/mod.rs:1
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.6.0](https://github.com/near/near-cli-rs/compare/v0.5.1...v0.6.0) - 2023-08-17

### Added
- Select your account when prompted interactively ([#224](https://github.com/near/near-cli-rs/pull/224))
- Allow to specify a custom Web Wallet URL when importing account (default to MyNearWallet) ([#218](https://github.com/near/near-cli-rs/pull/218))

### Other
- Upgrade cargo-dist to 0.1.0 release ([#229](https://github.com/near/near-cli-rs/pull/229))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).