### PR TITLE
chore: release v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1](https://github.com/near/near-cli-rs/compare/v0.8.0...v0.8.1) - 2024-02-26
+
+### Fixed
+- Added support for viewing account summary on networks without NEAR Social contract ([#302](https://github.com/near/near-cli-rs/pull/302))
+
+### Other
+- Improved formatting of the Install section in the README
+
 ## [0.8.0](https://github.com/near/near-cli-rs/compare/v0.7.8...v0.8.0) - 2024-02-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2277,7 +2277,7 @@ dependencies = [
 
 [[package]]
 name = "near-cli-rs"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "bip39",
  "bs58 0.5.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-cli-rs"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["FroVolod <frol_off@meta.ua>", "Near Inc <hello@nearprotocol.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `near-cli-rs`: 0.8.0 -> 0.8.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.8.1](https://github.com/near/near-cli-rs/compare/v0.8.0...v0.8.1) - 2024-02-26

### Fixed
- Added support for viewing account summary on networks without NEAR Social contract ([#302](https://github.com/near/near-cli-rs/pull/302))

### Other
- Improved formatting of the Install section in the README
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).