### PR TITLE
chore: release v0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.0](https://github.com/near/near-cli-rs/compare/v0.18.0...v0.19.0) - 2025-03-12
+
+### Added
+
+- Improved usability of NEAR CLI in scripts ([#445](https://github.com/near/near-cli-rs/pull/445))
+- Added "send all" option to fungible tokens ([#440](https://github.com/near/near-cli-rs/pull/440))
+- let users specify a memo when sending ft
+- A new `--quiet` flag to suppress noisy output in scripting scenarios ([#441](https://github.com/near/near-cli-rs/pull/441))
+
+### Fixed
+
+- Fixed information about successful transfer of "send all" ft tokens ([#447](https://github.com/near/near-cli-rs/pull/447))
+- Fixed cli command for memo parameter ([#446](https://github.com/near/near-cli-rs/pull/446))
+- Use legacy keychain as a fallback storage when system keychain is not supported (e.g. WSL, Codespaces, Docker containers, CI) ([#439](https://github.com/near/near-cli-rs/pull/439))
+
+### Other
+
+- [**breaking**] updates near-* dependencies to 0.29 release ([#455](https://github.com/near/near-cli-rs/pull/455))
+- Typos fix ([#451](https://github.com/near/near-cli-rs/pull/451))
+- Added the ability to add an account ID to the account list without using the legacy keychain ([#449](https://github.com/near/near-cli-rs/pull/449))
+- Updated the copyright year to 2025 ([#448](https://github.com/near/near-cli-rs/pull/448))
+
 ## [0.18.0](https://github.com/near/near-cli-rs/compare/v0.17.0...v0.18.0) - 2025-01-20
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2071,7 +2071,7 @@ dependencies = [
 
 [[package]]
 name = "near-cli-rs"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "bip39",
  "bs58 0.5.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-cli-rs"
-version = "0.18.0"
+version = "0.19.0"
 authors = ["FroVolod <frol_off@meta.ua>", "Near Inc <hello@nearprotocol.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION



## 🤖 New release

* `near-cli-rs`: 0.18.0 -> 0.19.0 (⚠ API breaking changes)

### ⚠ `near-cli-rs` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field GlobalContext.verbosity in /tmp/.tmpqoEbVp/near-cli-rs/src/lib.rs:19

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/function_missing.ron

Failed in:
  function near_cli_rs::common::create_used_account_list_from_keychain, previously in file /tmp/.tmpzjZyQv/near-cli-rs/src/common.rs:2604

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/function_parameter_count_changed.ron

Failed in:
  near_cli_rs::common::print_transaction_status now takes 3 parameters instead of 2, in /tmp/.tmpqoEbVp/near-cli-rs/src/common.rs:1323

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.39.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field teach_me of struct GlobalContext, previously in file /tmp/.tmpzjZyQv/near-cli-rs/src/lib.rs:19
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.19.0](https://github.com/near/near-cli-rs/compare/v0.18.0...v0.19.0) - 2025-03-12

### Added

- Improved usability of NEAR CLI in scripts ([#445](https://github.com/near/near-cli-rs/pull/445))
- Added "send all" option to fungible tokens ([#440](https://github.com/near/near-cli-rs/pull/440))
- let users specify a memo when sending ft
- A new `--quiet` flag to suppress noisy output in scripting scenarios ([#441](https://github.com/near/near-cli-rs/pull/441))

### Fixed

- Fixed information about successful transfer of "send all" ft tokens ([#447](https://github.com/near/near-cli-rs/pull/447))
- Fixed cli command for memo parameter ([#446](https://github.com/near/near-cli-rs/pull/446))
- Use legacy keychain as a fallback storage when system keychain is not supported (e.g. WSL, Codespaces, Docker containers, CI) ([#439](https://github.com/near/near-cli-rs/pull/439))

### Other

- [**breaking**] updates near-* dependencies to 0.29 release ([#455](https://github.com/near/near-cli-rs/pull/455))
- Typos fix ([#451](https://github.com/near/near-cli-rs/pull/451))
- Added the ability to add an account ID to the account list without using the legacy keychain ([#449](https://github.com/near/near-cli-rs/pull/449))
- Updated the copyright year to 2025 ([#448](https://github.com/near/near-cli-rs/pull/448))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).