### PR TITLE
fix: Fixed cli command `near tokens send-ft` without `memo`

### DIFF
--- a/src/commands/tokens/send_ft/amount_ft.rs
+++ b/src/commands/tokens/send_ft/amount_ft.rs
@@ -247,7 +247,7 @@ impl FtTransferParams {
     fn input_memo(_context: &AmountFtContext) -> color_eyre::eyre::Result<Option<String>> {
         let input = Text::new("Enter a memo for transfer (optional):").prompt()?;
         Ok(if input.trim().is_empty() {
-            None
+            Some(String::new())
         } else {
             Some(input)
         })

--- a/src/commands/tokens/send_ft/amount_ft.rs
+++ b/src/commands/tokens/send_ft/amount_ft.rs
@@ -245,11 +245,8 @@ impl From<FtTransferParamsContext> for crate::commands::ActionContext {
 
 impl FtTransferParams {
     fn input_memo(_context: &AmountFtContext) -> color_eyre::eyre::Result<Option<String>> {
-        let input = Text::new("Enter a memo for transfer (optional):").prompt()?;
-        Ok(if input.trim().is_empty() {
-            Some(String::new())
-        } else {
-            Some(input)
-        })
+        Ok(Some(
+            Text::new("Enter a memo for transfer (optional):").prompt()?,
+        ))
     }
 }


### PR DESCRIPTION
Resolves #472 

This fixed the generated command:
```
Here is your console command if you need to script it or re-run:
    near tokens slimedragon.near send-ft spear-1565.meme-cooking.near slimedragon.near '1 spear' memo network-config mainnet sign-with-keychain send
```
to:
```
Here is your console command if you need to script it or re-run:
    near tokens slimedragon.near send-ft spear-1565.meme-cooking.near slimedragon.near '1 spear' memo '' network-config mainnet sign-with-keychain send
```