### PR TITLE
feat: implemented nep-413 offchain messages signing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ openssl = { version = "0.10", features = ["vendored"] }
 
 bip39 = { version = "2.0.0", features = ["rand"] }
 bs58 = "0.5"
+borsh = "1.5.7"
 ed25519-dalek = { version = "2", default-features = false }
 hex = "0.4.2"
 linked-hash-map = { version = "0.5", features = ["serde_impl"] }

--- a/src/commands/account/mod.rs
+++ b/src/commands/account/mod.rs
@@ -4,7 +4,7 @@ mod add_key;
 pub mod create_account;
 mod delete_account;
 mod delete_key;
-mod export_account;
+pub mod export_account;
 mod get_public_key;
 mod import_account;
 mod list_keys;

--- a/src/commands/message/mod.rs
+++ b/src/commands/message/mod.rs
@@ -1,0 +1,23 @@
+use strum::{EnumDiscriminants, EnumIter, EnumMessage};
+
+pub mod sign_nep413;
+
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(context = crate::GlobalContext)]
+pub struct MessageCommand {
+    #[interactive_clap(subcommand)]
+    pub message_actions: MessageActions,
+}
+
+#[derive(Debug, EnumDiscriminants, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(context = crate::GlobalContext)]
+#[strum_discriminants(derive(EnumMessage, EnumIter))]
+#[non_exhaustive]
+/// What do you want to do with a message?
+pub enum MessageActions {
+    #[strum_discriminants(strum(
+        message = "sign-nep413         - Sign a NEP-413 message off-chain"
+    ))]
+    /// Sign a NEP-413 message off-chain
+    SignNep413(self::sign_nep413::SignNep413),
+}

