### PR TITLE
chore: release v0.14.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.3](https://github.com/near/near-cli-rs/compare/v0.14.2...v0.14.3) - 2024-08-21
+
+### Fixed
+- Fixed the fallback legacy keychain path ([#398](https://github.com/near/near-cli-rs/pull/398))
+
 ## [0.14.2](https://github.com/near/near-cli-rs/compare/v0.14.1...v0.14.2) - 2024-08-21
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2162,7 +2162,7 @@ dependencies = [
 
 [[package]]
 name = "near-cli-rs"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "bip39",
  "bs58 0.5.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-cli-rs"
-version = "0.14.2"
+version = "0.14.3"
 authors = ["FroVolod <frol_off@meta.ua>", "Near Inc <hello@nearprotocol.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `near-cli-rs`: 0.14.2 -> 0.14.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.14.3](https://github.com/near/near-cli-rs/compare/v0.14.2...v0.14.3) - 2024-08-21

### Fixed
- Fixed the fallback legacy keychain path ([#398](https://github.com/near/near-cli-rs/pull/398))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).