### PR TITLE
feat: extended action builder for new actions 

### DIFF
--- a/src/commands/transaction/construct_transaction/add_action_1/add_action/deploy_contract/initialize_mode/mod.rs
+++ b/src/commands/transaction/construct_transaction/add_action_1/add_action/deploy_contract/initialize_mode/mod.rs
@@ -1,7 +1,7 @@
 use strum::{EnumDiscriminants, EnumIter, EnumMessage};
 
 #[derive(Debug, Clone, EnumDiscriminants, interactive_clap_derive::InteractiveClap)]
-#[interactive_clap(context = super::ContractFileContext)]
+#[interactive_clap(context = super::super::super::super::ConstructTransactionContext)]
 #[strum_discriminants(derive(EnumMessage, EnumIter))]
 /// Select the need for initialization:
 pub enum InitializeMode {
@@ -14,7 +14,7 @@ pub enum InitializeMode {
 }
 
 #[derive(Debug, Clone, interactive_clap::InteractiveClap)]
-#[interactive_clap(context = super::ContractFileContext)]
+#[interactive_clap(context = super::super::super::super::ConstructTransactionContext)]
 pub struct NoInitialize {
     #[interactive_clap(subcommand)]
     next_action: super::super::super::super::add_action_2::NextAction,

--- a/src/commands/transaction/construct_transaction/add_action_1/add_action/deploy_global_contract/mod.rs
+++ b/src/commands/transaction/construct_transaction/add_action_1/add_action/deploy_global_contract/mod.rs
@@ -1,0 +1,97 @@
+use color_eyre::eyre::Context;
+use strum::{EnumDiscriminants, EnumIter, EnumMessage};
+
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(input_context = super::super::super::ConstructTransactionContext)]
+#[interactive_clap(output_context = DeployGlobalContractActionContext)]
+pub struct DeployGlobalContractAction {
+    /// What is a file location of the contract?
+    pub file_path: crate::types::path_buf::PathBuf,
+    #[interactive_clap(subcommand)]
+    mode: DeployGlobalMode,
+}
+
+#[derive(Debug, Clone)]
+pub struct DeployGlobalContractActionContext {
+    pub context: super::super::super::ConstructTransactionContext,
+    pub code: Vec<u8>,
+}
+
+impl DeployGlobalContractActionContext {
+    pub fn from_previous_context(
+        previous_context: super::super::super::ConstructTransactionContext,
+        scope: &<DeployGlobalContractAction as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+    ) -> color_eyre::eyre::Result<Self> {
+        let code = std::fs::read(&scope.file_path).wrap_err_with(|| {
+            format!("Failed to open or read the file: {:?}.", &scope.file_path.0,)
+        })?;
+        Ok(Self {
+            context: previous_context,
+            code,
+        })
+    }
+}
+
+#[derive(Debug, EnumDiscriminants, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(input_context = DeployGlobalContractActionContext)]
+#[interactive_clap(output_context = DeployGlobalModeContext)]
+#[strum_discriminants(derive(EnumMessage, EnumIter))]
+#[non_exhaustive]
+/// Choose a global contract deploy mode:
+pub enum DeployGlobalMode {
+    #[strum_discriminants(strum(
+        message = "as-global-hash       - Deploy code as a global contract code hash (immutable)"
+    ))]
+    /// Deploy code as a global contract code hash (immutable)
+    AsGlobalHash(NextCommand),
+    #[strum_discriminants(strum(
+        message = "as-global-account-id - Deploy code as a global contract account ID (mutable)"
+    ))]
+    /// Deploy code as a global contract account ID (mutable)
+    AsGlobalAccountId(NextCommand),
+}
+
+#[derive(Debug, Clone)]
+pub struct DeployGlobalModeContext(super::super::super::ConstructTransactionContext);
+
+impl DeployGlobalModeContext {
+    pub fn from_previous_context(
+        previous_context: DeployGlobalContractActionContext,
+        scope: &<DeployGlobalMode as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+    ) -> color_eyre::eyre::Result<Self> {
+        let action = near_primitives::transaction::Action::DeployGlobalContract(
+            near_primitives::action::DeployGlobalContractAction {
+                code: previous_context.code,
+                deploy_mode: match scope {
+                    DeployGlobalModeDiscriminants::AsGlobalHash => {
+                        near_primitives::action::GlobalContractDeployMode::CodeHash
+                    }
+                    DeployGlobalModeDiscriminants::AsGlobalAccountId => {
+                        near_primitives::action::GlobalContractDeployMode::AccountId
+                    }
+                },
+            },
+        );
+        let mut actions = previous_context.context.actions;
+        actions.push(action);
+        Ok(Self(super::super::super::ConstructTransactionContext {
+            global_context: previous_context.context.global_context,
+            signer_account_id: previous_context.context.signer_account_id,
+            receiver_account_id: previous_context.context.receiver_account_id,
+            actions,
+        }))
+    }
+}
+
+impl From<DeployGlobalModeContext> for super::super::super::ConstructTransactionContext {
+    fn from(item: DeployGlobalModeContext) -> Self {
+        item.0
+    }
+}
+
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(context = DeployGlobalModeContext)]
+pub struct NextCommand {
+    #[interactive_clap(subcommand)]
+    next_action: super::super::super::add_action_2::NextAction,
+}

