### PR TITLE
bugfix: handle new rate-limits for querying pools

### DIFF
--- a/src/commands/account/view_account_summary/mod.rs
+++ b/src/commands/account/view_account_summary/mod.rs
@@ -108,8 +108,8 @@ fn get_account_inquiry(
                 crate::common::fetch_historically_delegated_staking_pools(fastnear_url, account_id)
                     .ok()
             });
-    let validators = if let Some(validators) = historically_delegated_validators {
-        Ok(validators)
+    let pools_to_query = if let Some(user_staked_pools) = historically_delegated_validators {
+        Ok(user_staked_pools)
     } else if let Some(staking_pools_factory_account_id) =
         &network_config.staking_pools_factory_account_id
     {
@@ -132,7 +132,7 @@ fn get_account_inquiry(
 
     let delegated_stake: color_eyre::Result<
         std::collections::BTreeMap<near_primitives::types::AccountId, near_token::NearToken>,
-    > = match validators {
+    > = match pools_to_query {
         Ok(validators) => {
             let mut all_results = std::collections::BTreeMap::new();
             let validators: Vec<_> = validators.into_iter().collect();

--- a/src/config/migrations.rs
+++ b/src/config/migrations.rs
@@ -87,6 +87,16 @@ impl From<NetworkConfigV1> for NetworkConfigV2 {
     }
 }
 
+pub fn update_config_v2_to_v2_1(config_v2: ConfigV2) -> ConfigVersion {
+    let mut config_v2_1 = config_v2;
+    for (name, network_config) in config_v2_1.network_connection.iter_mut() {
+        if name == "testnet" && network_config.fastnear_url.is_none() {
+            network_config.fastnear_url = Some("https://test.api.fastnear.com/".parse().unwrap());
+        }
+    }
+    ConfigVersion::V2_1(config_v2_1)
+}
+
 #[derive(serde::Serialize, serde::Deserialize)]
 #[serde(tag = "version")]
 pub enum ConfigVersion {
@@ -94,4 +104,7 @@ pub enum ConfigVersion {
     V1(ConfigV1),
     #[serde(rename = "2")]
     V2(ConfigV2),
+    // Adds fastnear_url to the testnet config if it's not present
+    #[serde(rename = "2.1")]
+    V2_1(ConfigV2),
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -74,7 +74,7 @@ impl Config {
     }
 
     pub fn into_latest_version(self) -> migrations::ConfigVersion {
-        migrations::ConfigVersion::V2(self)
+        migrations::ConfigVersion::V2_1(self)
     }
 
     pub fn get_config_toml() -> color_eyre::eyre::Result<Self> {
@@ -193,7 +193,10 @@ impl From<migrations::ConfigVersion> for Config {
                     migrations::ConfigVersion::V2(config_v1.into())
                 }
                 migrations::ConfigVersion::V2(config_v2) => {
-                    break config_v2;
+                    migrations::update_config_v2_to_v2_1(config_v2)
+                }
+                migrations::ConfigVersion::V2_1(config_v2_1) => {
+                    break config_v2_1;
                 }
             };
         }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -74,7 +74,7 @@ impl Config {
     }
 
     pub fn into_latest_version(self) -> migrations::ConfigVersion {
-        migrations::ConfigVersion::V2_1(self)
+        migrations::ConfigVersion::V3(self)
     }
 
     pub fn get_config_toml() -> color_eyre::eyre::Result<Self> {
@@ -193,10 +193,10 @@ impl From<migrations::ConfigVersion> for Config {
                     migrations::ConfigVersion::V2(config_v1.into())
                 }
                 migrations::ConfigVersion::V2(config_v2) => {
-                    migrations::update_config_v2_to_v2_1(config_v2)
+                    migrations::ConfigVersion::V3(config_v2.into())
                 }
-                migrations::ConfigVersion::V2_1(config_v2_1) => {
-                    break config_v2_1;
+                migrations::ConfigVersion::V3(config_v3) => {
+                    break config_v3;
                 }
             };
         }


### PR DESCRIPTION
Closes: #431 

* Added fast-near for testnet
* Rate limited querying pools to 140 / 30s

Ideally, if Fastnear is stable enough, the user shouldn't be able to hit this limit as we will query information within the pools the user has staked before.
But in case the fastener fails, we would need to query all active pools, which number more than 150.

| Network | FastNear | Non fast near |
| :---:   | :---: | :---: |
| Testnet | < 140 (mostly 0-5) | 563 pools 
| Mainnet | < 140 ( mostly 0-5 ) | State of contract poolv1.near is too large to be viewed |

@race-of-sloths