### PR TITLE
chore: release v0.23.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.24.0](https://github.com/near/near-cli-rs/compare/v0.23.2...v0.24.0) - 2025-12-31
+## [0.23.3](https://github.com/near/near-cli-rs/compare/v0.23.2...v0.23.3) - 2025-12-31
 
 ### Fixed
 
-- Fixed UI for interactive mode ([#531](https://github.com/near/near-cli-rs/pull/531))
-
-### Other
-
-- Improve clarity and consistency of interactive prompts ([#538](https://github.com/near/near-cli-rs/pull/538))
+- Improved messages for interactive and teach-me modes ([#531](https://github.com/near/near-cli-rs/pull/531))
+- Improved clarity and consistency of interactive prompts ([#538](https://github.com/near/near-cli-rs/pull/538))
 
 ## [0.23.2](https://github.com/near/near-cli-rs/compare/v0.23.1...v0.23.2) - 2025-12-19
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2398,7 +2398,7 @@ dependencies = [
 
 [[package]]
 name = "near-cli-rs"
-version = "0.24.0"
+version = "0.23.3"
 dependencies = [
  "bip39",
  "borsh",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-cli-rs"
-version = "0.24.0"
+version = "0.23.3"
 authors = ["FroVolod <frol_off@meta.ua>", "Near Inc <hello@nearprotocol.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION


## 🤖 New release

* `near-cli-rs`: 0.23.2 -> 0.23.3

### ⚠ `near-cli-rs` breaking changes

```text
--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/function_parameter_count_changed.ron

Failed in:
  near_cli_rs::commands::account::create_account::sponsor_by_faucet_service::before_creating_account now takes 6 parameters instead of 5, in /tmp/.tmptMjHte/near-cli-rs/src/commands/account/create_account/sponsor_by_faucet_service/mod.rs:70
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.24.0](https://github.com/near/near-cli-rs/compare/v0.23.2...v0.23.3) - 2025-12-31

### Fixed

- Fixed UI for interactive mode ([#531](https://github.com/near/near-cli-rs/pull/531))

### Other

- Improve clarity and consistency of interactive prompts ([#538](https://github.com/near/near-cli-rs/pull/538))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).