### PR TITLE
chore: release v0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.2](https://github.com/near/near-cli-rs/compare/v0.6.1...v0.6.2) - 2023-10-17
+
+### Added
+- Exposed some of the functions to use "manage-profile" in bos-cli-rs ([#249](https://github.com/near/near-cli-rs/pull/249))
+- Exposed subcommands related to "deploy" to reuse in cargo-near ([#247](https://github.com/near/near-cli-rs/pull/247))
+
 ## [0.6.1](https://github.com/near/near-cli-rs/compare/v0.6.0...v0.6.1) - 2023-10-09
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2195,7 +2195,7 @@ dependencies = [
 
 [[package]]
 name = "near-cli-rs"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "bip39",
  "bs58 0.5.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-cli-rs"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["FroVolod <frol_off@meta.ua>", "Near Inc <hello@nearprotocol.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `near-cli-rs`: 0.6.1 -> 0.6.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.6.2](https://github.com/near/near-cli-rs/compare/v0.6.1...v0.6.2) - 2023-10-17

### Added
- Exposed some of the functions to use "manage-profile" in bos-cli-rs ([#249](https://github.com/near/near-cli-rs/pull/249))
- Exposed subcommands related to "deploy" to reuse in cargo-near ([#247](https://github.com/near/near-cli-rs/pull/247))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).