### PR TITLE
Give instructions that help to resolve a problem with missing keychain

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -1267,7 +1267,7 @@ pub fn save_access_key_to_keychain(
     keyring::Entry::new(&service_name, &format!("{}:{}", account_id, public_key_str))
         .wrap_err("Failed to open keychain")?
         .set_password(key_pair_properties_buf)
-        .wrap_err("Failed to save password to keychain")?;
+        .wrap_err("Failed to save password to keychain. You may have to install the secure keychain by the following instructions: https://github.com/jaraco/keyring#using-keyring-on-headless-linux-systems")?;
 
     Ok("The data for the access key is saved in the keychain".to_string())
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -1267,7 +1267,7 @@ pub fn save_access_key_to_keychain(
     keyring::Entry::new(&service_name, &format!("{}:{}", account_id, public_key_str))
         .wrap_err("Failed to open keychain")?
         .set_password(key_pair_properties_buf)
-        .wrap_err("Failed to save password to keychain. You may have to install the secure keychain by the following instructions: https://github.com/jaraco/keyring#using-keyring-on-headless-linux-systems")?;
+        .wrap_err("Failed to save password to keychain. You may need to install secure keychain package by following  this instructions: https://github.com/jaraco/keyring#using-keyring-on-headless-linux-systems")?;
 
     Ok("The data for the access key is saved in the keychain".to_string())
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -1267,7 +1267,7 @@ pub fn save_access_key_to_keychain(
     keyring::Entry::new(&service_name, &format!("{}:{}", account_id, public_key_str))
         .wrap_err("Failed to open keychain")?
         .set_password(key_pair_properties_buf)
-        .wrap_err("Failed to save password to keychain. You may need to install secure keychain package by following  this instructions: https://github.com/jaraco/keyring#using-keyring-on-headless-linux-systems")?;
+        .wrap_err("Failed to save password to keychain. You may need to install the secure keychain package by following this instruction: https://github.com/jaraco/keyring#using-keyring-on-headless-linux-systems")?;
 
     Ok("The data for the access key is saved in the keychain".to_string())
 }


### PR DESCRIPTION
I found out that certain headless linux systems don't implement keyring. For example on WSL we can`t use keychain because it is not seted up by default. User need to install gnome-keyring with pip3, start D-bust session and unlock keychain. Close https://github.com/near/near-cli-rs/issues/299