--- a/src/commands/transaction/construct_transaction/add_action_1/add_action/mod.rs
+++ b/src/commands/transaction/construct_transaction/add_action_1/add_action/mod.rs
@@ -6,9 +6,10 @@ pub mod create_account;
 pub mod delete_account;
 pub mod delete_key;
 pub mod deploy_contract;
+pub mod deploy_global_contract;
 pub mod stake;
 pub mod transfer;
-
+pub mod use_global_contract;
 #[derive(Debug, Clone, interactive_clap::InteractiveClap)]
 #[interactive_clap(context = super::super::ConstructTransactionContext)]
 pub struct AddAction {
@@ -22,35 +23,43 @@ pub struct AddAction {
 /// Select an action that you want to add to the action:
 pub enum ActionSubcommand {
     #[strum_discriminants(strum(
-        message = "transfer             - The transfer is carried out in NEAR tokens"
+        message = "transfer               - The transfer is carried out in NEAR tokens"
     ))]
     /// Specify data for transfer tokens
     Transfer(self::transfer::TransferAction),
     #[strum_discriminants(strum(
-        message = "function-call        - Execute function (contract method)"
+        message = "function-call          - Execute function (contract method)"
     ))]
     /// Specify data to call the function
     FunctionCall(self::call_function::FunctionCallAction),
-    #[strum_discriminants(strum(message = "stake                - Stake NEAR Tokens"))]
+    #[strum_discriminants(strum(message = "stake                  - Stake NEAR Tokens"))]
     /// Specify data to stake NEAR Tokens
     Stake(self::stake::StakeAction),
-    #[strum_discriminants(strum(message = "create-account       - Create a new sub-account"))]
+    #[strum_discriminants(strum(message = "create-account         - Create a new sub-account"))]
     /// Specify data to create a sub-account
     CreateAccount(self::create_account::CreateAccountAction),
-    #[strum_discriminants(strum(message = "delete-account       - Delete an account"))]
+    #[strum_discriminants(strum(message = "delete-account         - Delete an account"))]
     /// Specify data to delete an account
     DeleteAccount(self::delete_account::DeleteAccountAction),
     #[strum_discriminants(strum(
-        message = "add-key              - Add an access key to an account"
+        message = "add-key                - Add an access key to an account"
     ))]
     /// Specify the data to add an access key to the account
     AddKey(self::add_key::AddKeyAction),
     #[strum_discriminants(strum(
-        message = "delete-key           - Delete an access key from an account"
+        message = "delete-key             - Delete an access key from an account"
     ))]
     /// Specify the data to delete the access key to the account
     DeleteKey(self::delete_key::DeleteKeyAction),
-    #[strum_discriminants(strum(message = "deploy               - Add a new contract code"))]
+    #[strum_discriminants(strum(message = "deploy                 - Add a new contract code"))]
     /// Specify the details to deploy the contract code
     DeployContract(self::deploy_contract::DeployContractAction),
+    #[strum_discriminants(strum(
+        message = "deploy-global-contract - Add a new global contract code"
+    ))]
+    /// Specify the details to deploy the global contract code
+    DeployGlobalContract(self::deploy_global_contract::DeployGlobalContractAction),
+    #[strum_discriminants(strum(message = "use-global-contract    - Use a global contract"))]
+    /// Specify the details to use the global contract
+    UseGlobalContract(self::use_global_contract::UseGlobalContractAction),
 }

