### PR TITLE
chore: release v0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.1](https://github.com/near/near-cli-rs/compare/v0.11.0...v0.11.1) - 2024-07-01
+
+### Added
+- Added loading indicators for "contract" group commands  ([#357](https://github.com/near/near-cli-rs/pull/357))
+- Added loading indicators for "staking" group commands ([#356](https://github.com/near/near-cli-rs/pull/356))
+- Added loading indicators for "tokens" group commands ([#355](https://github.com/near/near-cli-rs/pull/355))
+- Added loading indicators for "accounts" group commands ([#352](https://github.com/near/near-cli-rs/pull/352))
+
+### Other
+- replace `ed25519-dalek` 1 -> 2 major version ([#359](https://github.com/near/near-cli-rs/pull/359))
+
 ## [0.11.0](https://github.com/near/near-cli-rs/compare/v0.10.2...v0.11.0) - 2024-06-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2473,7 +2473,7 @@ dependencies = [
 
 [[package]]
 name = "near-cli-rs"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "bip39",
  "bs58 0.5.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-cli-rs"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["FroVolod <frol_off@meta.ua>", "Near Inc <hello@nearprotocol.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `near-cli-rs`: 0.11.0 -> 0.11.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.11.1](https://github.com/near/near-cli-rs/compare/v0.11.0...v0.11.1) - 2024-07-01

### Added
- Added loading indicators for "contract" group commands  ([#357](https://github.com/near/near-cli-rs/pull/357))
- Added loading indicators for "staking" group commands ([#356](https://github.com/near/near-cli-rs/pull/356))
- Added loading indicators for "tokens" group commands ([#355](https://github.com/near/near-cli-rs/pull/355))
- Added loading indicators for "accounts" group commands ([#352](https://github.com/near/near-cli-rs/pull/352))

### Other
- replace `ed25519-dalek` 1 -> 2 major version ([#359](https://github.com/near/near-cli-rs/pull/359))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).