### PR TITLE
chore: release v0.7.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.4](https://github.com/near/near-cli-rs/compare/v0.7.3...v0.7.4) - 2023-12-06
+
+### Added
+- Removed the need for an additional network selection step if there is only one network connection in the config file ([#272](https://github.com/near/near-cli-rs/pull/272))
+- Added the ability to interactively select access keys to remove from the list of public keys ([#269](https://github.com/near/near-cli-rs/pull/269))
+
+### Other
+- Cleaned up duplicative CI checks and renamed 'master' to 'main' default branch
+- Automate publishing near-cli-rs to npmjs for `npx near-cli-rs` to use the latest released binary release by default ([#273](https://github.com/near/near-cli-rs/pull/273))
+
 ## [0.7.3](https://github.com/near/near-cli-rs/compare/v0.7.2...v0.7.3) - 2023-12-02
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2162,7 +2162,7 @@ dependencies = [
 
 [[package]]
 name = "near-cli-rs"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "bip39",
  "bs58 0.5.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-cli-rs"
-version = "0.7.3"
+version = "0.7.4"
 authors = ["FroVolod <frol_off@meta.ua>", "Near Inc <hello@nearprotocol.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `near-cli-rs`: 0.7.3 -> 0.7.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.7.4](https://github.com/near/near-cli-rs/compare/v0.7.3...v0.7.4) - 2023-12-06

### Added
- Removed the need for an additional network selection step if there is only one network connection in the config file ([#272](https://github.com/near/near-cli-rs/pull/272))
- Added the ability to interactively select access keys to remove from the list of public keys ([#269](https://github.com/near/near-cli-rs/pull/269))

### Other
- Cleaned up duplicative CI checks and renamed 'master' to 'main' default branch
- Automate publishing near-cli-rs to npmjs for `npx near-cli-rs` to use the latest released binary release by default ([#273](https://github.com/near/near-cli-rs/pull/273))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).