### PR TITLE
chore: release v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0](https://github.com/near/near-cli-rs/compare/v0.15.1...v0.16.0) - 2024-11-18
+
+### Other
+
+- [**breaking**] updates near-* dependencies to 0.27 release ([#414](https://github.com/near/near-cli-rs/pull/414))
+
 ## [0.15.1](https://github.com/near/near-cli-rs/compare/v0.15.0...v0.15.1) - 2024-09-11
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2057,7 +2057,7 @@ dependencies = [
 
 [[package]]
 name = "near-cli-rs"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "bip39",
  "bs58 0.5.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-cli-rs"
-version = "0.15.1"
+version = "0.16.0"
 authors = ["FroVolod <frol_off@meta.ua>", "Near Inc <hello@nearprotocol.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `near-cli-rs`: 0.15.1 -> 0.16.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.16.0](https://github.com/near/near-cli-rs/compare/v0.15.1...v0.16.0) - 2024-11-18

### Other

- [**breaking**] updates near-* dependencies to 0.27 release ([#414](https://github.com/near/near-cli-rs/pull/414))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).