### PR TITLE
chore: release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/near/near-cli-rs/compare/v0.6.2...v0.7.0) - 2023-10-31
+
+### Added
+- New command: staking - delegation ([#227](https://github.com/near/near-cli-rs/pull/227))
+
+### Other
+- Refactored NEAR tokens usages to use a strictly typed near-token crate ([#253](https://github.com/near/near-cli-rs/pull/253))
+
 ## [0.6.2](https://github.com/near/near-cli-rs/compare/v0.6.1...v0.6.2) - 2023-10-17
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2162,7 +2162,7 @@ dependencies = [
 
 [[package]]
 name = "near-cli-rs"
-version = "0.6.2"
+version = "0.7.0"
 dependencies = [
  "bip39",
  "bs58 0.5.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-cli-rs"
-version = "0.6.2"
+version = "0.7.0"
 authors = ["FroVolod <frol_off@meta.ua>", "Near Inc <hello@nearprotocol.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `near-cli-rs`: 0.6.2 -> 0.7.0 (⚠️ API breaking changes)

### ⚠️ `near-cli-rs` breaking changes

```
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.24.2/src/lints/enum_variant_added.ron

Failed in:
  variant TopLevelCommandDiscriminants:Staking in /tmp/.tmpLUH3fF/near-cli-rs/src/commands/mod.rs:33
  variant TopLevelCommandDiscriminants:Staking in /tmp/.tmpLUH3fF/near-cli-rs/src/commands/mod.rs:33
  variant CliTopLevelCommand:Staking in /tmp/.tmpLUH3fF/near-cli-rs/src/commands/mod.rs:14

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.24.2/src/lints/function_parameter_count_changed.ron

Failed in:
  near_cli_rs::common::display_account_info now takes 7 parameters instead of 6, in /tmp/.tmpLUH3fF/near-cli-rs/src/common.rs:1530

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.24.2/src/lints/inherent_method_missing.ron

Failed in:
  TransferAmount::to_yoctonear, previously in file /tmp/.tmpH9VITc/near-cli-rs/src/common.rs:108
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.7.0](https://github.com/near/near-cli-rs/compare/v0.6.2...v0.7.0) - 2023-10-31

### Added
- New command: staking - delegation ([#227](https://github.com/near/near-cli-rs/pull/227))

### Other
- Refactored NEAR tokens usages to use a strictly typed near-token crate ([#253](https://github.com/near/near-cli-rs/pull/253))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).