--- a/src/commands/transaction/construct_transaction/add_action_1/add_action/use_global_contract/mod.rs
+++ b/src/commands/transaction/construct_transaction/add_action_1/add_action/use_global_contract/mod.rs
@@ -1,0 +1,121 @@
+use strum::{EnumDiscriminants, EnumIter, EnumMessage};
+
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(context = super::super::super::ConstructTransactionContext)]
+pub struct UseGlobalContractAction {
+    #[interactive_clap(subcommand)]
+    mode: UseGlobalActionMode,
+}
+
+#[derive(Debug, EnumDiscriminants, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(context = super::super::super::ConstructTransactionContext)]
+#[strum_discriminants(derive(EnumMessage, EnumIter))]
+#[non_exhaustive]
+/// Choose a global contract deploy mode:
+pub enum UseGlobalActionMode {
+    #[strum_discriminants(strum(
+        message = "as-global-hash       - Deploy code as a global contract code hash (immutable)"
+    ))]
+    /// Deploy code as a global contract code hash (immutable)
+    AsGlobalHash(UseHashAction),
+    #[strum_discriminants(strum(
+        message = "as-global-account-id - Deploy code as a global contract account ID (mutable)"
+    ))]
+    /// Deploy code as a global contract account ID (mutable)
+    AsGlobalAccountId(UseAccountIdAction),
+}
+
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(input_context = super::super::super::ConstructTransactionContext)]
+#[interactive_clap(output_context = UseHashActionContext)]
+pub struct UseHashAction {
+    /// What is a hash of the global contract?
+    pub hash: crate::types::crypto_hash::CryptoHash,
+    #[interactive_clap(subcommand)]
+    initialize: super::deploy_contract::initialize_mode::InitializeMode,
+}
+
+#[derive(Debug, Clone)]
+pub struct UseHashActionContext(super::super::super::ConstructTransactionContext);
+
+impl UseHashActionContext {
+    pub fn from_previous_context(
+        previous_context: super::super::super::ConstructTransactionContext,
+        scope: &<UseHashAction as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+    ) -> color_eyre::eyre::Result<Self> {
+        let action = near_primitives::transaction::Action::UseGlobalContract(Box::new(
+            near_primitives::action::UseGlobalContractAction {
+                contract_identifier: near_primitives::action::GlobalContractIdentifier::CodeHash(
+                    scope.hash.into(),
+                ),
+            },
+        ));
+        let mut actions = previous_context.actions;
+        actions.push(action);
+        Ok(Self(super::super::super::ConstructTransactionContext {
+            global_context: previous_context.global_context,
+            signer_account_id: previous_context.signer_account_id,
+            receiver_account_id: previous_context.receiver_account_id,
+            actions,
+        }))
+    }
+}
+impl From<UseHashActionContext> for super::super::super::ConstructTransactionContext {
+    fn from(item: UseHashActionContext) -> Self {
+        item.0
+    }
+}
+
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(input_context = super::super::super::ConstructTransactionContext)]
+#[interactive_clap(output_context = UseAccountIdActionContext)]
+pub struct UseAccountIdAction {
+    #[interactive_clap(skip_default_input_arg)]
+    /// What is a account ID of the global contract?
+    pub account_id: crate::types::account_id::AccountId,
+    #[interactive_clap(subcommand)]
+    initialize: super::deploy_contract::initialize_mode::InitializeMode,
+}
+
+impl UseAccountIdAction {
+    pub fn input_account_id(
+        context: &super::super::super::ConstructTransactionContext,
+    ) -> color_eyre::eyre::Result<Option<crate::types::account_id::AccountId>> {
+        crate::common::input_signer_account_id_from_used_account_list(
+            &context.global_context.config.credentials_home_dir,
+            "What is a account ID of the global contract?",
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct UseAccountIdActionContext(super::super::super::ConstructTransactionContext);
+
+impl UseAccountIdActionContext {
+    pub fn from_previous_context(
+        previous_context: super::super::super::ConstructTransactionContext,
+        scope: &<UseAccountIdAction as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+    ) -> color_eyre::eyre::Result<Self> {
+        let action = near_primitives::transaction::Action::UseGlobalContract(Box::new(
+            near_primitives::action::UseGlobalContractAction {
+                contract_identifier: near_primitives::action::GlobalContractIdentifier::AccountId(
+                    scope.account_id.clone().into(),
+                ),
+            },
+        ));
+        let mut actions = previous_context.actions;
+        actions.push(action);
+        Ok(Self(super::super::super::ConstructTransactionContext {
+            global_context: previous_context.global_context,
+            signer_account_id: previous_context.signer_account_id,
+            receiver_account_id: previous_context.receiver_account_id,
+            actions,
+        }))
+    }
+}
+
+impl From<UseAccountIdActionContext> for super::super::super::ConstructTransactionContext {
+    fn from(item: UseAccountIdActionContext) -> Self {
+        item.0
+    }
+}

--- a/src/commands/transaction/construct_transaction/add_action_2/add_action/deploy_contract/initialize_mode/mod.rs
+++ b/src/commands/transaction/construct_transaction/add_action_2/add_action/deploy_contract/initialize_mode/mod.rs
@@ -1,7 +1,7 @@
 use strum::{EnumDiscriminants, EnumIter, EnumMessage};
 
 #[derive(Debug, Clone, EnumDiscriminants, interactive_clap_derive::InteractiveClap)]
-#[interactive_clap(context = super::ContractFileContext)]
+#[interactive_clap(context = super::super::super::super::ConstructTransactionContext)]
 #[strum_discriminants(derive(EnumMessage, EnumIter))]
 /// Select the need for initialization:
 pub enum InitializeMode {
@@ -14,7 +14,7 @@ pub enum InitializeMode {
 }
 
 #[derive(Debug, Clone, interactive_clap::InteractiveClap)]
-#[interactive_clap(context = super::ContractFileContext)]
+#[interactive_clap(context = super::super::super::super::ConstructTransactionContext)]
 pub struct NoInitialize {
     #[interactive_clap(subcommand)]
     next_action: super::super::super::super::add_action_3::NextAction,

--- a/src/commands/transaction/construct_transaction/add_action_2/add_action/deploy_contract/mod.rs
+++ b/src/commands/transaction/construct_transaction/add_action_2/add_action/deploy_contract/mod.rs
@@ -1,6 +1,6 @@
 use color_eyre::eyre::Context;
 
-mod initialize_mode;
+pub mod initialize_mode;
 
 #[derive(Debug, Clone, interactive_clap::InteractiveClap)]
 #[interactive_clap(context = super::super::super::ConstructTransactionContext)]

--- a/src/commands/transaction/construct_transaction/add_action_2/add_action/deploy_global_contract/mod.rs
+++ b/src/commands/transaction/construct_transaction/add_action_2/add_action/deploy_global_contract/mod.rs
@@ -1,0 +1,97 @@
+use color_eyre::eyre::Context;
+use strum::{EnumDiscriminants, EnumIter, EnumMessage};
+
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(input_context = super::super::super::ConstructTransactionContext)]
+#[interactive_clap(output_context = DeployGlobalContractActionContext)]
+pub struct DeployGlobalContractAction {
+    /// What is a file location of the contract?
+    pub file_path: crate::types::path_buf::PathBuf,
+    #[interactive_clap(subcommand)]
+    mode: DeployGlobalMode,
+}
+
+#[derive(Debug, Clone)]
+pub struct DeployGlobalContractActionContext {
+    pub context: super::super::super::ConstructTransactionContext,
+    pub code: Vec<u8>,
+}
+
+impl DeployGlobalContractActionContext {
+    pub fn from_previous_context(
+        previous_context: super::super::super::ConstructTransactionContext,
+        scope: &<DeployGlobalContractAction as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+    ) -> color_eyre::eyre::Result<Self> {
+        let code = std::fs::read(&scope.file_path).wrap_err_with(|| {
+            format!("Failed to open or read the file: {:?}.", &scope.file_path.0,)
+        })?;
+        Ok(Self {
+            context: previous_context,
+            code,
+        })
+    }
+}
+
+#[derive(Debug, EnumDiscriminants, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(input_context = DeployGlobalContractActionContext)]
+#[interactive_clap(output_context = DeployGlobalModeContext)]
+#[strum_discriminants(derive(EnumMessage, EnumIter))]
+#[non_exhaustive]
+/// Choose a global contract deploy mode:
+pub enum DeployGlobalMode {
+    #[strum_discriminants(strum(
+        message = "as-global-hash       - Deploy code as a global contract code hash (immutable)"
+    ))]
+    /// Deploy code as a global contract code hash (immutable)
+    AsGlobalHash(NextCommand),
+    #[strum_discriminants(strum(
+        message = "as-global-account-id - Deploy code as a global contract account ID (mutable)"
+    ))]
+    /// Deploy code as a global contract account ID (mutable)
+    AsGlobalAccountId(NextCommand),
+}
+
+#[derive(Debug, Clone)]
+pub struct DeployGlobalModeContext(super::super::super::ConstructTransactionContext);
+
+impl DeployGlobalModeContext {
+    pub fn from_previous_context(
+        previous_context: DeployGlobalContractActionContext,
+        scope: &<DeployGlobalMode as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+    ) -> color_eyre::eyre::Result<Self> {
+        let action = near_primitives::transaction::Action::DeployGlobalContract(
+            near_primitives::action::DeployGlobalContractAction {
+                code: previous_context.code,
+                deploy_mode: match scope {
+                    DeployGlobalModeDiscriminants::AsGlobalHash => {
+                        near_primitives::action::GlobalContractDeployMode::CodeHash
+                    }
+                    DeployGlobalModeDiscriminants::AsGlobalAccountId => {
+                        near_primitives::action::GlobalContractDeployMode::AccountId
+                    }
+                },
+            },
+        );
+        let mut actions = previous_context.context.actions;
+        actions.push(action);
+        Ok(Self(super::super::super::ConstructTransactionContext {
+            global_context: previous_context.context.global_context,
+            signer_account_id: previous_context.context.signer_account_id,
+            receiver_account_id: previous_context.context.receiver_account_id,
+            actions,
+        }))
+    }
+}
+
+impl From<DeployGlobalModeContext> for super::super::super::ConstructTransactionContext {
+    fn from(item: DeployGlobalModeContext) -> Self {
+        item.0
+    }
+}
+
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(context = DeployGlobalModeContext)]
+pub struct NextCommand {
+    #[interactive_clap(subcommand)]
+    next_action: super::super::super::add_action_3::NextAction,
+}

