### PR TITLE
chore: release v0.7.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.7](https://github.com/near/near-cli-rs/compare/v0.7.6...v0.7.7) - 2024-01-19
+
+### Added
+- Updated dialog for entering arguments to a function (as-read-only) ([#285](https://github.com/near/near-cli-rs/pull/285))
+
+### Other
+- Updated binary releases pipeline to use cargo-dist v0.7.2 (previously v0.3.0) ([#289](https://github.com/near/near-cli-rs/pull/289))
+- Avoid unnecessary "interactive_clap::FromCli" implementations ([#288](https://github.com/near/near-cli-rs/pull/288))
+
 ## [0.7.6](https://github.com/near/near-cli-rs/compare/v0.7.5...v0.7.6) - 2023-12-21
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2162,7 +2162,7 @@ dependencies = [
 
 [[package]]
 name = "near-cli-rs"
-version = "0.7.6"
+version = "0.7.7"
 dependencies = [
  "bip39",
  "bs58 0.5.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-cli-rs"
-version = "0.7.6"
+version = "0.7.7"
 authors = ["FroVolod <frol_off@meta.ua>", "Near Inc <hello@nearprotocol.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `near-cli-rs`: 0.7.6 -> 0.7.7 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.7.7](https://github.com/near/near-cli-rs/compare/v0.7.6...v0.7.7) - 2024-01-19

### Added
- Updated dialog for entering arguments to a function (as-read-only) ([#285](https://github.com/near/near-cli-rs/pull/285))

### Other
- Updated binary releases pipeline to use cargo-dist v0.7.2 (previously v0.3.0) ([#289](https://github.com/near/near-cli-rs/pull/289))
- Avoid unnecessary "interactive_clap::FromCli" implementations ([#288](https://github.com/near/near-cli-rs/pull/288))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).