--- a/src/commands/message/sign_nep413/mod.rs
+++ b/src/commands/message/sign_nep413/mod.rs
@@ -1,0 +1,152 @@
+use near_crypto::{SecretKey, Signature};
+use near_primitives::borsh::{self, BorshDeserialize, BorshSerialize};
+use near_primitives::hash::hash;
+use serde::Serialize;
+use strum::{EnumDiscriminants, EnumIter, EnumMessage};
+
+pub mod signature_options;
+
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(input_context = crate::GlobalContext)]
+#[interactive_clap(output_context = SignNep413Context)]
+pub struct SignNep413 {
+    #[interactive_clap(value_enum)]
+    #[interactive_clap(skip_default_input_arg)]
+    /// Message encoding:
+    encoding: MessageEncoding,
+    /// The message to sign:
+    message: String,
+    #[interactive_clap(long)]
+    /// A 32-byte nonce as a base64-encoded string:
+    nonce: crate::types::base64_bytes::Base64Bytes,
+    #[interactive_clap(long)]
+    /// The recipient of the message (e.g. "alice.near" or "myapp.com"):
+    recipient: String,
+    #[interactive_clap(long)]
+    /// Which account to sign the message with:
+    signer_account_id: crate::types::account_id::AccountId,
+    #[interactive_clap(subcommand)]
+    sign_with: self::signature_options::SignWith,
+}
+
+#[derive(Debug, Clone)]
+pub struct SignNep413Context {
+    pub global_context: crate::GlobalContext,
+    pub payload: NEP413Payload,
+    pub signer_id: near_primitives::types::AccountId,
+}
+
+impl SignNep413Context {
+    pub fn from_previous_context(
+        previous_context: crate::GlobalContext,
+        scope: &<SignNep413 as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+    ) -> color_eyre::eyre::Result<Self> {
+        let message = match scope.encoding {
+            MessageEncoding::Utf8 => scope.message.clone(),
+            MessageEncoding::Base64 => String::from_utf8(
+                near_primitives::serialize::from_base64(&scope.message).map_err(|e| {
+                    color_eyre::eyre::eyre!("Failed to decode base64 message: {}", e)
+                })?,
+            )
+            .map_err(|e| color_eyre::eyre::eyre!("Message is not valid UTF-8: {}", e))?,
+        };
+
+        let nonce_bytes = scope.nonce.as_bytes();
+        if nonce_bytes.len() != 32 {
+            return Err(color_eyre::eyre::eyre!(
+                "Invalid nonce length: expected 32 bytes, got {}",
+                nonce_bytes.len()
+            ));
+        }
+        let mut nonce = [0u8; 32];
+        nonce.copy_from_slice(nonce_bytes);
+
+        let payload = NEP413Payload {
+            message,
+            nonce,
+            recipient: scope.recipient.clone(),
+            callback_url: None,
+        };
+
+        Ok(Self {
+            global_context: previous_context,
+            payload,
+            signer_id: scope.signer_account_id.clone().into(),
+        })
+    }
+}
+
+#[derive(Debug, Clone, EnumDiscriminants, clap::ValueEnum)]
+#[strum_discriminants(derive(EnumMessage, EnumIter))]
+pub enum MessageEncoding {
+    Utf8,
+    Base64,
+}
+
+impl interactive_clap::ToCli for MessageEncoding {
+    type CliVariant = Self;
+}
+
+impl std::fmt::Display for MessageEncoding {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Utf8 => write!(f, "utf8"),
+            Self::Base64 => write!(f, "base64"),
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct SignedMessage {
+    #[serde(rename = "accountId")]
+    pub account_id: String,
+    #[serde(rename = "publicKey")]
+    pub public_key: String,
+    pub signature: String,
+}
+
+#[derive(Debug, Clone, BorshDeserialize, BorshSerialize)]
+pub struct NEP413Payload {
+    pub message: String,
+    pub nonce: [u8; 32],
+    pub recipient: String,
+    pub callback_url: Option<String>,
+}
+
+#[cfg(feature = "ledger")]
+impl From<NEP413Payload> for near_ledger::NEP413Payload {
+    fn from(payload: NEP413Payload) -> Self {
+        Self {
+            message: payload.message,
+            nonce: payload.nonce,
+            recipient: payload.recipient,
+            callback_url: payload.callback_url,
+        }
+    }
+}
+
+pub fn sign_nep413_payload(
+    payload: &NEP413Payload,
+    secret_key: &SecretKey,
+) -> color_eyre::eyre::Result<Signature> {
+    const NEP413_SIGN_MESSAGE_PREFIX: u32 = (1u32 << 31u32) + 413u32;
+    let mut bytes = NEP413_SIGN_MESSAGE_PREFIX.to_le_bytes().to_vec();
+    borsh::to_writer(&mut bytes, payload)?;
+    let hash = hash(&bytes);
+    let signature = secret_key.sign(hash.as_ref());
+    Ok(signature)
+}
+
+impl SignNep413 {
+    fn input_encoding(
+        _context: &crate::GlobalContext,
+    ) -> color_eyre::eyre::Result<Option<MessageEncoding>> {
+        Ok(Some(
+            inquire::Select::new(
+                "How is the message encoded?",
+                vec![MessageEncoding::Utf8, MessageEncoding::Base64],
+            )
+            .prompt()?,
+        ))
+    }
+}

--- a/src/commands/message/sign_nep413/signature_options/mod.rs
+++ b/src/commands/message/sign_nep413/signature_options/mod.rs
@@ -1,0 +1,41 @@
+use strum::{EnumDiscriminants, EnumIter, EnumMessage};
+
+pub mod sign_with_access_key_file;
+pub mod sign_with_keychain;
+#[cfg(feature = "ledger")]
+pub mod sign_with_ledger;
+pub mod sign_with_legacy_keychain;
+pub mod sign_with_private_key;
+pub mod sign_with_seed_phrase;
+
+#[derive(Debug, EnumDiscriminants, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(context = super::SignNep413Context)]
+#[strum_discriminants(derive(EnumMessage, EnumIter))]
+/// How do you want to sign the message?
+pub enum SignWith {
+    #[strum_discriminants(strum(
+        message = "sign-with-keychain               - Sign with a key saved in the secure keychain"
+    ))]
+    SignWithKeychain(self::sign_with_keychain::SignKeychain),
+    #[strum_discriminants(strum(
+        message = "sign-with-legacy-keychain        - Sign with a key saved in legacy keychain (compatible with the old near CLI)"
+    ))]
+    SignWithLegacyKeychain(self::sign_with_legacy_keychain::SignLegacyKeychain),
+    #[cfg(feature = "ledger")]
+    #[strum_discriminants(strum(
+        message = "sign-with-ledger                 - Sign with Ledger Nano device"
+    ))]
+    SignWithLedger(self::sign_with_ledger::SignLedger),
+    #[strum_discriminants(strum(
+        message = "sign-with-plaintext-private-key  - Sign with a plaintext private key"
+    ))]
+    SignWithPlaintextPrivateKey(self::sign_with_private_key::SignPrivateKey),
+    #[strum_discriminants(strum(
+        message = "sign-with-access-key-file        - Sign using an account access key file"
+    ))]
+    SignWithAccessKeyFile(self::sign_with_access_key_file::SignAccessKeyFile),
+    #[strum_discriminants(strum(
+        message = "sign-with-seed-phrase            - Sign using a seed phrase"
+    ))]
+    SignWithSeedPhrase(self::sign_with_seed_phrase::SignSeedPhrase),
+}