--- a/src/commands/transaction/construct_transaction/add_action_2/add_action/mod.rs
+++ b/src/commands/transaction/construct_transaction/add_action_2/add_action/mod.rs
@@ -6,8 +6,10 @@ mod create_account;
 mod delete_account;
 mod delete_key;
 mod deploy_contract;
+mod deploy_global_contract;
 mod stake;
 mod transfer;
+mod use_global_contract;
 
 #[derive(Debug, Clone, interactive_clap::InteractiveClap)]
 #[interactive_clap(context = super::super::ConstructTransactionContext)]
@@ -22,35 +24,43 @@ pub struct AddAction {
 /// Select an action that you want to add to the action:
 pub enum ActionSubcommand {
     #[strum_discriminants(strum(
-        message = "transfer             - The transfer is carried out in NEAR tokens"
+        message = "transfer               - The transfer is carried out in NEAR tokens"
     ))]
     /// Specify data for transfer tokens
     Transfer(self::transfer::TransferAction),
     #[strum_discriminants(strum(
-        message = "function-call        - Execute function (contract method)"
+        message = "function-call          - Execute function (contract method)"
     ))]
     /// Specify data to call the function
     FunctionCall(self::call_function::FunctionCallAction),
-    #[strum_discriminants(strum(message = "stake                - Stake NEAR Tokens"))]
+    #[strum_discriminants(strum(message = "stake                  - Stake NEAR Tokens"))]
     /// Specify data to stake NEAR Tokens
     Stake(self::stake::StakeAction),
-    #[strum_discriminants(strum(message = "create-account       - Create a new sub-account"))]
+    #[strum_discriminants(strum(message = "create-account         - Create a new sub-account"))]
     /// Specify data to create a sub-account
     CreateAccount(self::create_account::CreateAccountAction),
