### PR TITLE
bugfix: fixed reconstruction of transaction from contract deploy

### DIFF
--- a/src/commands/contract/download_wasm/mod.rs
+++ b/src/commands/contract/download_wasm/mod.rs
@@ -110,6 +110,24 @@ fn download_contract_code(
     network_config: &crate::config::NetworkConfig,
     block_reference: near_primitives::types::BlockReference,
 ) -> crate::CliResult {
+    let code = get_code(account_id, network_config, block_reference)?;
+    std::fs::File::create(file_path)
+        .wrap_err_with(|| format!("Failed to create file: {:?}", file_path))?
+        .write(&code)
+        .wrap_err_with(|| format!("Failed to write to file: {:?}", file_path))?;
+    tracing::info!(
+        parent: &tracing::Span::none(),
+        "The file {:?} was downloaded successfully",
+        file_path
+    );
+    Ok(())
+}
+
+pub fn get_code(
+    account_id: &near_primitives::types::AccountId,
+    network_config: &crate::config::NetworkConfig,
+    block_reference: near_primitives::types::BlockReference,
+) -> color_eyre::eyre::Result<Vec<u8>> {
     let query_view_method_response = network_config
         .json_rpc_client()
         .blocking_call(near_jsonrpc_client::methods::query::RpcQueryRequest {
@@ -132,14 +150,5 @@ fn download_contract_code(
         } else {
             return Err(color_eyre::Report::msg("Error call result".to_string()));
         };
-    std::fs::File::create(file_path)
-        .wrap_err_with(|| format!("Failed to create file: {:?}", file_path))?
-        .write(&call_access_view.code)
-        .wrap_err_with(|| format!("Failed to write to file: {:?}", file_path))?;
-    tracing::info!(
-        parent: &tracing::Span::none(),
-        "The file {:?} was downloaded successfully",
-        file_path
-    );
-    Ok(())
+    Ok(call_access_view.code)
 }

--- a/src/commands/contract/download_wasm/mod.rs
+++ b/src/commands/contract/download_wasm/mod.rs
@@ -103,7 +103,6 @@ impl DownloadContract {
     }
 }
 
-#[tracing::instrument(name = "Download contract code ...", skip_all)]
 fn download_contract_code(
     account_id: &near_primitives::types::AccountId,
     file_path: &std::path::PathBuf,
@@ -123,6 +122,7 @@ fn download_contract_code(
     Ok(())
 }
 
+#[tracing::instrument(name = "Download contract code ...", skip_all)]
 pub fn get_code(
     account_id: &near_primitives::types::AccountId,
     network_config: &crate::config::NetworkConfig,

--- a/src/commands/contract/mod.rs
+++ b/src/commands/contract/mod.rs
@@ -4,7 +4,7 @@ pub mod call_function;
 pub mod deploy;
 pub mod deploy_global;
 mod download_abi;
-mod download_wasm;
+pub mod download_wasm;
 mod inspect;
 mod view_storage;
 

--- a/src/commands/transaction/reconstruct_transaction/mod.rs
+++ b/src/commands/transaction/reconstruct_transaction/mod.rs
@@ -97,7 +97,7 @@ impl TransactionInfoContext {
                             add_action_1::add_action::CliAddAction {
                                 action: action_transformation(
                                     transaction_action,
-                                    prepopulated_transaction.receiver_id.clone().into(),
+                                    prepopulated_transaction.receiver_id.clone(),
                                     network_config,
                                     near_primitives::types::BlockReference::BlockId(
                                         near_primitives::types::BlockId::Hash(
@@ -226,7 +226,7 @@ fn action_transformation(
             if code_hash.0 != deploy_contract_action.code.as_slice() {
                 return Err(color_eyre::Report::msg("The code hash of the contract deploy action does not match the code that we retrieved from the archive node.".to_string()));
             }
-            
+
             std::fs::write(
                 "reconstruct-transaction-deploy-code.wasm",
                 code

--- a/src/commands/transaction/reconstruct_transaction/mod.rs
+++ b/src/commands/transaction/reconstruct_transaction/mod.rs
@@ -29,7 +29,7 @@ impl TransactionInfoContext {
             std::sync::Arc::new({
                 let tx_hash: near_primitives::hash::CryptoHash = scope.transaction_hash.into();
 
-                move |network_config| {
+                move |network_config: &crate::config::NetworkConfig| {
                     let query_view_transaction_status = super::view_status::get_transaction_info(network_config, tx_hash)?
                         .final_execution_outcome
                         .wrap_err_with(|| {
@@ -84,7 +84,7 @@ impl TransactionInfoContext {
                                         prepopulated_transaction.signer_id.into(),
                                     ),
                                     receiver_account_id: Some(
-                                        prepopulated_transaction.receiver_id.into(),
+                                        prepopulated_transaction.receiver_id.clone().into(),
                                     ),
                                     next_actions: None,
                                 },
@@ -95,7 +95,18 @@ impl TransactionInfoContext {
                     for transaction_action in prepopulated_transaction.actions {
                         let next_actions = add_action_1::CliNextAction::AddAction(
                             add_action_1::add_action::CliAddAction {
-                                action: action_transformation(transaction_action)?,
+                                action: action_transformation(
+                                    transaction_action,
+                                    prepopulated_transaction.receiver_id.clone().into(),
+                                    network_config,
+                                    near_primitives::types::BlockReference::BlockId(
+                                        near_primitives::types::BlockId::Hash(
+                                            query_view_transaction_status
+                                                .transaction_outcome
+                                                .block_hash,
+                                        ),
+                                    ),
+                                )?,
                             },
                         );
                         cmd_cli_args.extend(next_actions.to_cli_args());
@@ -150,6 +161,9 @@ impl From<TransactionInfoContext> for crate::network::NetworkContext {
 
 fn action_transformation(
     archival_action: near_primitives::transaction::Action,
+    receiver_id: near_primitives::types::AccountId,
+    network_config: &crate::config::NetworkConfig,
+    block_reference: near_primitives::types::BlockReference,
 ) -> color_eyre::eyre::Result<
     Option<super::construct_transaction::add_action_1::add_action::CliActionSubcommand>,
 > {
@@ -197,9 +211,25 @@ fn action_transformation(
             )))
         }
         Action::DeployContract(deploy_contract_action) => {
+            // Unfortunately, RPC doesn't return the code for the deployed contract. Only the hash.
+            // So we need to fetch it from archive node.
+
+            let code = crate::commands::contract::download_wasm::get_code(
+                &receiver_id,
+                network_config,
+                block_reference
+            ).map_err(|e| {
+                color_eyre::Report::msg(format!("Couldn't fetch the code. Please use the archival node to fetch the code. Error: {}", e))
+            })?;
+
+            let code_hash = near_primitives::hash::CryptoHash::hash_bytes(&code);
+            if code_hash.0 != deploy_contract_action.code.as_slice() {
+                return Err(color_eyre::Report::msg("The code hash of the contract deploy action does not match the code that we retrieved from the archive node.".to_string()));
+            }
+            
             std::fs::write(
                 "reconstruct-transaction-deploy-code.wasm",
-                deploy_contract_action.code
+                code
             )
             .wrap_err("Failed to write the deploy command code to file: 'reconstruct-transaction-deploy-code.wasm' in the current folder")?;
             Ok(Some(add_action::CliActionSubcommand::DeployContract(


### PR DESCRIPTION
The RPC stopped providing the code at some point and started to provide only a hash of the contract. This resolves the issue and loads the code manually

@race-of-sloths