### PR TITLE
fix: Fixed field name for JSON file with transaction information (signed-transaction-info.json)

### DIFF
--- a/src/commands/transaction/send_signed_transaction/mod.rs
+++ b/src/commands/transaction/send_signed_transaction/mod.rs
@@ -82,7 +82,7 @@ pub struct FileWithBase64SignedTransactionContext(SignedTransactionContext);
 
 #[derive(Debug, serde::Deserialize)]
 struct FileSignedTransaction {
-    #[serde(alias = "Signed transaction (serialized as base64)")]
+    #[serde(alias = "signedTransactionAsBase64")]
     signed_transaction: near_primitives::transaction::SignedTransaction,
 }
 

--- a/src/transaction_signature_options/save_to_file/mod.rs
+++ b/src/transaction_signature_options/save_to_file/mod.rs
@@ -39,7 +39,7 @@ impl SaveToFileContext {
                     .to_string();
 
                 let data_signed_transaction = serde_json::json!(
-                    {"Signed transaction (serialized as base64)": signed_transaction_as_base64});
+                    {"signedTransactionAsBase64": signed_transaction_as_base64});
 
                 std::fs::File::create(&file_path)
                     .wrap_err_with(|| format!("Failed to create file: {:?}", &file_path))?


### PR DESCRIPTION
As recommended by @akorchyn ([pull/412#pullrequestreview-2502347297](https://github.com/near/near-cli-rs/pull/412#pullrequestreview-2502347297)), the field name for the transaction information JSON file (signed-transaction-info.json) has been fixed.