### PR TITLE
chore: release v0.23.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.4](https://github.com/near/near-cli-rs/compare/v0.23.3...v0.23.4) - 2026-01-01
+
+### Other
+
+- Upgraded dependencies to the latest major dependencies ([#540](https://github.com/near/near-cli-rs/pull/540))
+
 ## [0.23.3](https://github.com/near/near-cli-rs/compare/v0.23.2...v0.23.3) - 2025-12-31
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2362,7 +2362,7 @@ dependencies = [
 
 [[package]]
 name = "near-cli-rs"
-version = "0.23.3"
+version = "0.23.4"
 dependencies = [
  "bip39",
  "borsh",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-cli-rs"
-version = "0.23.3"
+version = "0.23.4"
 authors = ["FroVolod <frol_off@meta.ua>", "Near Inc <hello@nearprotocol.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION



## 🤖 New release

* `near-cli-rs`: 0.23.3 -> 0.23.4 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.23.4](https://github.com/near/near-cli-rs/compare/v0.23.3...v0.23.4) - 2026-01-01

### Other

- Upgraded dependencies to the latest major dependencies ([#540](https://github.com/near/near-cli-rs/pull/540))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).