### PR TITLE
chore: release v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0](https://github.com/near/near-cli-rs/compare/v0.10.2...v0.11.0) - 2024-06-19
+
+### Added
+- Added loading indicators to wait for the view-account-summary command ([#349](https://github.com/near/near-cli-rs/pull/349))
+- Added loading indicators to wait for the create-account (sponsor-by-faucet-service) command ([#339](https://github.com/near/near-cli-rs/pull/339))
+
+### Fixed
+- Do not fail view-account-summary command if we could not retrieve access keys list ([#344](https://github.com/near/near-cli-rs/pull/344))
+
+### Other
+- [**breaking**] upgraded near-dependencies to the 0.23 version ([#350](https://github.com/near/near-cli-rs/pull/350))
+- Provide instructions that help to resolve a problem with missing keychain ([#347](https://github.com/near/near-cli-rs/pull/347))
+
 ## [0.10.2](https://github.com/near/near-cli-rs/compare/v0.10.1...v0.10.2) - 2024-05-21
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2501,7 +2501,7 @@ dependencies = [
 
 [[package]]
 name = "near-cli-rs"
-version = "0.10.2"
+version = "0.11.0"
 dependencies = [
  "bip39",
  "bs58 0.5.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-cli-rs"
-version = "0.10.2"
+version = "0.11.0"
 authors = ["FroVolod <frol_off@meta.ua>", "Near Inc <hello@nearprotocol.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `near-cli-rs`: 0.10.2 -> 0.11.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.11.0](https://github.com/near/near-cli-rs/compare/v0.10.2...v0.11.0) - 2024-06-19

### Added
- Added loading indicators to wait for the view-account-summary command ([#349](https://github.com/near/near-cli-rs/pull/349))
- Added loading indicators to wait for the create-account (sponsor-by-faucet-service) command ([#339](https://github.com/near/near-cli-rs/pull/339))

### Fixed
- Do not fail view-account-summary command if we could not retrieve access keys list ([#344](https://github.com/near/near-cli-rs/pull/344))

### Other
- [**breaking**] upgraded near-dependencies to the 0.23 version ([#350](https://github.com/near/near-cli-rs/pull/350))
- Provide instructions that help to resolve a problem with missing keychain ([#347](https://github.com/near/near-cli-rs/pull/347))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).