### PR TITLE
fix: Fixed a flaky test (block hash can be 43 or 44 characters long when base58-encoded)

### DIFF
--- a/tests/account.rs
+++ b/tests/account.rs
@@ -58,7 +58,7 @@ fn normalize_output(output: &str) -> String {
     let normalized = block_regex.replace_all(&normalized, "At block #[BLOCK_NUM]");
 
     // Replace block hashes (e.g., "(Gqo3Sym99tdtKm9Ha2aVFUvPPcqNVX8qfQ3dvpUk9B51)" -> "([BLOCK_HASH])")
-    let hash_regex = Regex::new(r"\([A-Za-z0-9]{44}\)").unwrap();
+    let hash_regex = Regex::new(r"\([A-Za-z0-9]{43,44}\)").unwrap();
     let normalized = hash_regex.replace_all(&normalized, "([BLOCK_HASH])");
 
     normalized.to_string()


### PR DESCRIPTION
https://github.com/near/near-cli-rs/actions/runs/19828241124/job/56807186458