### PR TITLE
chore: update `near-ledger` to `0.5.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2443,9 +2443,9 @@ dependencies = [
 
 [[package]]
 name = "near-ledger"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7706ef5fdfc979957a58c240f7bd6e7d969550310888a3d5b18267b73d50a51"
+checksum = "a8849fda5ad5da9774d313f5d28247260ff48ae89a57f281c8e65c32b64d6c99"
 dependencies = [
  "ed25519-dalek 1.0.1",
  "hex 0.4.3",
@@ -2453,6 +2453,7 @@ dependencies = [
  "ledger-transport",
  "ledger-transport-hid",
  "log",
+ "near-primitives",
  "near-primitives-core",
  "slip10",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,7 +66,7 @@ bytesize = "1.1.0"
 prettytable = "0.10.0"
 textwrap = "0.16.1"
 
-near-ledger = { version = "0.4.0", optional = true }
+near-ledger = { version = "0.5.0", optional = true }
 
 near-crypto = "0.20.1"
 near-primitives = "0.20.1"

--- a/src/common.rs
+++ b/src/common.rs
@@ -563,8 +563,13 @@ pub fn print_unsigned_transaction(transaction: &crate::commands::PrepopulatedTra
                     "--", "create account:", &transaction.receiver_id
                 )
             }
-            near_primitives::transaction::Action::DeployContract(_) => {
-                eprintln!("{:>5} {:<20}", "--", "deploy contract")
+            near_primitives::transaction::Action::DeployContract(code) => {
+                let code_hash = CryptoHash::hash_bytes(&code.code);
+                eprintln!(
+                    "{:>5} {:<70}",
+                    "--",
+                    format!("deploy contract {:?}", code_hash)
+                )
             }
             near_primitives::transaction::Action::FunctionCall(function_call_action) => {
                 eprintln!("{:>5} {:<20}", "--", "function call:");


### PR DESCRIPTION
- [x] check out and build old version of near-cli-rs ([revision](https://github.com/near/near-cli-rs/tree/0f484b5053f12f3baba66cda5a82252bee916913) before [blind signature pull](https://github.com/near/near-cli-rs/pull/259) )
  - [x] near 0.7.2
    - [x] test a normal tx on `app-near`: ok https://explorer.near.org/transactions/HSE5jFuKvrDYeaxEqd445PwVsahcYgXV6kZQQY5uDsj2
    - [x] test a long tx  on `app-near`: error 
        ```bash
        `near` CLI has a new update available 0.7.2 →  0.8.1
        To update `near` CLI use: near extensions self-update
        Error:
           0: Error occurred while signing the transaction: APDUExchangeError("Unknown Ledger APDU retcode: 27024")

        ❯ pcalc 27024
                27024                   0x6990                  0y110100110010000

        ❯ rg 0x6990
        workdir/app-near/src/constants.h
        37:#define SW_BUFFER_OVERFLOW 0x6990
        ```
    - [x] test a long tx on `app-near-rs`: ok https://nearblocks.io/txns/5yzwbUckGSWMyYj8hbG3jJjHWLef5atkzc2fiVrf8Loy 
- [x] current pr near 0.8.1
  - [x] test a normal tx on `app-near`: ok https://nearblocks.io/txns/5Ptbx3iGykXKQpxYBhR9YUa5BCmS6jGjyLiE7oGYGXKN 
  - [x] test a long tx on `app-near` : error
      ```bash
      Error:
         0: Error occurred while signing the transaction: APDUExchangeError("Ledger APDU retcode: 0x6990")
      ```
  - [x] test a long tx on `app-near-rs`: ok https://nearblocks.io/txns/2duat1ripdAxtHJjuNyNT7ZNd6adADs8LGMZ6VsV9FDm 
  - [x] test a deploy contract tx 
    - [x] on `app-near-rs`: ok https://nearblocks.io/txns/GV6Y9TcTMhqBUoYL6M6BxkeCXXkEe8TfmLJCVx64U7ME#
      ```bash
      Unsigned transaction:
      signer_id:    1b11b3b31673033936ad07bddc01f9da27d974811e480fb197c799e23480a489
      receiver_id:  1b11b3b31673033936ad07bddc01f9da27d974811e480fb197c799e23480a489
      actions:
         -- deploy contract DC1KnvBEyPhBzBxCBarMgY9ZN68krg449Dk8AxARU2QN
      ...
      ```
      - [x] https://nearblocks.io/address/1b11b3b31673033936ad07bddc01f9da27d974811e480fb197c799e23480a489#contract
    - [x] on `app-near`: error, same behaviour as long tx  (12288 bytes)
      ```bytes
      12288   ./examples/adder/res/adder.wasm
      ```