--- a/src/commands/message/sign_nep413/signature_options/sign_with_access_key_file.rs
+++ b/src/commands/message/sign_nep413/signature_options/sign_with_access_key_file.rs
@@ -1,0 +1,33 @@
+use color_eyre::eyre::WrapErr;
+
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(input_context = super::super::SignNep413Context)]
+#[interactive_clap(output_context = SignAccessKeyFileContext)]
+pub struct SignAccessKeyFile {
+    /// What is the location of the account access key file?
+    file_path: crate::types::path_buf::PathBuf,
+}
+
+#[derive(Debug, Clone)]
+pub struct SignAccessKeyFileContext;
+
+impl SignAccessKeyFileContext {
+    pub fn from_previous_context(
+        previous_context: super::super::SignNep413Context,
+        scope: &<SignAccessKeyFile as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+    ) -> color_eyre::eyre::Result<Self> {
+        let data =
+            std::fs::read_to_string(&scope.file_path).wrap_err("Access key file not found!")?;
+        let account_json: crate::transaction_signature_options::AccountKeyPair =
+            serde_json::from_str(&data).wrap_err_with(|| {
+                format!("Error reading data from file: {:?}", &scope.file_path)
+            })?;
+
+        let signature = super::super::sign_nep413_payload(
+            &previous_context.payload,
+            &account_json.private_key,
+        )?;
+        println!("Signature: {}", signature);
+        Ok(Self)
+    }
+}

--- a/src/commands/message/sign_nep413/signature_options/sign_with_keychain.rs
+++ b/src/commands/message/sign_nep413/signature_options/sign_with_keychain.rs
@@ -1,0 +1,41 @@
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(input_context = super::super::SignNep413Context)]
+#[interactive_clap(output_context = SignKeychainContext)]
+pub struct SignKeychain {
+    #[interactive_clap(named_arg)]
+    /// Select network
+    network_config: crate::network::Network,
+}
+
+pub struct SignKeychainContext(crate::network::NetworkContext);
+
+impl SignKeychainContext {
+    pub fn from_previous_context(
+        previous_context: super::super::SignNep413Context,
+        _scope: &<SignKeychain as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+    ) -> color_eyre::eyre::Result<Self> {
+        let on_after_getting_network_callback: crate::network::OnAfterGettingNetworkCallback =
+            std::sync::Arc::new({
+                let signer_id = previous_context.signer_id.clone();
+                let payload = previous_context.payload.clone();
+                move |network_config| {
+                    let secret_key = crate::commands::account::export_account::get_account_key_pair_from_keychain(network_config, &signer_id)?.private_key;
+                    let signature = super::super::sign_nep413_payload(&payload, &secret_key)?;
+                    println!("Signature: {}", signature);
+                    Ok(())
+                }
+            });
+
+        Ok(Self(crate::network::NetworkContext {
+            config: previous_context.global_context.config,
+            interacting_with_account_ids: vec![previous_context.signer_id],
+            on_after_getting_network_callback,
+        }))
+    }
+}
+
+impl From<SignKeychainContext> for crate::network::NetworkContext {
+    fn from(item: SignKeychainContext) -> Self {
+        item.0
+    }
+}