-    #[strum_discriminants(strum(message = "delete-account       - Delete an account"))]
+    #[strum_discriminants(strum(message = "delete-account         - Delete an account"))]
     /// Specify data to delete an account
     DeleteAccount(self::delete_account::DeleteAccountAction),
     #[strum_discriminants(strum(
-        message = "add-key              - Add an access key to an account"
+        message = "add-key                - Add an access key to an account"
     ))]
     /// Specify the data to add an access key to the account
     AddKey(self::add_key::AddKeyAction),
     #[strum_discriminants(strum(
-        message = "delete-key           - Delete an access key from an account"
+        message = "delete-key             - Delete an access key from an account"
     ))]
     /// Specify the data to delete the access key to the account
     DeleteKey(self::delete_key::DeleteKeyAction),
-    #[strum_discriminants(strum(message = "deploy               - Add a new contract code"))]
+    #[strum_discriminants(strum(message = "deploy                 - Add a new contract code"))]
     /// Specify the details to deploy the contract code
     DeployContract(self::deploy_contract::DeployContractAction),
+    #[strum_discriminants(strum(
+        message = "deploy-global-contract - Add a new global contract code"
+    ))]
+    /// Specify the details to deploy the global contract code
+    DeployGlobalContract(self::deploy_global_contract::DeployGlobalContractAction),
+    #[strum_discriminants(strum(message = "use-global-contract    - Use a global contract"))]
+    /// Specify the details to use the global contract
+    UseGlobalContract(self::use_global_contract::UseGlobalContractAction),
 }

