### PR TITLE
feat: improved fetching staking pools

### DIFF
--- a/src/commands/account/view_account_summary/mod.rs
+++ b/src/commands/account/view_account_summary/mod.rs
@@ -23,6 +23,8 @@ impl ViewAccountSummaryContext {
         previous_context: crate::GlobalContext,
         scope: &<ViewAccountSummary as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
     ) -> color_eyre::eyre::Result<Self> {
+        let stake_delegators_api = previous_context.config.stake_delegators_api.clone();
+
         let on_after_getting_block_reference_callback: crate::network_view_at_block::OnAfterGettingBlockReferenceCallback = std::sync::Arc::new({
             let account_id: near_primitives::types::AccountId = scope.account_id.clone().into();
 
@@ -54,7 +56,7 @@ impl ViewAccountSummaryContext {
                     })?
                     .access_key_list_view()?;
 
-                let validators = match crate::common::fetch_validators_api(&account_id) {
+                let validators = match crate::common::fetch_validators_api(&account_id, stake_delegators_api.clone()) {
                     Ok(api_validators) => api_validators,
                     Err(_) => crate::common::fetch_validators_rpc(&json_rpc_client)?,
                 };

--- a/src/commands/account/view_account_summary/mod.rs
+++ b/src/commands/account/view_account_summary/mod.rs
@@ -54,7 +54,7 @@ impl ViewAccountSummaryContext {
                     })?
                     .access_key_list_view()?;
 
-                let validators = match crate::common::fetch_validators_api(&account_id, network_config.stake_delegators_api.clone()) {
+                let validators = match crate::common::fetch_validators_api(&account_id, network_config.fastnear_url.clone()) {
                     Ok(api_validators) => api_validators,
                     Err(_) => crate::common::fetch_validators_rpc(&json_rpc_client, network_config.staking_pools_factory_account_id.clone())?,
                 };

--- a/src/commands/account/view_account_summary/mod.rs
+++ b/src/commands/account/view_account_summary/mod.rs
@@ -23,8 +23,6 @@ impl ViewAccountSummaryContext {
         previous_context: crate::GlobalContext,
         scope: &<ViewAccountSummary as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
     ) -> color_eyre::eyre::Result<Self> {
-        let stake_delegators_api = previous_context.config.stake_delegators_api.clone();
-
         let on_after_getting_block_reference_callback: crate::network_view_at_block::OnAfterGettingBlockReferenceCallback = std::sync::Arc::new({
             let account_id: near_primitives::types::AccountId = scope.account_id.clone().into();
 
@@ -56,9 +54,9 @@ impl ViewAccountSummaryContext {
                     })?
                     .access_key_list_view()?;
 
-                let validators = match crate::common::fetch_validators_api(&account_id, stake_delegators_api.clone()) {
+                let validators = match crate::common::fetch_validators_api(&account_id, network_config.stake_delegators_api.clone()) {
                     Ok(api_validators) => api_validators,
-                    Err(_) => crate::common::fetch_validators_rpc(&json_rpc_client)?,
+                    Err(_) => crate::common::fetch_validators_rpc(&json_rpc_client, network_config.staking_pools_factory_account_id.clone())?,
                 };
 
                 let runtime = tokio::runtime::Builder::new_multi_thread()

--- a/src/commands/account/view_account_summary/mod.rs
+++ b/src/commands/account/view_account_summary/mod.rs
@@ -54,7 +54,10 @@ impl ViewAccountSummaryContext {
                     })?
                     .access_key_list_view()?;
 
-                let validators_stake = crate::common::get_validators_stake(&json_rpc_client)?;
+                let validators = match crate::common::fetch_validators_api(&account_id) {
+                    Ok(api_validators) => api_validators,
+                    Err(_) => crate::common::fetch_validators_rpc(&json_rpc_client)?,
+                };
 
                 let runtime = tokio::runtime::Builder::new_multi_thread()
                     .enable_all()
@@ -62,7 +65,7 @@ impl ViewAccountSummaryContext {
                 let concurrency = 10;
                 let delegated_stake: std::collections::BTreeMap<near_primitives::types::AccountId, near_token::NearToken> = runtime
                     .block_on(
-                        futures::stream::iter(validators_stake.into_keys())
+                        futures::stream::iter(validators)
                         .map(|validator_account_id| async {
                             let balance = get_delegated_staked_balance(&json_rpc_client, block_reference, &validator_account_id, &account_id).await?;
                             Ok::<_, color_eyre::eyre::Report>((

--- a/src/commands/config/add_connection/mod.rs
+++ b/src/commands/config/add_connection/mod.rs
@@ -34,6 +34,11 @@ pub struct AddNetworkConnection {
     #[interactive_clap(long)]
     #[interactive_clap(skip_default_input_arg)]
     meta_transaction_relayer_url: Option<crate::types::url::Url>,
+    #[interactive_clap(long)]
+    #[interactive_clap(skip_default_input_arg)]
+    stake_delegators_api: Option<String>,
+    #[interactive_clap(long)]
+    staking_pools_factory_account_id: crate::types::account_id::AccountId,
 }
 
 #[derive(Debug, Clone)]
@@ -68,6 +73,11 @@ impl AddNetworkConnectionContext {
                     .meta_transaction_relayer_url
                     .clone()
                     .map(|meta_transaction_relayer_url| meta_transaction_relayer_url.into()),
+                stake_delegators_api: scope.stake_delegators_api.clone(),
+                staking_pools_factory_account_id: scope
+                    .staking_pools_factory_account_id
+                    .clone()
+                    .into(),
             },
         );
         eprintln!();
@@ -205,6 +215,31 @@ impl AddNetworkConnection {
             let meta_transaction_relayer_url: crate::types::url::Url =
                 CustomType::new("What is the relayer url?").prompt()?;
             Ok(Some(meta_transaction_relayer_url))
+        } else {
+            Ok(None)
+        }
+    }
+
+    fn input_stake_delegators_api(
+        _context: &crate::GlobalContext,
+    ) -> color_eyre::eyre::Result<Option<String>> {
+        eprintln!();
+        #[derive(strum_macros::Display)]
+        enum ConfirmOptions {
+            #[strum(to_string = "Yes, I want to enter the stake delegators API")]
+            Yes,
+            #[strum(to_string = "No, I don't want to enter the stake delegators API")]
+            No,
+        }
+        let select_choose_input = Select::new(
+            "Do you want to enter the stake delegators API?",
+            vec![ConfirmOptions::Yes, ConfirmOptions::No],
+        )
+        .prompt()?;
+        if let ConfirmOptions::Yes = select_choose_input {
+            let stake_delegators_api: String =
+                CustomType::new("What is the stake delegators API?").prompt()?;
+            Ok(Some(stake_delegators_api))
         } else {
             Ok(None)
         }

--- a/src/commands/config/add_connection/mod.rs
+++ b/src/commands/config/add_connection/mod.rs
@@ -36,7 +36,7 @@ pub struct AddNetworkConnection {
     meta_transaction_relayer_url: Option<crate::types::url::Url>,
     #[interactive_clap(long)]
     #[interactive_clap(skip_default_input_arg)]
-    stake_delegators_api: Option<String>,
+    fastnear_url: Option<String>,
     #[interactive_clap(long)]
     staking_pools_factory_account_id: crate::types::account_id::AccountId,
 }
@@ -73,7 +73,7 @@ impl AddNetworkConnectionContext {
                     .meta_transaction_relayer_url
                     .clone()
                     .map(|meta_transaction_relayer_url| meta_transaction_relayer_url.into()),
-                stake_delegators_api: scope.stake_delegators_api.clone(),
+                fastnear_url: scope.fastnear_url.clone(),
                 staking_pools_factory_account_id: scope
                     .staking_pools_factory_account_id
                     .clone()
@@ -220,25 +220,25 @@ impl AddNetworkConnection {
         }
     }
 
-    fn input_stake_delegators_api(
+    fn input_fastnear_url(
         _context: &crate::GlobalContext,
     ) -> color_eyre::eyre::Result<Option<String>> {
         eprintln!();
         #[derive(strum_macros::Display)]
         enum ConfirmOptions {
-            #[strum(to_string = "Yes, I want to enter the stake delegators API")]
+            #[strum(to_string = "Yes, I want to enter the fastnear API url")]
             Yes,
-            #[strum(to_string = "No, I don't want to enter the stake delegators API")]
+            #[strum(to_string = "No, I don't want to enter the fastnear API url")]
             No,
         }
         let select_choose_input = Select::new(
-            "Do you want to enter the stake delegators API?",
+            "Do you want to enter the fastnear API url?",
             vec![ConfirmOptions::Yes, ConfirmOptions::No],
         )
         .prompt()?;
         if let ConfirmOptions::Yes = select_choose_input {
             let stake_delegators_api: String =
-                CustomType::new("What is the stake delegators API?").prompt()?;
+                CustomType::new("What is the fastnear API url?").prompt()?;
             Ok(Some(stake_delegators_api))
         } else {
             Ok(None)

--- a/src/common.rs
+++ b/src/common.rs
@@ -1502,8 +1502,9 @@ struct StakingResponse {
 
 pub fn fetch_validators_api(
     account_id: &near_primitives::types::AccountId,
+    stake_delegators_api: String,
 ) -> color_eyre::Result<std::collections::BTreeSet<near_primitives::types::AccountId>> {
-    let url = format!("https://api.fastnear.com/v1/account/{}/staking", account_id);
+    let url = stake_delegators_api.replace("{account_id}", account_id.as_ref());
 
     let request = reqwest::blocking::get(url)?;
     let response: StakingResponse = request.json()?;

--- a/src/common.rs
+++ b/src/common.rs
@@ -1502,15 +1502,15 @@ struct StakingResponse {
 
 pub fn fetch_validators_api(
     account_id: &near_primitives::types::AccountId,
-    stake_delegators_api: Option<String>,
+    fastnear_url: Option<String>,
 ) -> color_eyre::Result<std::collections::BTreeSet<near_primitives::types::AccountId>> {
-    let Some(stake_delegators_api) = stake_delegators_api else {
+    let Some(fastnear_url) = fastnear_url else {
         return Err(color_eyre::Report::msg(
             "Stake delegators API is not set for selected network",
         ));
     };
 
-    let url = stake_delegators_api.replace("{account_id}", account_id.as_ref());
+    let url = format!("{fastnear_url}/v1/account/{account_id}/staking");
 
     let request = reqwest::blocking::get(url)?;
     let response: StakingResponse = request.json()?;

--- a/src/common.rs
+++ b/src/common.rs
@@ -1527,7 +1527,7 @@ pub fn fetch_validators_rpc(
                 include_proof: false,
             },
         })
-        .context("Failed to fetch query ViewState for <poolv1.near> on network <beta-rpc>")?;
+        .context("Failed to fetch query ViewState for <poolv1.near> on the selected network")?;
     if let near_jsonrpc_primitives::types::query::QueryResponseKind::ViewState(result) =
         query_view_method_response.kind
     {

--- a/src/config.rs
+++ b/src/config.rs
@@ -29,9 +29,7 @@ impl Default for Config {
                 near_social_db_contract_account_id: Some("social.near".parse().unwrap()),
                 faucet_url: None,
                 meta_transaction_relayer_url: None,
-                stake_delegators_api: Some(String::from(
-                    "https://api.fastnear.com/v1/account/{account_id}/staking",
-                )),
+                fastnear_url: Some(String::from("https://api.fastnear.com")),
                 staking_pools_factory_account_id: "poolv1.near".parse().unwrap(),
             },
         );
@@ -49,7 +47,7 @@ impl Default for Config {
                 near_social_db_contract_account_id: Some("v1.social08.testnet".parse().unwrap()),
                 faucet_url: Some("https://helper.nearprotocol.com/account".parse().unwrap()),
                 meta_transaction_relayer_url: None,
-                stake_delegators_api: None,
+                fastnear_url: None,
                 staking_pools_factory_account_id: "pool.f863973.m0".parse().unwrap(),
             },
         );
@@ -83,7 +81,7 @@ pub struct NetworkConfig {
     pub near_social_db_contract_account_id: Option<near_primitives::types::AccountId>,
     pub faucet_url: Option<url::Url>,
     pub meta_transaction_relayer_url: Option<url::Url>,
-    pub stake_delegators_api: Option<String>,
+    pub fastnear_url: Option<String>,
     pub staking_pools_factory_account_id: near_primitives::types::AccountId,
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,7 @@ use tracing_indicatif::span_ext::IndicatifSpanExt;
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Config {
     pub credentials_home_dir: std::path::PathBuf,
+    pub stake_delegators_api: String,
     pub network_connection: linked_hash_map::LinkedHashMap<String, NetworkConfig>,
 }
 
@@ -13,6 +14,9 @@ impl Default for Config {
         let home_dir = dirs::home_dir().expect("Impossible to get your home dir!");
         let mut credentials_home_dir = std::path::PathBuf::from(&home_dir);
         credentials_home_dir.push(".near-credentials");
+
+        let stake_delegators_api =
+            String::from("https://api.fastnear.com/v1/account/{account_id}/staking");
 
         let mut network_connection = linked_hash_map::LinkedHashMap::new();
         network_connection.insert(
@@ -49,6 +53,7 @@ impl Default for Config {
         );
         Self {
             credentials_home_dir,
+            stake_delegators_api,
             network_connection,
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,7 +5,6 @@ use tracing_indicatif::span_ext::IndicatifSpanExt;
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Config {
     pub credentials_home_dir: std::path::PathBuf,
-    pub stake_delegators_api: String,
     pub network_connection: linked_hash_map::LinkedHashMap<String, NetworkConfig>,
 }
 
@@ -14,9 +13,6 @@ impl Default for Config {
         let home_dir = dirs::home_dir().expect("Impossible to get your home dir!");
         let mut credentials_home_dir = std::path::PathBuf::from(&home_dir);
         credentials_home_dir.push(".near-credentials");
-
-        let stake_delegators_api =
-            String::from("https://api.fastnear.com/v1/account/{account_id}/staking");
 
         let mut network_connection = linked_hash_map::LinkedHashMap::new();
         network_connection.insert(
@@ -33,6 +29,10 @@ impl Default for Config {
                 near_social_db_contract_account_id: Some("social.near".parse().unwrap()),
                 faucet_url: None,
                 meta_transaction_relayer_url: None,
+                stake_delegators_api: Some(String::from(
+                    "https://api.fastnear.com/v1/account/{account_id}/staking",
+                )),
+                staking_pools_factory_account_id: "poolv1.near".parse().unwrap(),
             },
         );
         network_connection.insert(
@@ -49,11 +49,13 @@ impl Default for Config {
                 near_social_db_contract_account_id: Some("v1.social08.testnet".parse().unwrap()),
                 faucet_url: Some("https://helper.nearprotocol.com/account".parse().unwrap()),
                 meta_transaction_relayer_url: None,
+                stake_delegators_api: None,
+                staking_pools_factory_account_id: "pool.f863973.m0".parse().unwrap(),
             },
         );
+
         Self {
             credentials_home_dir,
-            stake_delegators_api,
             network_connection,
         }
     }
@@ -81,6 +83,8 @@ pub struct NetworkConfig {
     pub near_social_db_contract_account_id: Option<near_primitives::types::AccountId>,
     pub faucet_url: Option<url::Url>,
     pub meta_transaction_relayer_url: Option<url::Url>,
+    pub stake_delegators_api: Option<String>,
+    pub staking_pools_factory_account_id: near_primitives::types::AccountId,
 }
 
 impl NetworkConfig {


### PR DESCRIPTION
I've noticed that `view account summary` command was taking too much time. The problems lay in scanning through validators to find if the user’s account id belongs to it. Furthermore, `get_validators_stake` function didn't give all available validators, only +-240 out of 450 were scannable. To fix this, I used fastnear API to retrieve validators in one request, if this process fails, then it will switch to the previous strategy

*before*
![image](https://github.com/near/near-cli-rs/assets/59515280/7d1c063c-8f0f-4d02-8b75-ac775e6fcc26)
*after*
![image](https://github.com/near/near-cli-rs/assets/59515280/89574457-de3a-4bbb-aea1-0663fb929bb8)
  