### PR TITLE
chore: release v0.7.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.5](https://github.com/near/near-cli-rs/compare/v0.7.4...v0.7.5) - 2023-12-19
+
+### Added
+- Improved self-update UX with more details ([#274](https://github.com/near/near-cli-rs/pull/274))
+
+### Fixed
+- Display NEAR token amounts precisely ([#278](https://github.com/near/near-cli-rs/pull/278))
+
+### Other
+- Updated the guide around the usage of system keychain on Linux, Windows, and macOS ([#277](https://github.com/near/near-cli-rs/pull/277))
+- Added explicit installation instructions to README.md
+
 ## [0.7.4](https://github.com/near/near-cli-rs/compare/v0.7.3...v0.7.4) - 2023-12-06
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2162,7 +2162,7 @@ dependencies = [
 
 [[package]]
 name = "near-cli-rs"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "bip39",
  "bs58 0.5.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-cli-rs"
-version = "0.7.4"
+version = "0.7.5"
 authors = ["FroVolod <frol_off@meta.ua>", "Near Inc <hello@nearprotocol.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `near-cli-rs`: 0.7.4 -> 0.7.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.7.5](https://github.com/near/near-cli-rs/compare/v0.7.4...v0.7.5) - 2023-12-19

### Added
- Improved self-update UX with more details ([#274](https://github.com/near/near-cli-rs/pull/274))

### Fixed
- Display NEAR token amounts precisely ([#278](https://github.com/near/near-cli-rs/pull/278))

### Other
- Updated the guide around the usage of system keychain on Linux, Windows, and macOS ([#277](https://github.com/near/near-cli-rs/pull/277))
- Added explicit installation instructions to README.md
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).