--- a/src/commands/transaction/construct_transaction/add_action_2/add_action/use_global_contract/mod.rs
+++ b/src/commands/transaction/construct_transaction/add_action_2/add_action/use_global_contract/mod.rs
@@ -1,0 +1,121 @@
+use strum::{EnumDiscriminants, EnumIter, EnumMessage};
+
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(context = super::super::super::ConstructTransactionContext)]
+pub struct UseGlobalContractAction {
+    #[interactive_clap(subcommand)]
+    mode: UseGlobalActionMode,
+}
+
+#[derive(Debug, EnumDiscriminants, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(context = super::super::super::ConstructTransactionContext)]
+#[strum_discriminants(derive(EnumMessage, EnumIter))]
+#[non_exhaustive]
+/// Choose a global contract deploy mode:
+pub enum UseGlobalActionMode {
+    #[strum_discriminants(strum(
+        message = "as-global-hash       - Deploy code as a global contract code hash (immutable)"
+    ))]
+    /// Deploy code as a global contract code hash (immutable)
+    AsGlobalHash(UseHashAction),
+    #[strum_discriminants(strum(
+        message = "as-global-account-id - Deploy code as a global contract account ID (mutable)"
+    ))]
+    /// Deploy code as a global contract account ID (mutable)
+    AsGlobalAccountId(UseAccountIdAction),
+}
+
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(input_context = super::super::super::ConstructTransactionContext)]
+#[interactive_clap(output_context = UseHashActionContext)]
+pub struct UseHashAction {
+    /// What is a hash of the global contract?
+    pub hash: crate::types::crypto_hash::CryptoHash,
+    #[interactive_clap(subcommand)]
+    initialize: super::deploy_contract::initialize_mode::InitializeMode,
+}
+
+#[derive(Debug, Clone)]
+pub struct UseHashActionContext(super::super::super::ConstructTransactionContext);
+
+impl UseHashActionContext {
+    pub fn from_previous_context(
+        previous_context: super::super::super::ConstructTransactionContext,
+        scope: &<UseHashAction as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+    ) -> color_eyre::eyre::Result<Self> {
+        let action = near_primitives::transaction::Action::UseGlobalContract(Box::new(
+            near_primitives::action::UseGlobalContractAction {
+                contract_identifier: near_primitives::action::GlobalContractIdentifier::CodeHash(
+                    scope.hash.into(),
+                ),
+            },
+        ));
+        let mut actions = previous_context.actions;
+        actions.push(action);
+        Ok(Self(super::super::super::ConstructTransactionContext {
+            global_context: previous_context.global_context,
+            signer_account_id: previous_context.signer_account_id,
+            receiver_account_id: previous_context.receiver_account_id,
+            actions,
+        }))
+    }
+}
+impl From<UseHashActionContext> for super::super::super::ConstructTransactionContext {
+    fn from(item: UseHashActionContext) -> Self {
+        item.0
+    }
+}
+
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(input_context = super::super::super::ConstructTransactionContext)]
+#[interactive_clap(output_context = UseAccountIdActionContext)]
+pub struct UseAccountIdAction {
+    #[interactive_clap(skip_default_input_arg)]
+    /// What is a account ID of the global contract?
+    pub account_id: crate::types::account_id::AccountId,
+    #[interactive_clap(subcommand)]
+    initialize: super::deploy_contract::initialize_mode::InitializeMode,
+}
+
+impl UseAccountIdAction {
+    pub fn input_account_id(
+        context: &super::super::super::ConstructTransactionContext,
+    ) -> color_eyre::eyre::Result<Option<crate::types::account_id::AccountId>> {
+        crate::common::input_signer_account_id_from_used_account_list(
+            &context.global_context.config.credentials_home_dir,
+            "What is a account ID of the global contract?",
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct UseAccountIdActionContext(super::super::super::ConstructTransactionContext);
+
+impl UseAccountIdActionContext {
+    pub fn from_previous_context(
+        previous_context: super::super::super::ConstructTransactionContext,
+        scope: &<UseAccountIdAction as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+    ) -> color_eyre::eyre::Result<Self> {
+        let action = near_primitives::transaction::Action::UseGlobalContract(Box::new(
+            near_primitives::action::UseGlobalContractAction {
+                contract_identifier: near_primitives::action::GlobalContractIdentifier::AccountId(
+                    scope.account_id.clone().into(),
+                ),
+            },
+        ));
+        let mut actions = previous_context.actions;
+        actions.push(action);
+        Ok(Self(super::super::super::ConstructTransactionContext {
+            global_context: previous_context.global_context,
+            signer_account_id: previous_context.signer_account_id,
+            receiver_account_id: previous_context.receiver_account_id,
+            actions,
+        }))
+    }
+}
+
+impl From<UseAccountIdActionContext> for super::super::super::ConstructTransactionContext {
+    fn from(item: UseAccountIdActionContext) -> Self {
+        item.0
+    }
+}

--- a/src/commands/transaction/construct_transaction/add_action_3/add_action/deploy_contract/initialize_mode/mod.rs
+++ b/src/commands/transaction/construct_transaction/add_action_3/add_action/deploy_contract/initialize_mode/mod.rs
@@ -1,7 +1,7 @@
 use strum::{EnumDiscriminants, EnumIter, EnumMessage};
 
 #[derive(Debug, Clone, EnumDiscriminants, interactive_clap_derive::InteractiveClap)]
-#[interactive_clap(context = super::ContractFileContext)]
+#[interactive_clap(context = super::super::super::super::ConstructTransactionContext)]
 #[strum_discriminants(derive(EnumMessage, EnumIter))]
 /// Select the need for initialization:
 pub enum InitializeMode {
@@ -14,7 +14,7 @@ pub enum InitializeMode {
 }
 
 #[derive(Debug, Clone, interactive_clap::InteractiveClap)]
-#[interactive_clap(context = super::ContractFileContext)]
+#[interactive_clap(context = super::super::super::super::ConstructTransactionContext)]
 pub struct NoInitialize {
     #[interactive_clap(subcommand)]
     next_action: super::super::super::super::add_action_last::NextAction,

--- a/src/commands/transaction/construct_transaction/add_action_3/add_action/deploy_contract/mod.rs
+++ b/src/commands/transaction/construct_transaction/add_action_3/add_action/deploy_contract/mod.rs
@@ -1,6 +1,6 @@
 use color_eyre::eyre::Context;
 
-mod initialize_mode;
+pub mod initialize_mode;
 
 #[derive(Debug, Clone, interactive_clap::InteractiveClap)]
 #[interactive_clap(context = super::super::super::ConstructTransactionContext)]

--- a/src/commands/transaction/construct_transaction/add_action_3/add_action/deploy_global_contract/mod.rs
+++ b/src/commands/transaction/construct_transaction/add_action_3/add_action/deploy_global_contract/mod.rs
@@ -1,0 +1,97 @@
+use color_eyre::eyre::Context;
+use strum::{EnumDiscriminants, EnumIter, EnumMessage};
+
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(input_context = super::super::super::ConstructTransactionContext)]
+#[interactive_clap(output_context = DeployGlobalContractActionContext)]
+pub struct DeployGlobalContractAction {
+    /// What is a file location of the contract?
+    pub file_path: crate::types::path_buf::PathBuf,
+    #[interactive_clap(subcommand)]
+    mode: DeployGlobalMode,
+}
+
+#[derive(Debug, Clone)]
+pub struct DeployGlobalContractActionContext {
+    pub context: super::super::super::ConstructTransactionContext,
+    pub code: Vec<u8>,
+}
+
+impl DeployGlobalContractActionContext {
+    pub fn from_previous_context(
+        previous_context: super::super::super::ConstructTransactionContext,
+        scope: &<DeployGlobalContractAction as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+    ) -> color_eyre::eyre::Result<Self> {
+        let code = std::fs::read(&scope.file_path).wrap_err_with(|| {
+            format!("Failed to open or read the file: {:?}.", &scope.file_path.0,)
+        })?;
+        Ok(Self {
+            context: previous_context,
+            code,
+        })
+    }
+}
+
+#[derive(Debug, EnumDiscriminants, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(input_context = DeployGlobalContractActionContext)]
+#[interactive_clap(output_context = DeployGlobalModeContext)]
+#[strum_discriminants(derive(EnumMessage, EnumIter))]
+#[non_exhaustive]
+/// Choose a global contract deploy mode:
+pub enum DeployGlobalMode {
+    #[strum_discriminants(strum(
+        message = "as-global-hash       - Deploy code as a global contract code hash (immutable)"
+    ))]
+    /// Deploy code as a global contract code hash (immutable)
+    AsGlobalHash(NextCommand),
+    #[strum_discriminants(strum(
+        message = "as-global-account-id - Deploy code as a global contract account ID (mutable)"
+    ))]
+    /// Deploy code as a global contract account ID (mutable)
+    AsGlobalAccountId(NextCommand),
+}
+
+#[derive(Debug, Clone)]
+pub struct DeployGlobalModeContext(super::super::super::ConstructTransactionContext);
+
+impl DeployGlobalModeContext {
+    pub fn from_previous_context(
+        previous_context: DeployGlobalContractActionContext,
+        scope: &<DeployGlobalMode as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+    ) -> color_eyre::eyre::Result<Self> {
+        let action = near_primitives::transaction::Action::DeployGlobalContract(
+            near_primitives::action::DeployGlobalContractAction {
+                code: previous_context.code,
+                deploy_mode: match scope {
+                    DeployGlobalModeDiscriminants::AsGlobalHash => {
+                        near_primitives::action::GlobalContractDeployMode::CodeHash
+                    }
+                    DeployGlobalModeDiscriminants::AsGlobalAccountId => {
+                        near_primitives::action::GlobalContractDeployMode::AccountId
+                    }
+                },
+            },
+        );
+        let mut actions = previous_context.context.actions;
+        actions.push(action);
+        Ok(Self(super::super::super::ConstructTransactionContext {
+            global_context: previous_context.context.global_context,
+            signer_account_id: previous_context.context.signer_account_id,
+            receiver_account_id: previous_context.context.receiver_account_id,
+            actions,
+        }))
+    }
+}
+
+impl From<DeployGlobalModeContext> for super::super::super::ConstructTransactionContext {
+    fn from(item: DeployGlobalModeContext) -> Self {
+        item.0
+    }
+}
+
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(context = DeployGlobalModeContext)]
+pub struct NextCommand {
+    #[interactive_clap(subcommand)]
+    next_action: super::super::super::add_action_last::NextAction,
+}

