### PR TITLE
chore: release v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0](https://github.com/near/near-cli-rs/compare/v0.14.3...v0.15.0) - 2024-09-02
+
+### Added
+- Extended --teach-me mode: async account details fetching RPC methods are also covered now ([#389](https://github.com/near/near-cli-rs/pull/389))
+
+### Other
+- Updated near-* dependencies to 0.25.0 (matching nearcore 2.1 release) ([#401](https://github.com/near/near-cli-rs/pull/401))
+
 ## [0.14.3](https://github.com/near/near-cli-rs/compare/v0.14.2...v0.14.3) - 2024-08-21
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1898,7 +1898,7 @@ dependencies = [
 
 [[package]]
 name = "near-cli-rs"
-version = "0.14.3"
+version = "0.15.0"
 dependencies = [
  "bip39",
  "bs58 0.5.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-cli-rs"
-version = "0.14.3"
+version = "0.15.0"
 authors = ["FroVolod <frol_off@meta.ua>", "Near Inc <hello@nearprotocol.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `near-cli-rs`: 0.14.3 -> 0.15.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.15.0](https://github.com/near/near-cli-rs/compare/v0.14.3...v0.15.0) - 2024-09-02

### Added
- Extended --teach-me mode: async account details fetching RPC methods are also covered now ([#389](https://github.com/near/near-cli-rs/pull/389))

### Other
- Updated near-* dependencies to 0.25.0 (matching nearcore 2.1 release) ([#401](https://github.com/near/near-cli-rs/pull/401))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).