### PR TITLE
chore: release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/near/near-cli-rs/compare/v0.7.8...v0.8.0) - 2024-02-19
+
+### Added
+- Added `inspect` and `download-abi` commands for contracts! ([#293](https://github.com/near/near-cli-rs/pull/293))
+
+### Fixed
+- Fixed incorrect serialization in staking delegation commands that required to input amounts ([#300](https://github.com/near/near-cli-rs/pull/300))
+- Fixed a syntax error in CI (publish-to-npm.yml)
+
 ## [0.7.8](https://github.com/near/near-cli-rs/compare/v0.7.7...v0.7.8) - 2024-02-03
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2277,7 +2277,7 @@ dependencies = [
 
 [[package]]
 name = "near-cli-rs"
-version = "0.7.8"
+version = "0.8.0"
 dependencies = [
  "bip39",
  "bs58 0.5.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-cli-rs"
-version = "0.7.8"
+version = "0.8.0"
 authors = ["FroVolod <frol_off@meta.ua>", "Near Inc <hello@nearprotocol.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `near-cli-rs`: 0.7.8 -> 0.8.0 (⚠️ API breaking changes)

### ⚠️ `near-cli-rs` breaking changes

```
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.28.0/src/lints/enum_variant_added.ron

Failed in:
  variant ContractActionsDiscriminants:Inspect in /tmp/.tmpCcWnr1/near-cli-rs/src/commands/contract/mod.rs:35
  variant ContractActionsDiscriminants:DownloadAbi in /tmp/.tmpCcWnr1/near-cli-rs/src/commands/contract/mod.rs:38
  variant ContractActionsDiscriminants:Inspect in /tmp/.tmpCcWnr1/near-cli-rs/src/commands/contract/mod.rs:35
  variant ContractActionsDiscriminants:DownloadAbi in /tmp/.tmpCcWnr1/near-cli-rs/src/commands/contract/mod.rs:38
  variant CliContractActions:Inspect in /tmp/.tmpCcWnr1/near-cli-rs/src/commands/contract/mod.rs:17
  variant CliContractActions:DownloadAbi in /tmp/.tmpCcWnr1/near-cli-rs/src/commands/contract/mod.rs:17
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.8.0](https://github.com/near/near-cli-rs/compare/v0.7.8...v0.8.0) - 2024-02-19

### Added
- Added `inspect` and `download-abi` commands for contracts! ([#293](https://github.com/near/near-cli-rs/pull/293))

### Fixed
- Fixed incorrect serialization in staking delegation commands that required to input amounts ([#300](https://github.com/near/near-cli-rs/pull/300))
- Fixed a syntax error in CI (publish-to-npm.yml)
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).