--- a/src/commands/transaction/construct_transaction/add_action_3/add_action/mod.rs
+++ b/src/commands/transaction/construct_transaction/add_action_3/add_action/mod.rs
@@ -6,9 +6,10 @@ mod create_account;
 mod delete_account;
 mod delete_key;
 mod deploy_contract;
+mod deploy_global_contract;
 mod stake;
 mod transfer;
-
+mod use_global_contract;
 #[derive(Debug, Clone, interactive_clap::InteractiveClap)]
 #[interactive_clap(context = super::super::ConstructTransactionContext)]
 pub struct AddAction {
@@ -22,35 +23,43 @@ pub struct AddAction {
 /// Select an action that you want to add to the action:
 pub enum ActionSubcommand {
     #[strum_discriminants(strum(
-        message = "transfer             - The transfer is carried out in NEAR tokens"
+        message = "transfer               - The transfer is carried out in NEAR tokens"
     ))]
     /// Specify data for transfer tokens
     Transfer(self::transfer::TransferAction),
     #[strum_discriminants(strum(
-        message = "function-call        - Execute function (contract method)"
+        message = "function-call          - Execute function (contract method)"
     ))]
     /// Specify data to call the function
     FunctionCall(self::call_function::FunctionCallAction),
-    #[strum_discriminants(strum(message = "stake                - Stake NEAR Tokens"))]
+    #[strum_discriminants(strum(message = "stake                  - Stake NEAR Tokens"))]
     /// Specify data to stake NEAR Tokens
     Stake(self::stake::StakeAction),
-    #[strum_discriminants(strum(message = "create-account       - Create a new sub-account"))]
+    #[strum_discriminants(strum(message = "create-account         - Create a new sub-account"))]
     /// Specify data to create a sub-account
     CreateAccount(self::create_account::CreateAccountAction),
-    #[strum_discriminants(strum(message = "delete-account       - Delete an account"))]
+    #[strum_discriminants(strum(message = "delete-account         - Delete an account"))]
     /// Specify data to delete an account
     DeleteAccount(self::delete_account::DeleteAccountAction),
     #[strum_discriminants(strum(
-        message = "add-key              - Add an access key to an account"
+        message = "add-key                - Add an access key to an account"
     ))]
     /// Specify the data to add an access key to the account
     AddKey(self::add_key::AddKeyAction),
     #[strum_discriminants(strum(
-        message = "delete-key           - Delete an access key from an account"
+        message = "delete-key             - Delete an access key from an account"
     ))]
     /// Specify the data to delete the access key to the account
     DeleteKey(self::delete_key::DeleteKeyAction),
-    #[strum_discriminants(strum(message = "deploy               - Add a new contract code"))]
+    #[strum_discriminants(strum(message = "deploy                 - Add a new contract code"))]
     /// Specify the details to deploy the contract code
     DeployContract(self::deploy_contract::DeployContractAction),
+    #[strum_discriminants(strum(
+        message = "deploy-global-contract - Add a new global contract code"
+    ))]
+    /// Specify the details to deploy the global contract code
+    DeployGlobalContract(self::deploy_global_contract::DeployGlobalContractAction),
+    #[strum_discriminants(strum(message = "use-global-contract    - Use a global contract"))]
+    /// Specify the details to use the global contract
+    UseGlobalContract(self::use_global_contract::UseGlobalContractAction),
 }

