### PR TITLE
chore: release v0.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.2](https://github.com/near/near-cli-rs/compare/v0.10.1...v0.10.2) - 2024-05-21
+
+### Fixed
+- Wrong console command for adding Function-Call key with unlimited allowance ([#342](https://github.com/near/near-cli-rs/pull/342))
+- Fallback to non-auto-suggesting input of the keys to be deleted in interactive mode in offline mode or if there is a connectivity issue ([#338](https://github.com/near/near-cli-rs/pull/338))
+
 ## [0.10.1](https://github.com/near/near-cli-rs/compare/v0.10.0...v0.10.1) - 2024-05-07
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2373,7 +2373,7 @@ dependencies = [
 
 [[package]]
 name = "near-cli-rs"
-version = "0.10.1"
+version = "0.10.2"
 dependencies = [
  "bip39",
  "bs58 0.5.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-cli-rs"
-version = "0.10.1"
+version = "0.10.2"
 authors = ["FroVolod <frol_off@meta.ua>", "Near Inc <hello@nearprotocol.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `near-cli-rs`: 0.10.1 -> 0.10.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.10.2](https://github.com/near/near-cli-rs/compare/v0.10.1...v0.10.2) - 2024-05-21

### Fixed
- Wrong console command for adding Function-Call key with unlimited allowance ([#342](https://github.com/near/near-cli-rs/pull/342))
- Fallback to non-auto-suggesting input of the keys to be deleted in interactive mode in offline mode or if there is a connectivity issue ([#338](https://github.com/near/near-cli-rs/pull/338))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).