### PR TITLE
chore: release v0.23.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.2](https://github.com/near/near-cli-rs/compare/v0.23.1...v0.23.2) - 2025-12-19
+
+### Added
+
+- New commands for getting and adding MPC-derived access key to account (`account -> get-public-key -> from-mpc`, `account -> add-key -> use-mpc-contract`) ([#535](https://github.com/near/near-cli-rs/pull/535))
+
 ## [0.23.1](https://github.com/near/near-cli-rs/compare/v0.23.0...v0.23.1) - 2025-12-17
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2398,7 +2398,7 @@ dependencies = [
 
 [[package]]
 name = "near-cli-rs"
-version = "0.23.1"
+version = "0.23.2"
 dependencies = [
  "bip39",
  "borsh",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-cli-rs"
-version = "0.23.1"
+version = "0.23.2"
 authors = ["FroVolod <frol_off@meta.ua>", "Near Inc <hello@nearprotocol.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION



## 🤖 New release

* `near-cli-rs`: 0.23.1 -> 0.23.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.23.2](https://github.com/near/near-cli-rs/compare/v0.23.1...v0.23.2) - 2025-12-19

### Added

- New commands for getting and adding MPC-derived access key to account (`account -> get-public-key -> from-mpc`, `account -> add-key -> use-mpc-contract`) ([#535](https://github.com/near/near-cli-rs/pull/535))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).