### PR TITLE
chore: fixed shell configuration for command history

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -2352,6 +2352,7 @@ pub fn input_network_name(
 }
 
 pub trait JsonRpcClientExt {
+    #[allow(clippy::result_large_err)] // temporary workaround for clippy on 1.87 rust toolchain
     fn blocking_call<M>(
         &self,
         method: M,
@@ -2370,6 +2371,7 @@ pub trait JsonRpcClientExt {
         block_reference: near_primitives::types::BlockReference,
     ) -> Result<near_primitives::views::CallResult, color_eyre::eyre::Error>;
 
+    #[allow(clippy::result_large_err)] // temporary workaround for clippy on 1.87 rust toolchain
     fn blocking_call_view_access_key(
         &self,
         account_id: &near_primitives::types::AccountId,
@@ -2382,6 +2384,7 @@ pub trait JsonRpcClientExt {
         >,
     >;
 
+    #[allow(clippy::result_large_err)] // temporary workaround for clippy on 1.87 rust toolchain
     fn blocking_call_view_access_key_list(
         &self,
         account_id: &near_primitives::types::AccountId,
@@ -2393,6 +2396,7 @@ pub trait JsonRpcClientExt {
         >,
     >;
 
+    #[allow(clippy::result_large_err)] // temporary workaround for clippy on 1.87 rust toolchain
     fn blocking_call_view_account(
         &self,
         account_id: &near_primitives::types::AccountId,


### PR DESCRIPTION
This pull requests closes #479 

Resolves the problem with zsh and Fish shell scripts, not being able to write escaped characters properly into history