### PR TITLE
chore: release v0.7.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.6](https://github.com/near/near-cli-rs/compare/v0.7.5...v0.7.6) - 2023-12-21
+
+### Other
+- Removed excessive step during transaction status view to improve UX ([#280](https://github.com/near/near-cli-rs/pull/280))
+- Updated reconstruct-transaction command ([#281](https://github.com/near/near-cli-rs/pull/281))
+
 ## [0.7.5](https://github.com/near/near-cli-rs/compare/v0.7.4...v0.7.5) - 2023-12-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2162,7 +2162,7 @@ dependencies = [
 
 [[package]]
 name = "near-cli-rs"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "bip39",
  "bs58 0.5.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-cli-rs"
-version = "0.7.5"
+version = "0.7.6"
 authors = ["FroVolod <frol_off@meta.ua>", "Near Inc <hello@nearprotocol.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `near-cli-rs`: 0.7.5 -> 0.7.6 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.7.6](https://github.com/near/near-cli-rs/compare/v0.7.5...v0.7.6) - 2023-12-21

### Other
- Removed excessive step during transaction status view to improve UX ([#280](https://github.com/near/near-cli-rs/pull/280))
- Updated reconstruct-transaction command ([#281](https://github.com/near/near-cli-rs/pull/281))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).