--- a/src/commands/message/sign_nep413/signature_options/sign_with_ledger.rs
+++ b/src/commands/message/sign_nep413/signature_options/sign_with_ledger.rs
@@ -1,0 +1,67 @@
+use color_eyre::eyre::WrapErr;
+use near_crypto::Signature;
+
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(input_context = super::super::SignNep413Context)]
+#[interactive_clap(output_context = SignLedgerContext)]
+pub struct SignLedger {
+    #[interactive_clap(long)]
+    #[interactive_clap(skip_default_input_arg)]
+    seed_phrase_hd_path: crate::types::slip10::BIP32Path,
+}
+
+#[derive(Debug, Clone)]
+pub struct SignLedgerContext;
+
+impl SignLedgerContext {
+    pub fn from_previous_context(
+        previous_context: super::super::SignNep413Context,
+        scope: &<SignLedger as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+    ) -> color_eyre::eyre::Result<Self> {
+        let seed_phrase_hd_path = scope.seed_phrase_hd_path.clone();
+
+        eprintln!("Opening the NEAR application... Please approve opening the application");
+        near_ledger::open_near_application().map_err(|ledger_error| {
+            color_eyre::Report::msg(format!(
+                "An error happened while trying to open the NEAR application on the ledger: {:?}",
+                ledger_error
+            ))
+        })?;
+
+        let public_key = near_crypto::PublicKey::ED25519(near_crypto::ED25519PublicKey::from(
+            near_ledger::get_public_key(scope.seed_phrase_hd_path.clone().into())
+                .map_err(|err| color_eyre::eyre::eyre!("Ledger get_public_key error: {:?}", err))?
+                .to_bytes(),
+        ));
+
+        std::thread::sleep(std::time::Duration::from_secs(1));
+
+        eprintln!("Please approve the message signing on your Ledger device (HD Path: {seed_phrase_hd_path})");
+
+        let signature_bytes = near_ledger::sign_message_nep413(
+            &previous_context.payload.into(),
+            seed_phrase_hd_path.into(),
+        )
+        .map_err(|err| color_eyre::eyre::eyre!("Ledger signing error: {:?}", err))?;
+
+        let signature = Signature::from_parts(near_crypto::KeyType::ED25519, &signature_bytes)
+            .wrap_err("Signature is not expected to fail on deserialization")?;
+
+        let signed_message = super::super::SignedMessage {
+            account_id: previous_context.signer_id.to_string(),
+            public_key: public_key.to_string(),
+            signature: signature.to_string(),
+        };
+        println!("{}", serde_json::to_string_pretty(&signed_message)?);
+
+        Ok(Self)
+    }
+}
+
+impl SignLedger {
+    pub fn input_seed_phrase_hd_path(
+        _context: &super::super::SignNep413Context,
+    ) -> color_eyre::eyre::Result<Option<crate::types::slip10::BIP32Path>> {
+        crate::transaction_signature_options::sign_with_ledger::input_seed_phrase_hd_path()
+    }
+}

--- a/src/commands/message/sign_nep413/signature_options/sign_with_legacy_keychain.rs
+++ b/src/commands/message/sign_nep413/signature_options/sign_with_legacy_keychain.rs
@@ -1,0 +1,50 @@
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(input_context = super::super::SignNep413Context)]
+#[interactive_clap(output_context = SignLegacyKeychainContext)]
+pub struct SignLegacyKeychain {
+    #[interactive_clap(named_arg)]
+    /// Select network
+    network_config: crate::network::Network,
+}
+
+pub struct SignLegacyKeychainContext(crate::network::NetworkContext);
+
+impl SignLegacyKeychainContext {
+    pub fn from_previous_context(
+        previous_context: super::super::SignNep413Context,
+        _scope: &<SignLegacyKeychain as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+    ) -> color_eyre::eyre::Result<Self> {
+        let on_after_getting_network_callback: crate::network::OnAfterGettingNetworkCallback =
+            std::sync::Arc::new({
+                let signer_id = previous_context.signer_id.clone();
+                let payload = previous_context.payload.clone();
+                let credentials_home_dir = previous_context
+                    .global_context
+                    .config
+                    .credentials_home_dir
+                    .clone();
+                move |network_config| {
+                    let secret_key = crate::commands::account::export_account::get_account_key_pair_from_legacy_keychain(
+                        network_config,
+                        &signer_id,
+                        &credentials_home_dir
+                    )?.private_key;
+                    let signature = super::super::sign_nep413_payload(&payload, &secret_key)?;
+                    println!("Signature: {}", signature);
+                    Ok(())
+                }
+            });
+
+        Ok(Self(crate::network::NetworkContext {
+            config: previous_context.global_context.config,
+            interacting_with_account_ids: vec![previous_context.signer_id],
+            on_after_getting_network_callback,
+        }))
+    }
+}
+
+impl From<SignLegacyKeychainContext> for crate::network::NetworkContext {
+    fn from(item: SignLegacyKeychainContext) -> Self {
+        item.0
+    }
+}

