### PR TITLE
chore: release v0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/near/near-cli-rs/compare/v0.6.0...v0.7.0) - 2023-10-09
+
+### Added
+- Added a new command to manage BOS profile in SocialDB ([#231](https://github.com/near/near-cli-rs/pull/231))
+- Provide a relevant faucet error message when helper API server returns an error ([#243](https://github.com/near/near-cli-rs/pull/243))
+
+### Other
+- Exposed sponsor_by_faucet_service module to re-use in "cargo-near" ([#246](https://github.com/near/near-cli-rs/pull/246))
+
 ## [0.6.0](https://github.com/near/near-cli-rs/compare/v0.5.2...v0.6.0) - 2023-09-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.7.0](https://github.com/near/near-cli-rs/compare/v0.6.0...v0.7.0) - 2023-10-09
+## [0.6.1](https://github.com/near/near-cli-rs/compare/v0.6.0...v0.6.1) - 2023-10-09
 
 ### Added
 - Added a new command to manage BOS profile in SocialDB ([#231](https://github.com/near/near-cli-rs/pull/231))

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2133,7 +2133,7 @@ dependencies = [
 
 [[package]]
 name = "near-cli-rs"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "bip39",
  "bs58 0.5.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2133,7 +2133,7 @@ dependencies = [
 
 [[package]]
 name = "near-cli-rs"
-version = "0.7.0"
+version = "0.6.1"
 dependencies = [
  "bip39",
  "bs58 0.5.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-cli-rs"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["FroVolod <frol_off@meta.ua>", "Near Inc <hello@nearprotocol.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-cli-rs"
-version = "0.7.0"
+version = "0.6.1"
 authors = ["FroVolod <frol_off@meta.ua>", "Near Inc <hello@nearprotocol.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `near-cli-rs`: 0.6.0 -> 0.6.1 (⚠️ API breaking changes)

### ⚠️ `near-cli-rs` breaking changes

```
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.23.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field NetworkConfig.near_social_db_contract_account_id in /tmp/.tmpwia7Cy/near-cli-rs/src/config.rs:20

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.23.0/src/lints/enum_variant_added.ron

Failed in:
  variant AccountActionsDiscriminants:UpdateSocialProfile in /tmp/.tmpwia7Cy/near-cli-rs/src/commands/account/mod.rs:49
  variant AccountActionsDiscriminants:UpdateSocialProfile in /tmp/.tmpwia7Cy/near-cli-rs/src/commands/account/mod.rs:49
  variant CliAccountActions:UpdateSocialProfile in /tmp/.tmpwia7Cy/near-cli-rs/src/commands/account/mod.rs:23

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.23.0/src/lints/function_parameter_count_changed.ron

Failed in:
  near_cli_rs::common::display_account_info now takes 6 parameters instead of 5, in /tmp/.tmpwia7Cy/near-cli-rs/src/common.rs:1279

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.23.0/src/lints/struct_missing.ron

Failed in:
  struct near_cli_rs::common::NearBalance, previously in file /tmp/.tmpjO2Ejv/near-cli-rs/src/common.rs:74
  struct near_cli_rs::common::StorageBalance, previously in file /tmp/.tmpjO2Ejv/near-cli-rs/src/common.rs:1627

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.23.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field inner of struct Base64Bytes, previously in file /tmp/.tmpjO2Ejv/near-cli-rs/src/types/base64_bytes.rs:3

--- failure tuple_struct_to_plain_struct: tuple struct changed to plain struct ---

Description:
A publicly-visible, exhaustive tuple struct with pub fields changed to normal (curly-braces) struct, which cannot be constructed using the same struct literal syntax.
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.23.0/src/lints/tuple_struct_to_plain_struct.ron

Failed in:
  struct Json in /tmp/.tmpwia7Cy/near-cli-rs/src/types/json.rs:5
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.7.0](https://github.com/near/near-cli-rs/compare/v0.6.0...v0.7.0) - 2023-10-09

### Added
- Added a new command to manage BOS profile in SocialDB ([#231](https://github.com/near/near-cli-rs/pull/231))
- Provide a relevant faucet error message when helper API server returns an error ([#243](https://github.com/near/near-cli-rs/pull/243))

### Other
- Exposed sponsor_by_faucet_service module to re-use in "cargo-near" ([#246](https://github.com/near/near-cli-rs/pull/246))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).