### PR TITLE
chore: release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0](https://github.com/near/near-cli-rs/compare/v0.9.1...v0.10.0) - 2024-05-03
+
+### Added
+- Added loading indicators to wait for staking properties to be viewed ([#328](https://github.com/near/near-cli-rs/pull/328))
+- improved fetching staking pools ([#325](https://github.com/near/near-cli-rs/pull/325))
+- Added loading indicators for waiting for the transaction to be signed ([#324](https://github.com/near/near-cli-rs/pull/324))
+
+### Fixed
+- Wrong console command for adding Function-Call key with any methods to account ([#329](https://github.com/near/near-cli-rs/pull/329))
+
+### Other
+- Support automatic config version migration ([#331](https://github.com/near/near-cli-rs/pull/331))
+- Updated dependencies ([#332](https://github.com/near/near-cli-rs/pull/332))
+- Refactored the command for adding Function-Call Access key ([#330](https://github.com/near/near-cli-rs/pull/330))
+
 ## [0.9.1](https://github.com/near/near-cli-rs/compare/v0.9.0...v0.9.1) - 2024-04-25
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2319,7 +2319,7 @@ dependencies = [
 
 [[package]]
 name = "near-cli-rs"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "bip39",
  "bs58 0.5.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-cli-rs"
-version = "0.9.1"
+version = "0.10.0"
 authors = ["FroVolod <frol_off@meta.ua>", "Near Inc <hello@nearprotocol.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `near-cli-rs`: 0.9.1 -> 0.10.0 (⚠️ API breaking changes)

### ⚠️ `near-cli-rs` breaking changes

```
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.31.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field NetworkConfig.fastnear_url in /tmp/.tmpU5mqGQ/near-cli-rs/src/config/mod.rs:139
  field NetworkConfig.staking_pools_factory_account_id in /tmp/.tmpU5mqGQ/near-cli-rs/src/config/mod.rs:140

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.31.0/src/lints/function_missing.ron

Failed in:
  function near_cli_rs::common::write_config_toml, previously in file /tmp/.tmpW4FDJ4/near-cli-rs/src/common.rs:1274
  function near_cli_rs::common::get_config_toml, previously in file /tmp/.tmpW4FDJ4/near-cli-rs/src/common.rs:1255
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.10.0](https://github.com/near/near-cli-rs/compare/v0.9.1...v0.10.0) - 2024-05-03

### Added
- Added loading indicators to wait for staking properties to be viewed ([#328](https://github.com/near/near-cli-rs/pull/328))
- improved fetching staking pools ([#325](https://github.com/near/near-cli-rs/pull/325))
- Added loading indicators for waiting for the transaction to be signed ([#324](https://github.com/near/near-cli-rs/pull/324))

### Fixed
- Wrong console command for adding Function-Call key with any methods to account ([#329](https://github.com/near/near-cli-rs/pull/329))

### Other
- Support automatic config version migration ([#331](https://github.com/near/near-cli-rs/pull/331))
- Updated dependencies ([#332](https://github.com/near/near-cli-rs/pull/332))
- Refactored the command for adding Function-Call Access key ([#330](https://github.com/near/near-cli-rs/pull/330))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).