### PR TITLE
chore: release v0.14.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.2](https://github.com/near/near-cli-rs/compare/v0.14.1...v0.14.2) - 2024-08-21
+
+### Added
+- Upgraded cargo-dist to 0.21.1 and enabled Linux ARM64 build ([#397](https://github.com/near/near-cli-rs/pull/397))
+- Prioritize searching an access key in the signer account subfolder (<credentials-dir>/<network>/<account-id>/*.json) in legacy keychain and then fallback to <credentials-dir>/<network>/<account-id>.json instead of the other way around ([#396](https://github.com/near/near-cli-rs/pull/396))
+
+### Other
+- Fixed the one-liner curl installation command
+
 ## [0.14.1](https://github.com/near/near-cli-rs/compare/v0.14.0...v0.14.1) - 2024-08-15
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2162,7 +2162,7 @@ dependencies = [
 
 [[package]]
 name = "near-cli-rs"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "bip39",
  "bs58 0.5.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-cli-rs"
-version = "0.14.1"
+version = "0.14.2"
 authors = ["FroVolod <frol_off@meta.ua>", "Near Inc <hello@nearprotocol.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `near-cli-rs`: 0.14.1 -> 0.14.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.14.2](https://github.com/near/near-cli-rs/compare/v0.14.1...v0.14.2) - 2024-08-21

### Added
- Upgraded cargo-dist to 0.21.1 and enabled Linux ARM64 build ([#397](https://github.com/near/near-cli-rs/pull/397))
- Prioritize searching an access key in the signer account subfolder (<credentials-dir>/<network>/<account-id>/*.json) in legacy keychain and then fallback to <credentials-dir>/<network>/<account-id>.json instead of the other way around ([#396](https://github.com/near/near-cli-rs/pull/396))

### Other
- Fixed the one-liner curl installation command
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).