### PR TITLE
chore: release v0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.0](https://github.com/near/near-cli-rs/compare/v0.19.0...v0.20.0) - 2025-05-13
+
+### Added
+
+- display global contracts info on account details query ([#483](https://github.com/near/near-cli-rs/pull/483))
+- extended action builder with new released items ([#457](https://github.com/near/near-cli-rs/pull/457))
+- deploy and use global contracts from UI excluding action builder. ([#456](https://github.com/near/near-cli-rs/pull/456))
+- Do not require to explicitly provide public key during signing transactions with a plaintext private key (we can always extract it from the private key) ([#468](https://github.com/near/near-cli-rs/pull/468))
+- Added new command "get public key from plaintext private key" ([#466](https://github.com/near/near-cli-rs/pull/466))
+- Use free ARM64 GitHub Action runners for pre-built binaries ([#454](https://github.com/near/near-cli-rs/pull/454))
+
+### Fixed
+
+- Fixed returning the result of a function call ([#462](https://github.com/near/near-cli-rs/pull/462))
+- Fixed canceling the CLI operation in retry prompts ([#478](https://github.com/near/near-cli-rs/pull/478))
+- Fixed cli command `near tokens send-ft` without `memo` ([#474](https://github.com/near/near-cli-rs/pull/474))
+- allow forks to leverage transfer-to-project workflow ([#464](https://github.com/near/near-cli-rs/pull/464))
+
+### Other
+
+- removed unsupported reconstruction for DeployGlobalContract ([#484](https://github.com/near/near-cli-rs/pull/484))
+- [**breaking**] updates near-* dependencies to 0.30 release ([#481](https://github.com/near/near-cli-rs/pull/481))
+- fixed reconstruction of transaction from contract deploy ([#476](https://github.com/near/near-cli-rs/pull/476))
+- Refactored 'send-ft memo' command from using Option<String> to just String ([#477](https://github.com/near/near-cli-rs/pull/477))
+- Replaced Linux x86-64 ubuntu-20.04 build environment with ubuntu-22.04 as 20.04 reached its end of life, so minimal supported glibc for pre-built binaries is now 2.35 - Linux users with older glibc will have to install CLIs from the source code or update their OS ([#470](https://github.com/near/near-cli-rs/pull/470))
+- updated GUIDE ([#469](https://github.com/near/near-cli-rs/pull/469))
+- Updated CI secret name in the devtools pipeline ([#460](https://github.com/near/near-cli-rs/pull/460))
+
 ## [0.19.0](https://github.com/near/near-cli-rs/compare/v0.18.0...v0.19.0) - 2025-03-12
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2055,7 +2055,7 @@ dependencies = [
 
 [[package]]
 name = "near-cli-rs"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "bip39",
  "bs58 0.5.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-cli-rs"
-version = "0.19.0"
+version = "0.20.0"
 authors = ["FroVolod <frol_off@meta.ua>", "Near Inc <hello@nearprotocol.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION



## 🤖 New release

* `near-cli-rs`: 0.19.0 -> 0.20.0 (⚠ API breaking changes)

### ⚠ `near-cli-rs` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field CliContract.deploy_mode in /tmp/.tmpg27DR7/near-cli-rs/src/commands/contract/deploy/mod.rs:6

--- failure derive_trait_impl_removed: built-in derived trait no longer implemented ---

Description:
A public type has stopped deriving one or more traits. This can break downstream code that depends on those types implementing those traits.
        ref: https://doc.rust-lang.org/reference/attributes/derive.html#derive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/derive_trait_impl_removed.ron

Failed in:
  type ContractFileContext no longer derives Debug, in /tmp/.tmpg27DR7/near-cli-rs/src/commands/contract/deploy/mod.rs:92
  type ContractFileContext no longer derives Clone, in /tmp/.tmpg27DR7/near-cli-rs/src/commands/contract/deploy/mod.rs:92

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_missing.ron

Failed in:
  enum near_cli_rs::commands::contract::deploy::ClapNamedArgContractFileForContract, previously in file /tmp/.tmporyarC/near-cli-rs/src/commands/contract/deploy/mod.rs:5

--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant ContractActionsDiscriminants::Inspect 2 -> 3 in /tmp/.tmpg27DR7/near-cli-rs/src/commands/contract/mod.rs:43
  variant ContractActionsDiscriminants::DownloadAbi 3 -> 4 in /tmp/.tmpg27DR7/near-cli-rs/src/commands/contract/mod.rs:46
  variant ContractActionsDiscriminants::DownloadWasm 4 -> 5 in /tmp/.tmpg27DR7/near-cli-rs/src/commands/contract/mod.rs:49
  variant ContractActionsDiscriminants::ViewStorage 5 -> 6 in /tmp/.tmpg27DR7/near-cli-rs/src/commands/contract/mod.rs:52
  variant ContractActionsDiscriminants::Inspect 2 -> 3 in /tmp/.tmpg27DR7/near-cli-rs/src/commands/contract/mod.rs:43
  variant ContractActionsDiscriminants::DownloadAbi 3 -> 4 in /tmp/.tmpg27DR7/near-cli-rs/src/commands/contract/mod.rs:46
  variant ContractActionsDiscriminants::DownloadWasm 4 -> 5 in /tmp/.tmpg27DR7/near-cli-rs/src/commands/contract/mod.rs:49
  variant ContractActionsDiscriminants::ViewStorage 5 -> 6 in /tmp/.tmpg27DR7/near-cli-rs/src/commands/contract/mod.rs:52

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_variant_added.ron

Failed in:
  variant ContractActionsDiscriminants:DeployAsGlobal in /tmp/.tmpg27DR7/near-cli-rs/src/commands/contract/mod.rs:38
  variant ContractActionsDiscriminants:DeployAsGlobal in /tmp/.tmpg27DR7/near-cli-rs/src/commands/contract/mod.rs:38
  variant CliActionSubcommand:DeployGlobalContract in /tmp/.tmpg27DR7/near-cli-rs/src/commands/transaction/construct_transaction/add_action_1/add_action/mod.rs:20
  variant CliActionSubcommand:UseGlobalContract in /tmp/.tmpg27DR7/near-cli-rs/src/commands/transaction/construct_transaction/add_action_1/add_action/mod.rs:20
  variant ActionSubcommand:DeployGlobalContract in /tmp/.tmpg27DR7/near-cli-rs/src/commands/transaction/construct_transaction/add_action_1/add_action/mod.rs:61
  variant ActionSubcommand:UseGlobalContract in /tmp/.tmpg27DR7/near-cli-rs/src/commands/transaction/construct_transaction/add_action_1/add_action/mod.rs:66
  variant CliContractActions:DeployAsGlobal in /tmp/.tmpg27DR7/near-cli-rs/src/commands/contract/mod.rs:18
  variant ActionSubcommandDiscriminants:DeployGlobalContract in /tmp/.tmpg27DR7/near-cli-rs/src/commands/transaction/construct_transaction/add_action_1/add_action/mod.rs:61
  variant ActionSubcommandDiscriminants:UseGlobalContract in /tmp/.tmpg27DR7/near-cli-rs/src/commands/transaction/construct_transaction/add_action_1/add_action/mod.rs:66
  variant ActionSubcommandDiscriminants:DeployGlobalContract in /tmp/.tmpg27DR7/near-cli-rs/src/commands/transaction/construct_transaction/add_action_1/add_action/mod.rs:61
  variant ActionSubcommandDiscriminants:UseGlobalContract in /tmp/.tmpg27DR7/near-cli-rs/src/commands/transaction/construct_transaction/add_action_1/add_action/mod.rs:66

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field use_file of struct CliContract, previously in file /tmp/.tmporyarC/near-cli-rs/src/commands/contract/deploy/mod.rs:5
  field signer_public_key of struct CliSignPrivateKey, previously in file /tmp/.tmporyarC/near-cli-rs/src/transaction_signature_options/sign_with_private_key/mod.rs:9
  field signer_public_key of struct InteractiveClapContextScopeForSignPrivateKey, previously in file /tmp/.tmporyarC/near-cli-rs/src/transaction_signature_options/sign_with_private_key/mod.rs:9
  field signer_public_key of struct SignPrivateKey, previously in file /tmp/.tmporyarC/near-cli-rs/src/transaction_signature_options/sign_with_private_key/mod.rs:15
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.20.0](https://github.com/near/near-cli-rs/compare/v0.19.0...v0.20.0) - 2025-05-13

### Added

- display global contracts info on account details query ([#483](https://github.com/near/near-cli-rs/pull/483))
- extended action builder with new released items ([#457](https://github.com/near/near-cli-rs/pull/457))
- deploy and use global contracts from UI excluding action builder. ([#456](https://github.com/near/near-cli-rs/pull/456))
- Do not require to explicitly provide public key during signing transactions with a plaintext private key (we can always extract it from the private key) ([#468](https://github.com/near/near-cli-rs/pull/468))
- Added new command "get public key from plaintext private key" ([#466](https://github.com/near/near-cli-rs/pull/466))
- Use free ARM64 GitHub Action runners for pre-built binaries ([#454](https://github.com/near/near-cli-rs/pull/454))

### Fixed

- Fixed returning the result of a function call ([#462](https://github.com/near/near-cli-rs/pull/462))
- Fixed canceling the CLI operation in retry prompts ([#478](https://github.com/near/near-cli-rs/pull/478))
- Fixed cli command `near tokens send-ft` without `memo` ([#474](https://github.com/near/near-cli-rs/pull/474))
- allow forks to leverage transfer-to-project workflow ([#464](https://github.com/near/near-cli-rs/pull/464))

### Other

- removed unsupported reconstruction for DeployGlobalContract ([#484](https://github.com/near/near-cli-rs/pull/484))
- [**breaking**] updates near-* dependencies to 0.30 release ([#481](https://github.com/near/near-cli-rs/pull/481))
- fixed reconstruction of transaction from contract deploy ([#476](https://github.com/near/near-cli-rs/pull/476))
- Refactored 'send-ft memo' command from using Option<String> to just String ([#477](https://github.com/near/near-cli-rs/pull/477))
- Replaced Linux x86-64 ubuntu-20.04 build environment with ubuntu-22.04 as 20.04 reached its end of life, so minimal supported glibc for pre-built binaries is now 2.35 - Linux users with older glibc will have to install CLIs from the source code or update their OS ([#470](https://github.com/near/near-cli-rs/pull/470))
- updated GUIDE ([#469](https://github.com/near/near-cli-rs/pull/469))
- Updated CI secret name in the devtools pipeline ([#460](https://github.com/near/near-cli-rs/pull/460))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).