### PR TITLE
chore: release v0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.1](https://github.com/near/near-cli-rs/compare/v0.13.0...v0.13.1) - 2024-08-11
+
+### Fixed
+- Handle delegated stake errors gracefully and display a warning message instead of failing the view-account-summary command completely ([#382](https://github.com/near/near-cli-rs/pull/382))
+- Entering the name of the function in interactive mode ([#379](https://github.com/near/near-cli-rs/pull/379))
+- Fixed a typo in `inspect` output about missing ABI support ([#374](https://github.com/near/near-cli-rs/pull/374))
+
+### Other
+- Added videos to the README for installation process on Windows ([#378](https://github.com/near/near-cli-rs/pull/378))
+- Cleaned up error message reporting by disabling env section of color_eyre report ([#380](https://github.com/near/near-cli-rs/pull/380))
+
 ## [0.13.0](https://github.com/near/near-cli-rs/compare/v0.12.0...v0.13.0) - 2024-07-30
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2473,7 +2473,7 @@ dependencies = [
 
 [[package]]
 name = "near-cli-rs"
-version = "0.13.0"
+version = "0.13.1"
 dependencies = [
  "bip39",
  "bs58 0.5.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-cli-rs"
-version = "0.13.0"
+version = "0.13.1"
 authors = ["FroVolod <frol_off@meta.ua>", "Near Inc <hello@nearprotocol.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `near-cli-rs`: 0.13.0 -> 0.13.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.13.1](https://github.com/near/near-cli-rs/compare/v0.13.0...v0.13.1) - 2024-08-11

### Fixed
- Handle delegated stake errors gracefully and display a warning message instead of failing the view-account-summary command completely ([#382](https://github.com/near/near-cli-rs/pull/382))
- Entering the name of the function in interactive mode ([#379](https://github.com/near/near-cli-rs/pull/379))
- Fixed a typo in `inspect` output about missing ABI support ([#374](https://github.com/near/near-cli-rs/pull/374))

### Other
- Added videos to the README for installation process on Windows ([#378](https://github.com/near/near-cli-rs/pull/378))
- Cleaned up error message reporting by disabling env section of color_eyre report ([#380](https://github.com/near/near-cli-rs/pull/380))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).