### PR TITLE
chore: release v0.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.3](https://github.com/near/near-cli-rs/compare/v0.7.2...v0.7.3) - 2023-12-02
+
+### Added
+- Added support for blind signing with Ledger [requires updated Ledger app that is not yet published] ([#259](https://github.com/near/near-cli-rs/pull/259))
+- New command to reconstruct NEAR CLI command from a historical transaction ([#266](https://github.com/near/near-cli-rs/pull/266))
+
+### Other
+- Addressed all default cargo clippy warnings ([#263](https://github.com/near/near-cli-rs/pull/263))
+
 ## [0.7.2](https://github.com/near/near-cli-rs/compare/v0.7.1...v0.7.2) - 2023-11-21
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2162,7 +2162,7 @@ dependencies = [
 
 [[package]]
 name = "near-cli-rs"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "bip39",
  "bs58 0.5.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-cli-rs"
-version = "0.7.2"
+version = "0.7.3"
 authors = ["FroVolod <frol_off@meta.ua>", "Near Inc <hello@nearprotocol.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `near-cli-rs`: 0.7.2 -> 0.7.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.7.3](https://github.com/near/near-cli-rs/compare/v0.7.2...v0.7.3) - 2023-12-02

### Added
- Added support for blind signing with Ledger [requires updated Ledger app that is not yet published] ([#259](https://github.com/near/near-cli-rs/pull/259))
- New command to reconstruct NEAR CLI command from a historical transaction ([#266](https://github.com/near/near-cli-rs/pull/266))

### Other
- Addressed all default cargo clippy warnings ([#263](https://github.com/near/near-cli-rs/pull/263))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).