### PR TITLE
chore: release v0.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.1](https://github.com/near/near-cli-rs/compare/v0.16.0...v0.16.1) - 2024-12-06
+
+### Added
+
+- Added the ability to save payload for broadcast_tx_commit ([#413](https://github.com/near/near-cli-rs/pull/413))
+- Get the final CLI command into the shell history with a small helper setup ([#415](https://github.com/near/near-cli-rs/pull/415))
+- Trace configuration for loading wait indicators and --teach-me flag moved to library ([#417](https://github.com/near/near-cli-rs/pull/417))
+- add to devtools workflow
+
 ## [0.16.0](https://github.com/near/near-cli-rs/compare/v0.15.1...v0.16.0) - 2024-11-18
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2057,7 +2057,7 @@ dependencies = [
 
 [[package]]
 name = "near-cli-rs"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "bip39",
  "bs58 0.5.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-cli-rs"
-version = "0.16.0"
+version = "0.16.1"
 authors = ["FroVolod <frol_off@meta.ua>", "Near Inc <hello@nearprotocol.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
## 🤖 New release
* `near-cli-rs`: 0.16.0 -> 0.16.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.16.1](https://github.com/near/near-cli-rs/compare/v0.16.0...v0.16.1) - 2024-12-06

### Added

- Added the ability to save payload for broadcast_tx_commit ([#413](https://github.com/near/near-cli-rs/pull/413))
- Get the final CLI command into the shell history with a small helper setup ([#415](https://github.com/near/near-cli-rs/pull/415))
- Trace configuration for loading wait indicators and --teach-me flag moved to library ([#417](https://github.com/near/near-cli-rs/pull/417))
- add to devtools workflow
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).