### PR TITLE
fix: Wrong console command for adding Function-Call key with unlimited allowance

### DIFF
--- a/src/commands/account/add_key/access_key_type/mod.rs
+++ b/src/commands/account/add_key/access_key_type/mod.rs
@@ -68,7 +68,7 @@ pub struct FunctionCallType {
 pub struct FunctionCallTypeContext {
     global_context: crate::GlobalContext,
     signer_account_id: near_primitives::types::AccountId,
-    allowance: Option<near_token::NearToken>,
+    allowance: Option<crate::types::near_token::NearToken>,
     receiver_account_id: crate::types::account_id::AccountId,
     method_names: crate::types::vec_string::VecString,
 }

--- a/src/commands/account/add_key/access_key_type/mod.rs
+++ b/src/commands/account/add_key/access_key_type/mod.rs
@@ -53,7 +53,7 @@ impl From<FullAccessTypeContext> for AccessTypeContext {
 pub struct FunctionCallType {
     #[interactive_clap(long)]
     #[interactive_clap(skip_default_input_arg)]
-    allowance: crate::types::near_token::NearToken,
+    allowance: crate::types::near_allowance::NearAllowance,
     #[interactive_clap(long)]
     /// Enter a receiver to use by this access key to pay for function call gas and transaction fees:
     receiver_account_id: crate::types::account_id::AccountId,
@@ -68,7 +68,7 @@ pub struct FunctionCallType {
 pub struct FunctionCallTypeContext {
     global_context: crate::GlobalContext,
     signer_account_id: near_primitives::types::AccountId,
-    allowance: Option<crate::types::near_token::NearToken>,
+    allowance: Option<near_token::NearToken>,
     receiver_account_id: crate::types::account_id::AccountId,
     method_names: crate::types::vec_string::VecString,
 }
@@ -81,7 +81,7 @@ impl FunctionCallTypeContext {
         Ok(Self {
             global_context: previous_context.global_context,
             signer_account_id: previous_context.owner_account_id.into(),
-            allowance: Some(scope.allowance),
+            allowance: scope.allowance.optional_near_token(),
             receiver_account_id: scope.receiver_account_id.clone(),
             method_names: scope.method_names.clone(),
         })
@@ -144,10 +144,10 @@ impl FunctionCallType {
 
     pub fn input_allowance(
         _context: &super::AddKeyCommandContext,
-    ) -> color_eyre::eyre::Result<Option<crate::types::near_token::NearToken>> {
-        let allowance_near_balance: crate::types::near_token::NearToken =
+    ) -> color_eyre::eyre::Result<Option<crate::types::near_allowance::NearAllowance>> {
+        let allowance_near_balance: crate::types::near_allowance::NearAllowance =
             CustomType::new("Enter the allowance, a budget this access key can use to pay for transaction fees (example: 10NEAR or 0.5near or 10000yoctonear):")
-                .with_starting_input("0.25 NEAR")
+                .with_starting_input("unlimited")
                 .prompt()?;
         Ok(Some(allowance_near_balance))
     }

--- a/src/js_command_match/add_key.rs
+++ b/src/js_command_match/add_key.rs
@@ -7,8 +7,8 @@ pub struct AddKeyArgs {
     contract_id: Option<String>,
     #[clap(long, aliases = ["method_names", "methodNames"], requires = "contract_id", value_delimiter = ',', num_args = 1..)]
     method_names: Vec<String>,
-    #[clap(long, default_value = "0")]
-    allowance: String,
+    #[clap(long, default_value = None)]
+    allowance: Option<String>,
     #[clap(allow_hyphen_values = true, num_args = 0..)]
     _unknown_args: Vec<String>,
 }
@@ -16,13 +16,18 @@ pub struct AddKeyArgs {
 impl AddKeyArgs {
     pub fn to_cli_args(&self, network_config: String) -> Vec<String> {
         if let Some(contract_id) = self.contract_id.as_deref() {
+            let allowance = if let Some(allowance) = &self.allowance {
+                format!("{} NEAR", allowance)
+            } else {
+                "unlimited".to_string()
+            };
             return vec![
                 "account".to_owned(),
                 "add-key".to_owned(),
                 self.account_id.to_owned(),
                 "grant-function-call-access".to_owned(),
                 "--allowance".to_owned(),
-                format!("{} NEAR", self.allowance),
+                allowance,
                 "--receiver-account-id".to_owned(),
                 contract_id.to_owned(),
                 "--method-names".to_owned(),

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -5,6 +5,7 @@ pub mod crypto_hash;
 pub mod file_bytes;
 pub mod ft_properties;
 pub mod json;
+pub mod near_allowance;
 pub mod near_token;
 pub mod path_buf;
 pub mod public_key;

--- a/src/types/near_allowance.rs
+++ b/src/types/near_allowance.rs
@@ -24,7 +24,7 @@ impl std::fmt::Display for NearAllowance {
 }
 
 impl std::str::FromStr for NearAllowance {
-    type Err = color_eyre::eyre::Report;
+    type Err = near_token::NearTokenError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if s == UNLIMITED {

--- a/src/types/near_allowance.rs
+++ b/src/types/near_allowance.rs
@@ -3,7 +3,6 @@ const UNLIMITED: &str = "unlimited";
 
 #[derive(
     Debug,
-    Default,
     Clone,
     Copy,
     serde::Serialize,

--- a/src/types/near_allowance.rs
+++ b/src/types/near_allowance.rs
@@ -1,0 +1,104 @@
+const ONE_NEAR: u128 = 10u128.pow(24);
+const UNLIMITED: &str = "unlimited";
+
+#[derive(
+    Debug,
+    Default,
+    Clone,
+    Copy,
+    serde::Serialize,
+    serde::Deserialize,
+    derive_more::AsRef,
+    derive_more::From,
+    derive_more::Into,
+)]
+#[as_ref(forward)]
+pub struct NearAllowance(Option<near_token::NearToken>);
+
+impl std::fmt::Display for NearAllowance {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(amount) = self.0 {
+            if amount.as_yoctonear() == 0 {
+                write!(f, "0 NEAR")
+            } else if amount.as_yoctonear() <= 1_000 {
+                write!(f, "{} yoctoNEAR", amount.as_yoctonear())
+            } else if amount.as_yoctonear() % ONE_NEAR == 0 {
+                write!(f, "{} NEAR", amount.as_yoctonear() / ONE_NEAR,)
+            } else {
+                write!(
+                    f,
+                    "{}.{} NEAR",
+                    amount.as_yoctonear() / ONE_NEAR,
+                    format!("{:0>24}", (amount.as_yoctonear() % ONE_NEAR)).trim_end_matches('0')
+                )
+            }
+        } else {
+            write!(f, "{UNLIMITED}")
+        }
+    }
+}
+
+impl std::str::FromStr for NearAllowance {
+    type Err = color_eyre::eyre::Report;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s == UNLIMITED {
+            return Ok(Self(None));
+        }
+        Ok(Self(Some(near_token::NearToken::from_str(s)?)))
+    }
+}
+
+impl NearAllowance {
+    pub fn optional_near_token(&self) -> Option<near_token::NearToken> {
+        self.0
+    }
+}
+
+impl interactive_clap::ToCli for NearAllowance {
+    type CliVariant = NearAllowance;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn near_allowance_to_string_0_near() {
+        assert_eq!(
+            NearAllowance(Some(near_token::NearToken::from_near(0))).to_string(),
+            "0 NEAR".to_string()
+        )
+    }
+    #[test]
+    fn near_allowance_to_string_0_millinear() {
+        assert_eq!(
+            NearAllowance(Some(near_token::NearToken::from_millinear(0))).to_string(),
+            "0 NEAR".to_string()
+        )
+    }
+    #[test]
+    fn near_allowance_to_string_none() {
+        assert_eq!(NearAllowance(None).to_string(), "unlimited".to_string())
+    }
+    #[test]
+    fn near_allowance_to_string_0dot02_near() {
+        assert_eq!(
+            NearAllowance(Some(near_token::NearToken::from_yoctonear(
+                20_000_000_000_000_000_000_000
+            )))
+            .to_string(),
+            "0.02 NEAR".to_string()
+        )
+    }
+    #[test]
+    fn near_allowance_from_str_unlimited() {
+        assert_eq!(
+            NearAllowance::from_str("unlimited")
+                .unwrap_or_default()
+                .optional_near_token(),
+            None
+        )
+    }
+}

--- a/src/types/near_allowance.rs
+++ b/src/types/near_allowance.rs
@@ -18,20 +18,7 @@ pub struct NearAllowance(Option<near_token::NearToken>);
 impl std::fmt::Display for NearAllowance {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if let Some(amount) = self.0 {
-            if amount.as_yoctonear() == 0 {
-                write!(f, "0 NEAR")
-            } else if amount.as_yoctonear() <= 1_000 {
-                write!(f, "{} yoctoNEAR", amount.as_yoctonear())
-            } else if amount.as_yoctonear() % ONE_NEAR == 0 {
-                write!(f, "{} NEAR", amount.as_yoctonear() / ONE_NEAR,)
-            } else {
-                write!(
-                    f,
-                    "{}.{} NEAR",
-                    amount.as_yoctonear() / ONE_NEAR,
-                    format!("{:0>24}", (amount.as_yoctonear() % ONE_NEAR)).trim_end_matches('0')
-                )
-            }
+            amount.fmt(f)
         } else {
             write!(f, "{UNLIMITED}")
         }

--- a/src/types/near_allowance.rs
+++ b/src/types/near_allowance.rs
@@ -1,4 +1,3 @@
-const ONE_NEAR: u128 = 10u128.pow(24);
 const UNLIMITED: &str = "unlimited";
 
 #[derive(
@@ -12,7 +11,7 @@ const UNLIMITED: &str = "unlimited";
     derive_more::Into,
 )]
 #[as_ref(forward)]
-pub struct NearAllowance(Option<near_token::NearToken>);
+pub struct NearAllowance(Option<crate::types::near_token::NearToken>);
 
 impl std::fmt::Display for NearAllowance {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -31,12 +30,14 @@ impl std::str::FromStr for NearAllowance {
         if s == UNLIMITED {
             return Ok(Self(None));
         }
-        Ok(Self(Some(near_token::NearToken::from_str(s)?)))
+        Ok(Self(Some(crate::types::near_token::NearToken::from_str(
+            s,
+        )?)))
     }
 }
 
 impl NearAllowance {
-    pub fn optional_near_token(&self) -> Option<near_token::NearToken> {
+    pub fn optional_near_token(&self) -> Option<crate::types::near_token::NearToken> {
         self.0
     }
 }
@@ -53,14 +54,14 @@ mod tests {
     #[test]
     fn near_allowance_to_string_0_near() {
         assert_eq!(
-            NearAllowance(Some(near_token::NearToken::from_near(0))).to_string(),
+            NearAllowance(Some(near_token::NearToken::from_near(0).into())).to_string(),
             "0 NEAR".to_string()
         )
     }
     #[test]
     fn near_allowance_to_string_0_millinear() {
         assert_eq!(
-            NearAllowance(Some(near_token::NearToken::from_millinear(0))).to_string(),
+            NearAllowance(Some(near_token::NearToken::from_millinear(0).into())).to_string(),
             "0 NEAR".to_string()
         )
     }
@@ -71,9 +72,9 @@ mod tests {
     #[test]
     fn near_allowance_to_string_0dot02_near() {
         assert_eq!(
-            NearAllowance(Some(near_token::NearToken::from_yoctonear(
-                20_000_000_000_000_000_000_000
-            )))
+            NearAllowance(Some(
+                near_token::NearToken::from_yoctonear(20_000_000_000_000_000_000_000).into()
+            ))
             .to_string(),
             "0.02 NEAR".to_string()
         )
@@ -82,7 +83,7 @@ mod tests {
     fn near_allowance_from_str_unlimited() {
         assert_eq!(
             NearAllowance::from_str("unlimited")
-                .unwrap_or_default()
+                .unwrap()
                 .optional_near_token(),
             None
         )

--- a/src/types/near_token.rs
+++ b/src/types/near_token.rs
@@ -5,13 +5,16 @@ const ONE_NEAR: u128 = 10u128.pow(24);
     Default,
     Clone,
     Copy,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
     serde::Serialize,
     serde::Deserialize,
     derive_more::AsRef,
     derive_more::From,
     derive_more::Into,
     derive_more::FromStr,
-    PartialEq,
 )]
 #[as_ref(forward)]
 pub struct NearToken(pub near_token::NearToken);

--- a/src/types/near_token.rs
+++ b/src/types/near_token.rs
@@ -11,6 +11,7 @@ const ONE_NEAR: u128 = 10u128.pow(24);
     derive_more::From,
     derive_more::Into,
     derive_more::FromStr,
+    PartialEq,
 )]
 #[as_ref(forward)]
 pub struct NearToken(pub near_token::NearToken);


### PR DESCRIPTION
Resolves #341 

_near-cli_ (JS) command with "allowance":
```
near add-key example-acct.testnet GkMNfc92fwM1AmwH1MTjF4b7UZuceamsq96XPkHsQ9vi --allowance 30000000000 --contract-id example-contract.testnet --method-names example_method
```
_near-cli-rs_ command:
```
near account add-key example-acct.testnet grant-function-call-access --allowance '30000000000 NEAR' --receiver-account-id example-contract.testnet --method-names example_method use-manually-provided-public-key GkMNfc92fwM1AmwH1MTjF4b7UZuceamsq96XPkHsQ9vi network-config testnet sign-with-keychain send
```

_near-cli_ (JS) command without "allowance":
```
near add-key example-acct.testnet GkMNfc92fwM1AmwH1MTjF4b7UZuceamsq96XPkHsQ9vi --contract-id example-contract.testnet --method-names example_method
```
_near-cli-rs_ command:
```
near account add-key example-acct.testnet grant-function-call-access --allowance unlimited --receiver-account-id example-contract.testnet --method-names example_method use-manually-provided-public-key ed25519:GkMNfc92fwM1AmwH1MTjF4b7UZuceamsq96XPkHsQ9vi network-config testnet
```