### PR TITLE
chore: release v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1](https://github.com/near/near-cli-rs/compare/v0.9.0...v0.9.1) - 2024-04-25
+
+### Added
+- Added loading indicators for waiting for responses from RPC ([#315](https://github.com/near/near-cli-rs/pull/315))
+
 ## [0.9.0](https://github.com/near/near-cli-rs/compare/v0.8.1...v0.9.0) - 2024-04-22
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2303,7 +2303,7 @@ dependencies = [
 
 [[package]]
 name = "near-cli-rs"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "bip39",
  "bs58 0.5.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-cli-rs"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["FroVolod <frol_off@meta.ua>", "Near Inc <hello@nearprotocol.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `near-cli-rs`: 0.9.0 -> 0.9.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.9.1](https://github.com/near/near-cli-rs/compare/v0.9.0...v0.9.1) - 2024-04-25

### Added
- Added loading indicators for waiting for responses from RPC ([#315](https://github.com/near/near-cli-rs/pull/315))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).