### PR TITLE
chore: release v0.22.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.2](https://github.com/near/near-cli-rs/compare/v0.22.1...v0.22.2) - 2025-08-31
+
+### Fixed
+
+- Fixed the inspection command for the global contract on the account. ([#513](https://github.com/near/near-cli-rs/pull/513))
+
 ## [0.22.1](https://github.com/near/near-cli-rs/compare/v0.22.0...v0.22.1) - 2025-08-15
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2213,7 +2213,7 @@ dependencies = [
 
 [[package]]
 name = "near-cli-rs"
-version = "0.22.1"
+version = "0.22.2"
 dependencies = [
  "bip39",
  "borsh",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-cli-rs"
-version = "0.22.1"
+version = "0.22.2"
 authors = ["FroVolod <frol_off@meta.ua>", "Near Inc <hello@nearprotocol.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION



## 🤖 New release

* `near-cli-rs`: 0.22.1 -> 0.22.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.22.2](https://github.com/near/near-cli-rs/compare/v0.22.1...v0.22.2) - 2025-08-31

### Fixed

- Fixed the inspection command for the global contract on the account. ([#513](https://github.com/near/near-cli-rs/pull/513))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).