### PR TITLE
chore: release v0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.0](https://github.com/near/near-cli-rs/compare/v0.22.2...v0.23.0) - 2025-12-11
+
+### Added
+
+- Updated user interface for interactive mode ([#524](https://github.com/near/near-cli-rs/pull/524))
+- Added support for reconstructing transaction with global contracts deploy or use actions ([#521](https://github.com/near/near-cli-rs/pull/521))
+- Sign transactions with MPC from a different account or even through a DAO proposal ([#520](https://github.com/near/near-cli-rs/pull/520))
+- Enabled aarch64 Windows binary builds (upgraded cargo-dist to 0.29.0) ([#518](https://github.com/near/near-cli-rs/pull/518))
+- introduce tests ([#522](https://github.com/near/near-cli-rs/pull/522))
+
+### Fixed
+
+- Fixed a flaky test (block hash can be 43 or 44 characters long when base58-encoded) ([#529](https://github.com/near/near-cli-rs/pull/529))
+
+### Other
+
+- bump near-* dependencies to 0.34 (nearcore release 2.10) ([#528](https://github.com/near/near-cli-rs/pull/528))
+- changed default rpc to archival fastnear ([#527](https://github.com/near/near-cli-rs/pull/527))
+
 ## [0.22.2](https://github.com/near/near-cli-rs/compare/v0.22.1...v0.22.2) - 2025-08-31
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2398,7 +2398,7 @@ dependencies = [
 
 [[package]]
 name = "near-cli-rs"
-version = "0.22.2"
+version = "0.23.0"
 dependencies = [
  "bip39",
  "borsh",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-cli-rs"
-version = "0.22.2"
+version = "0.23.0"
 authors = ["FroVolod <frol_off@meta.ua>", "Near Inc <hello@nearprotocol.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION



## 🤖 New release

* `near-cli-rs`: 0.22.2 -> 0.23.0 (⚠ API breaking changes)

### ⚠ `near-cli-rs` breaking changes

```text
--- failure auto_trait_impl_removed: auto trait no longer implemented ---

Description:
A public type has stopped implementing one or more auto traits. This can break downstream code that depends on the traits being implemented.
        ref: https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/auto_trait_impl_removed.ron

Failed in:
  type DaoProposalArgumentsContext is no longer Send, in /tmp/.tmpJqGcSK/near-cli-rs/src/transaction_signature_options/submit_dao_proposal/mod.rs:86
  type DaoProposalArgumentsContext is no longer Sync, in /tmp/.tmpJqGcSK/near-cli-rs/src/transaction_signature_options/submit_dao_proposal/mod.rs:86
  type DaoProposalArgumentsContext is no longer UnwindSafe, in /tmp/.tmpJqGcSK/near-cli-rs/src/transaction_signature_options/submit_dao_proposal/mod.rs:86
  type DaoProposalArgumentsContext is no longer RefUnwindSafe, in /tmp/.tmpJqGcSK/near-cli-rs/src/transaction_signature_options/submit_dao_proposal/mod.rs:86
  type PrepaidGasContext is no longer Send, in /tmp/.tmpJqGcSK/near-cli-rs/src/transaction_signature_options/submit_dao_proposal/mod.rs:141
  type PrepaidGasContext is no longer Sync, in /tmp/.tmpJqGcSK/near-cli-rs/src/transaction_signature_options/submit_dao_proposal/mod.rs:141
  type PrepaidGasContext is no longer UnwindSafe, in /tmp/.tmpJqGcSK/near-cli-rs/src/transaction_signature_options/submit_dao_proposal/mod.rs:141
  type PrepaidGasContext is no longer RefUnwindSafe, in /tmp/.tmpJqGcSK/near-cli-rs/src/transaction_signature_options/submit_dao_proposal/mod.rs:141
  type DepositContext is no longer Send, in /tmp/.tmpJqGcSK/near-cli-rs/src/transaction_signature_options/submit_dao_proposal/mod.rs:207
  type DepositContext is no longer Sync, in /tmp/.tmpJqGcSK/near-cli-rs/src/transaction_signature_options/submit_dao_proposal/mod.rs:207
  type DepositContext is no longer UnwindSafe, in /tmp/.tmpJqGcSK/near-cli-rs/src/transaction_signature_options/submit_dao_proposal/mod.rs:207
  type DepositContext is no longer RefUnwindSafe, in /tmp/.tmpJqGcSK/near-cli-rs/src/transaction_signature_options/submit_dao_proposal/mod.rs:207
  type DaoProposalContext is no longer Send, in /tmp/.tmpJqGcSK/near-cli-rs/src/transaction_signature_options/submit_dao_proposal/mod.rs:20
  type DaoProposalContext is no longer Sync, in /tmp/.tmpJqGcSK/near-cli-rs/src/transaction_signature_options/submit_dao_proposal/mod.rs:20
  type DaoProposalContext is no longer UnwindSafe, in /tmp/.tmpJqGcSK/near-cli-rs/src/transaction_signature_options/submit_dao_proposal/mod.rs:20
  type DaoProposalContext is no longer RefUnwindSafe, in /tmp/.tmpJqGcSK/near-cli-rs/src/transaction_signature_options/submit_dao_proposal/mod.rs:20

--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field TransactionContext.on_after_signing_callback in /tmp/.tmpJqGcSK/near-cli-rs/src/commands/mod.rs:121
  field CliContract.contract_kind in /tmp/.tmpJqGcSK/near-cli-rs/src/commands/contract/download_wasm/mod.rs:299
  field NetworkConfig.mpc_contract_account_id in /tmp/.tmpJqGcSK/near-cli-rs/src/config/mod.rs:238

--- failure derive_trait_impl_removed: built-in derived trait no longer implemented ---

Description:
A public type has stopped deriving one or more traits. This can break downstream code that depends on those types implementing those traits.
        ref: https://doc.rust-lang.org/reference/attributes/derive.html#derive
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/derive_trait_impl_removed.ron

Failed in:
  type DownloadContractContext no longer derives Clone, in /tmp/.tmpJqGcSK/near-cli-rs/src/commands/contract/download_wasm/mod.rs:86

--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/enum_missing.ron

Failed in:
  enum near_cli_rs::commands::contract::download_wasm::ClapNamedArgDownloadContractForContract, previously in file /tmp/.tmpsx396w/near-cli-rs/src/commands/contract/download_wasm/mod.rs:8

--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant SignWithDiscriminants::SignLater 6 -> 7 in /tmp/.tmpJqGcSK/near-cli-rs/src/transaction_signature_options/mod.rs:65
  variant SignWithDiscriminants::SubmitAsDaoProposal 7 -> 8 in /tmp/.tmpJqGcSK/near-cli-rs/src/transaction_signature_options/mod.rs:70
  variant SignWithDiscriminants::SignLater 6 -> 7 in /tmp/.tmpJqGcSK/near-cli-rs/src/transaction_signature_options/mod.rs:65
  variant SignWithDiscriminants::SubmitAsDaoProposal 7 -> 8 in /tmp/.tmpJqGcSK/near-cli-rs/src/transaction_signature_options/mod.rs:70

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/enum_variant_added.ron

Failed in:
  variant CliSignWith:SignWithMpc in /tmp/.tmpJqGcSK/near-cli-rs/src/transaction_signature_options/mod.rs:20
  variant SignWith:SignWithMpc in /tmp/.tmpJqGcSK/near-cli-rs/src/transaction_signature_options/mod.rs:60
  variant SignWithDiscriminants:SignWithMpc in /tmp/.tmpJqGcSK/near-cli-rs/src/transaction_signature_options/mod.rs:60
  variant SignWithDiscriminants:SignWithMpc in /tmp/.tmpJqGcSK/near-cli-rs/src/transaction_signature_options/mod.rs:60

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/inherent_method_missing.ron

Failed in:
  Contract::input_account_id, previously in file /tmp/.tmpsx396w/near-cli-rs/src/commands/contract/download_wasm/mod.rs:39
  NearAllowance::from_yoctonear, previously in file /tmp/.tmpsx396w/near-cli-rs/src/types/near_allowance.rs:44

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/struct_missing.ron

Failed in:
  struct near_cli_rs::commands::contract::download_wasm::ContractContext, previously in file /tmp/.tmpsx396w/near-cli-rs/src/commands/contract/download_wasm/mod.rs:21

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field account_id of struct InteractiveClapContextScopeForContract, previously in file /tmp/.tmpsx396w/near-cli-rs/src/commands/contract/download_wasm/mod.rs:8
  field account_id of struct CliContract, previously in file /tmp/.tmpsx396w/near-cli-rs/src/commands/contract/download_wasm/mod.rs:8
  field save_to_file of struct CliContract, previously in file /tmp/.tmpsx396w/near-cli-rs/src/commands/contract/download_wasm/mod.rs:8
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.23.0](https://github.com/near/near-cli-rs/compare/v0.22.2...v0.23.0) - 2025-12-11

### Added

- Updated user interface for interactive mode ([#524](https://github.com/near/near-cli-rs/pull/524))
- Added support for reconstructing transaction with global contracts deploy or use actions ([#521](https://github.com/near/near-cli-rs/pull/521))
- Sign transactions with MPC from a different account or even through a DAO proposal ([#520](https://github.com/near/near-cli-rs/pull/520))
- Enabled aarch64 Windows binary builds (upgraded cargo-dist to 0.29.0) ([#518](https://github.com/near/near-cli-rs/pull/518))
- introduce tests ([#522](https://github.com/near/near-cli-rs/pull/522))

### Fixed

- Fixed a flaky test (block hash can be 43 or 44 characters long when base58-encoded) ([#529](https://github.com/near/near-cli-rs/pull/529))

### Other

- bump near-* dependencies to 0.34 (nearcore release 2.10) ([#528](https://github.com/near/near-cli-rs/pull/528))
- changed default rpc to archival fastnear ([#527](https://github.com/near/near-cli-rs/pull/527))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).