### PR TITLE
chore: release v0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.0](https://github.com/near/near-cli-rs/compare/v0.21.0...v0.22.0) - 2025-07-21
+
+### Added
+
+- New "message sign-nep413" command - NEP-413 offchain messages signing ([#507](https://github.com/near/near-cli-rs/pull/507))
+
+### Fixed
+
+- Gracefully handle (Started, NotStarted) transaction status ([#510](https://github.com/near/near-cli-rs/pull/510))
+
+### Other
+
+- Removed dj8yfo from CODEOWNERS
+
 ## [0.21.0](https://github.com/near/near-cli-rs/compare/v0.20.0...v0.21.0) - 2025-07-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2210,7 +2210,7 @@ dependencies = [
 
 [[package]]
 name = "near-cli-rs"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "bip39",
  "borsh",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-cli-rs"
-version = "0.21.0"
+version = "0.22.0"
 authors = ["FroVolod <frol_off@meta.ua>", "Near Inc <hello@nearprotocol.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION



## 🤖 New release

* `near-cli-rs`: 0.21.0 -> 0.22.0 (⚠ API breaking changes)

### ⚠ `near-cli-rs` breaking changes

```text
--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant TopLevelCommandDiscriminants::Config 5 -> 6 in /tmp/.tmphokuMN/near-cli-rs/src/commands/mod.rs:50
  variant TopLevelCommandDiscriminants::Extensions 6 -> 7 in /tmp/.tmphokuMN/near-cli-rs/src/commands/mod.rs:54
  variant TopLevelCommandDiscriminants::Config 5 -> 6 in /tmp/.tmphokuMN/near-cli-rs/src/commands/mod.rs:50
  variant TopLevelCommandDiscriminants::Extensions 6 -> 7 in /tmp/.tmphokuMN/near-cli-rs/src/commands/mod.rs:54

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.41.0/src/lints/enum_variant_added.ron

Failed in:
  variant CliTopLevelCommand:Message in /tmp/.tmphokuMN/near-cli-rs/src/commands/mod.rs:15
  variant TopLevelCommandDiscriminants:Message in /tmp/.tmphokuMN/near-cli-rs/src/commands/mod.rs:45
  variant TopLevelCommandDiscriminants:Message in /tmp/.tmphokuMN/near-cli-rs/src/commands/mod.rs:45
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.22.0](https://github.com/near/near-cli-rs/compare/v0.21.0...v0.22.0) - 2025-07-21

### Added

- New "message sign-nep413" command - NEP-413 offchain messages signing ([#507](https://github.com/near/near-cli-rs/pull/507))

### Fixed

- Gracefully handle (Started, NotStarted) transaction status ([#510](https://github.com/near/near-cli-rs/pull/510))

### Other

- Removed dj8yfo from CODEOWNERS
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).