### PR TITLE
chore: release v0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0](https://github.com/near/near-cli-rs/compare/v0.12.0...v0.13.0) - 2024-07-30
+
+### Added
+- Automatically exec legacy JS CLI commands for full backward compatibility ([#366](https://github.com/near/near-cli-rs/pull/366))
+- Added the ability to use the TEACH-ME mode ([#360](https://github.com/near/near-cli-rs/pull/360))
+- Added a new subcommand to edit configuration parameters ([#367](https://github.com/near/near-cli-rs/pull/367))
+
+### Fixed
+- Fixed the fallback implementation of fetching active staking pools ([#369](https://github.com/near/near-cli-rs/pull/369))
+
+### Other
+- Fixed typos in user prompts and the guide ([#372](https://github.com/near/near-cli-rs/pull/372))
+
 ## [0.12.0](https://github.com/near/near-cli-rs/compare/v0.11.1...v0.12.0) - 2024-07-09
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2473,7 +2473,7 @@ dependencies = [
 
 [[package]]
 name = "near-cli-rs"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "bip39",
  "bs58 0.5.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-cli-rs"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["FroVolod <frol_off@meta.ua>", "Near Inc <hello@nearprotocol.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `near-cli-rs`: 0.12.0 -> 0.13.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.13.0](https://github.com/near/near-cli-rs/compare/v0.12.0...v0.13.0) - 2024-07-30

### Added
- Automatically exec legacy JS CLI commands for full backward compatibility ([#366](https://github.com/near/near-cli-rs/pull/366))
- Added the ability to use the TEACH-ME mode ([#360](https://github.com/near/near-cli-rs/pull/360))
- Added a new subcommand to edit configuration parameters ([#367](https://github.com/near/near-cli-rs/pull/367))

### Fixed
- Fixed the fallback implementation of fetching active staking pools ([#369](https://github.com/near/near-cli-rs/pull/369))

### Other
- Fixed typos in user prompts and the guide ([#372](https://github.com/near/near-cli-rs/pull/372))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).