### PR TITLE
chore: release v0.19.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.1](https://github.com/near/near-cli-rs/compare/v0.19.0...v0.19.1) - 2025-04-10
+
+### Added
+
+- Added new command "get public key from plaintext private key" ([#466](https://github.com/near/near-cli-rs/pull/466))
+- Use free ARM64 GitHub Action runners for pre-built binaries ([#454](https://github.com/near/near-cli-rs/pull/454))
+
+### Fixed
+
+- allow forks to leverage transfer-to-project workflow ([#464](https://github.com/near/near-cli-rs/pull/464))
+
+### Other
+
+- updated GUIDE ([#469](https://github.com/near/near-cli-rs/pull/469))
+- Updated CI secret name in the devtools pipeline ([#460](https://github.com/near/near-cli-rs/pull/460))
+
 ## [0.19.0](https://github.com/near/near-cli-rs/compare/v0.18.0...v0.19.0) - 2025-03-12
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2071,7 +2071,7 @@ dependencies = [
 
 [[package]]
 name = "near-cli-rs"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "bip39",
  "bs58 0.5.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-cli-rs"
-version = "0.19.0"
+version = "0.19.1"
 authors = ["FroVolod <frol_off@meta.ua>", "Near Inc <hello@nearprotocol.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION



## 🤖 New release

* `near-cli-rs`: 0.19.0 -> 0.19.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.19.1](https://github.com/near/near-cli-rs/compare/v0.19.0...v0.19.1) - 2025-04-10

### Added

- Added new command "get public key from plaintext private key" ([#466](https://github.com/near/near-cli-rs/pull/466))
- Use free ARM64 GitHub Action runners for pre-built binaries ([#454](https://github.com/near/near-cli-rs/pull/454))

### Fixed

- allow forks to leverage transfer-to-project workflow ([#464](https://github.com/near/near-cli-rs/pull/464))

### Other

- updated GUIDE ([#469](https://github.com/near/near-cli-rs/pull/469))
- Updated CI secret name in the devtools pipeline ([#460](https://github.com/near/near-cli-rs/pull/460))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).