### PR TITLE
Show hash-to-sign when using the sign_later transaction signature option

### DIFF
--- a/src/transaction_signature_options/sign_later/mod.rs
+++ b/src/transaction_signature_options/sign_later/mod.rs
@@ -34,10 +34,7 @@ impl DisplayContext {
         let hash_and_size_ref = hash_and_size.0.as_ref();
         let hash_to_sign_hex = hex::encode(hash_and_size_ref);
 
-        eprintln!(
-            "\nHash to sign:\n{}\n",
-            hash_to_sign_hex
-        );
+        eprintln!("\nHash to sign:\n{}", hash_to_sign_hex);
 
         eprintln!(
             "\nUnsigned transaction (serialized as base64):\n{}\n",

--- a/src/transaction_signature_options/sign_later/mod.rs
+++ b/src/transaction_signature_options/sign_later/mod.rs
@@ -30,11 +30,10 @@ impl DisplayContext {
             actions: previous_context.prepopulated_transaction.actions,
         };
 
-        let hash_and_size = unsigned_transaction.get_hash_and_size();
-        let hash_and_size_ref = hash_and_size.0.as_ref();
-        let hash_to_sign_hex = hex::encode(hash_and_size_ref);
-
-        eprintln!("\nHash to sign:\n{}", hash_to_sign_hex);
+        eprintln!(
+            "\nTransaction hash to sign:\n{}",
+            hex::encode(unsigned_transaction.get_hash_and_size().0)
+        );
 
         eprintln!(
             "\nUnsigned transaction (serialized as base64):\n{}\n",

--- a/src/transaction_signature_options/sign_later/mod.rs
+++ b/src/transaction_signature_options/sign_later/mod.rs
@@ -30,6 +30,15 @@ impl DisplayContext {
             actions: previous_context.prepopulated_transaction.actions,
         };
 
+        let hash_and_size = unsigned_transaction.get_hash_and_size();
+        let hash_and_size_ref = hash_and_size.0.as_ref();
+        let hash_to_sign_hex = hex::encode(hash_and_size_ref);
+
+        eprintln!(
+            "\nHash to sign:\n{}\n",
+            hash_to_sign_hex
+        );
+
         eprintln!(
             "\nUnsigned transaction (serialized as base64):\n{}\n",
             crate::types::transaction::TransactionAsBase64::from(unsigned_transaction)


### PR DESCRIPTION
In delegated signing contexts it is useful to see the SHA256 hash of the unsigned transaction when using the `sign-later` transaction signature option.