### PR TITLE
chore: release v0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0](https://github.com/near/near-cli-rs/compare/v0.11.1...v0.12.0) - 2024-07-09
+
+### Added
+- Cover *all* commands from near-cli JS with the new near-cli-rs suggestions for full compatibility  ([#345](https://github.com/near/near-cli-rs/pull/345))
+- Added the ability to select HD Path from the ledger ([#362](https://github.com/near/near-cli-rs/pull/362))
+- Added loading indicators for "transaction" group commands and improved the prompt messages  ([#358](https://github.com/near/near-cli-rs/pull/358))
+
 ## [0.11.1](https://github.com/near/near-cli-rs/compare/v0.11.0...v0.11.1) - 2024-07-01
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2473,7 +2473,7 @@ dependencies = [
 
 [[package]]
 name = "near-cli-rs"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "bip39",
  "bs58 0.5.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-cli-rs"
-version = "0.11.1"
+version = "0.12.0"
 authors = ["FroVolod <frol_off@meta.ua>", "Near Inc <hello@nearprotocol.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `near-cli-rs`: 0.11.1 -> 0.12.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.12.0](https://github.com/near/near-cli-rs/compare/v0.11.1...v0.12.0) - 2024-07-09

### Added
- Cover *all* commands from near-cli JS with the new near-cli-rs suggestions for full compatibility  ([#345](https://github.com/near/near-cli-rs/pull/345))
- Added the ability to select HD Path from the ledger ([#362](https://github.com/near/near-cli-rs/pull/362))
- Added loading indicators for "transaction" group commands and improved the prompt messages  ([#358](https://github.com/near/near-cli-rs/pull/358))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).