--- a/src/commands/message/sign_nep413/signature_options/sign_with_private_key.rs
+++ b/src/commands/message/sign_nep413/signature_options/sign_with_private_key.rs
@@ -1,0 +1,29 @@
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(input_context = super::super::SignNep413Context)]
+#[interactive_clap(output_context = SignPrivateKeyContext)]
+pub struct SignPrivateKey {
+    /// Enter your private (secret) key:
+    pub private_key: crate::types::secret_key::SecretKey,
+}
+
+#[derive(Debug, Clone)]
+pub struct SignPrivateKeyContext;
+
+impl SignPrivateKeyContext {
+    pub fn from_previous_context(
+        previous_context: super::super::SignNep413Context,
+        scope: &<SignPrivateKey as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+    ) -> color_eyre::eyre::Result<Self> {
+        let secret_key: near_crypto::SecretKey = scope.private_key.clone().into();
+        let public_key = secret_key.public_key();
+        let signature = super::super::sign_nep413_payload(&previous_context.payload, &secret_key)?;
+
+        let signed_message = super::super::SignedMessage {
+            account_id: previous_context.signer_id.to_string(),
+            public_key: public_key.to_string(),
+            signature: signature.to_string(),
+        };
+        println!("{}", serde_json::to_string_pretty(&signed_message)?);
+        Ok(Self)
+    }
+}

--- a/src/commands/message/sign_nep413/signature_options/sign_with_seed_phrase.rs
+++ b/src/commands/message/sign_nep413/signature_options/sign_with_seed_phrase.rs
@@ -1,0 +1,39 @@
+use std::str::FromStr;
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(input_context = super::super::SignNep413Context)]
+#[interactive_clap(output_context = SignSeedPhraseContext)]
+pub struct SignSeedPhrase {
+    /// Enter the seed-phrase for this account:
+    master_seed_phrase: String,
+    #[interactive_clap(long)]
+    #[interactive_clap(skip_default_input_arg)]
+    seed_phrase_hd_path: crate::types::slip10::BIP32Path,
+}
+
+#[derive(Debug, Clone)]
+pub struct SignSeedPhraseContext;
+
+impl SignSeedPhraseContext {
+    pub fn from_previous_context(
+        previous_context: super::super::SignNep413Context,
+        scope: &<SignSeedPhrase as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+    ) -> color_eyre::eyre::Result<Self> {
+        let key_pair_properties = crate::common::get_key_pair_properties_from_seed_phrase(
+            scope.seed_phrase_hd_path.clone(),
+            scope.master_seed_phrase.clone(),
+        )?;
+        let secret_key = near_crypto::SecretKey::from_str(&key_pair_properties.secret_keypair_str)?;
+
+        let signature = super::super::sign_nep413_payload(&previous_context.payload, &secret_key)?;
+        println!("Signature: {}", signature);
+        Ok(Self)
+    }
+}
+
+impl SignSeedPhrase {
+    fn input_seed_phrase_hd_path(
+        _context: &super::super::SignNep413Context,
+    ) -> color_eyre::eyre::Result<Option<crate::types::slip10::BIP32Path>> {
+        crate::transaction_signature_options::sign_with_seed_phrase::input_seed_phrase_hd_path()
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -4,6 +4,7 @@ use strum::{EnumDiscriminants, EnumIter, EnumMessage};
 pub mod account;
 mod config;
 pub mod contract;
+pub mod message;
 mod staking;
 mod tokens;
 pub mod transaction;
@@ -48,6 +49,9 @@ pub enum TopLevelCommand {
     #[strum_discriminants(strum(message = "extension   - Manage near CLI and extensions"))]
     /// Use this to manage near CLI and extensions
     Extensions(self::extensions::ExtensionsCommands),
+    #[strum_discriminants(strum(message = "message     - Sign an arbitrary message (NEP-413)"))]
+    /// Sign an arbitrary message (NEP-413)
+    Message(self::message::MessageCommand),
 }
 
 pub type OnBeforeSigningCallback = std::sync::Arc<


### PR DESCRIPTION
```
near-cli-rs git:nep413-cli*  
❯ ./target/debug/near message sign-nep413 utf8 "Hello NEAR" \  --nonce "KNV0cOpvJ50D5vfF9pqWom8wo2sliQ4W+Wa7uZ3Uk6Y=" \  --recipient "example.near" \  
  --signer-account-id "round-toad.testnet" \
  sign-with-seed-phrase "fatal edge jacket cash hard pass gallery fabric whisper size rain biology"


> Enter seed phrase HD Path (if not sure, keep the default): m/44'/397'/0'
Signature: ed25519:5KtCukfZJJ9tHrgxot3navRRXuuSYsfSiCcvQfj4s4mdET2TtbtwN5zCJP5kiKZZM2Tafpe9jQ1krm5Kyj4XFWiv

```