--- a/src/commands/transaction/construct_transaction/add_action_3/add_action/use_global_contract/mod.rs
+++ b/src/commands/transaction/construct_transaction/add_action_3/add_action/use_global_contract/mod.rs
@@ -1,0 +1,121 @@
+use strum::{EnumDiscriminants, EnumIter, EnumMessage};
+
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(context = super::super::super::ConstructTransactionContext)]
+pub struct UseGlobalContractAction {
+    #[interactive_clap(subcommand)]
+    mode: UseGlobalActionMode,
+}
+
+#[derive(Debug, EnumDiscriminants, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(context = super::super::super::ConstructTransactionContext)]
+#[strum_discriminants(derive(EnumMessage, EnumIter))]
+#[non_exhaustive]
+/// Choose a global contract deploy mode:
+pub enum UseGlobalActionMode {
+    #[strum_discriminants(strum(
+        message = "as-global-hash       - Deploy code as a global contract code hash (immutable)"
+    ))]
+    /// Deploy code as a global contract code hash (immutable)
+    AsGlobalHash(UseHashAction),
+    #[strum_discriminants(strum(
+        message = "as-global-account-id - Deploy code as a global contract account ID (mutable)"
+    ))]
+    /// Deploy code as a global contract account ID (mutable)
+    AsGlobalAccountId(UseAccountIdAction),
+}
+
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(input_context = super::super::super::ConstructTransactionContext)]
+#[interactive_clap(output_context = UseHashActionContext)]
+pub struct UseHashAction {
+    /// What is a hash of the global contract?
+    pub hash: crate::types::crypto_hash::CryptoHash,
+    #[interactive_clap(subcommand)]
+    initialize: super::deploy_contract::initialize_mode::InitializeMode,
+}
+
+#[derive(Debug, Clone)]
+pub struct UseHashActionContext(super::super::super::ConstructTransactionContext);
+
+impl UseHashActionContext {
+    pub fn from_previous_context(
+        previous_context: super::super::super::ConstructTransactionContext,
+        scope: &<UseHashAction as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+    ) -> color_eyre::eyre::Result<Self> {
+        let action = near_primitives::transaction::Action::UseGlobalContract(Box::new(
+            near_primitives::action::UseGlobalContractAction {
+                contract_identifier: near_primitives::action::GlobalContractIdentifier::CodeHash(
+                    scope.hash.into(),
+                ),
+            },
+        ));
+        let mut actions = previous_context.actions;
+        actions.push(action);
+        Ok(Self(super::super::super::ConstructTransactionContext {
+            global_context: previous_context.global_context,
+            signer_account_id: previous_context.signer_account_id,
+            receiver_account_id: previous_context.receiver_account_id,
+            actions,
+        }))
+    }
+}
+impl From<UseHashActionContext> for super::super::super::ConstructTransactionContext {
+    fn from(item: UseHashActionContext) -> Self {
+        item.0
+    }
+}
+
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(input_context = super::super::super::ConstructTransactionContext)]
+#[interactive_clap(output_context = UseAccountIdActionContext)]
+pub struct UseAccountIdAction {
+    #[interactive_clap(skip_default_input_arg)]
+    /// What is a account ID of the global contract?
+    pub account_id: crate::types::account_id::AccountId,
+    #[interactive_clap(subcommand)]
+    initialize: super::deploy_contract::initialize_mode::InitializeMode,
+}
+
+impl UseAccountIdAction {
+    pub fn input_account_id(
+        context: &super::super::super::ConstructTransactionContext,
+    ) -> color_eyre::eyre::Result<Option<crate::types::account_id::AccountId>> {
+        crate::common::input_signer_account_id_from_used_account_list(
+            &context.global_context.config.credentials_home_dir,
+            "What is a account ID of the global contract?",
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct UseAccountIdActionContext(super::super::super::ConstructTransactionContext);
+
+impl UseAccountIdActionContext {
+    pub fn from_previous_context(
+        previous_context: super::super::super::ConstructTransactionContext,
+        scope: &<UseAccountIdAction as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+    ) -> color_eyre::eyre::Result<Self> {
+        let action = near_primitives::transaction::Action::UseGlobalContract(Box::new(
+            near_primitives::action::UseGlobalContractAction {
+                contract_identifier: near_primitives::action::GlobalContractIdentifier::AccountId(
+                    scope.account_id.clone().into(),
+                ),
+            },
+        ));
+        let mut actions = previous_context.actions;
+        actions.push(action);
+        Ok(Self(super::super::super::ConstructTransactionContext {
+            global_context: previous_context.global_context,
+            signer_account_id: previous_context.signer_account_id,
+            receiver_account_id: previous_context.receiver_account_id,
+            actions,
+        }))
+    }
+}
+
+impl From<UseAccountIdActionContext> for super::super::super::ConstructTransactionContext {
+    fn from(item: UseAccountIdActionContext) -> Self {
+        item.0
+    }
+}


### PR DESCRIPTION
* Extended action builder for DeployGlobalContract and UseGlobalContract actions introduced by nearcore-2.5.0 release
* Implemented todo related to transaction reconstruction

```bash
# Constructing transactions using action builder:
./target/release/near transaction construct-transaction round-toad.testnet round-toad.testnet 
      add-action use-global-contract as-global-account-id yurtur2.near without-init-call
      add-action deploy-global-contract ./code.wasm as-global-account-id 
      add-action deploy-global-contract ./code.wasm as-global-hash
```
![image](https://github.com/user-attachments/assets/933ec8e5-e25b-4d0c-96a4-87aeb8b398c6)


@race-of-sloths