### PR TITLE
chore: release v0.7.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.8](https://github.com/near/near-cli-rs/compare/v0.7.7...v0.7.8) - 2024-02-03
+
+### Other
+- Updated binary releases pipeline to use cargo-dist v0.9.0 (previously v0.7.2) ([#294](https://github.com/near/near-cli-rs/pull/294))
+- Updated send-ft command ([#283](https://github.com/near/near-cli-rs/pull/283))
+
 ## [0.7.7](https://github.com/near/near-cli-rs/compare/v0.7.6...v0.7.7) - 2024-01-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2158,7 +2158,7 @@ dependencies = [
 
 [[package]]
 name = "near-cli-rs"
-version = "0.7.7"
+version = "0.7.8"
 dependencies = [
  "bip39",
  "bs58 0.5.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-cli-rs"
-version = "0.7.7"
+version = "0.7.8"
 authors = ["FroVolod <frol_off@meta.ua>", "Near Inc <hello@nearprotocol.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `near-cli-rs`: 0.7.7 -> 0.7.8 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.7.8](https://github.com/near/near-cli-rs/compare/v0.7.7...v0.7.8) - 2024-02-03

### Other
- Updated binary releases pipeline to use cargo-dist v0.9.0 (previously v0.7.2) ([#294](https://github.com/near/near-cli-rs/pull/294))
- Updated send-ft command ([#283](https://github.com/near/near-cli-rs/pull/283))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).