### PR TITLE
Typos fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -289,7 +289,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Provide a relevant faucet error message when helper API server returns an error ([#243](https://github.com/near/near-cli-rs/pull/243))
 
 ### Other
-- Exposed sponsor_by_faucet_service module to re-use in "cargo-near" ([#246](https://github.com/near/near-cli-rs/pull/246))
+- Exposed sponsor_by_faucet_service module to reuse in "cargo-near" ([#246](https://github.com/near/near-cli-rs/pull/246))
 
 ## [0.6.0](https://github.com/near/near-cli-rs/compare/v0.5.2...v0.6.0) - 2023-09-28
 


### PR DESCRIPTION
Fix: Corrected typos in source files

**Changes**

Corrected typo in /CHANGELOG.md (Line 292)

"re-use" → "reuse"

**Purpose**

Improved code accuracy and professionalism by fixing typos.