### PR TITLE
chore: release v0.23.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.5](https://github.com/near/near-cli-rs/compare/v0.23.4...v0.23.5) - 2026-01-01
+
+### Fixed
+
+- Fixed testnet-lava RPC URL ([#542](https://github.com/near/near-cli-rs/pull/542))
+
 ## [0.23.4](https://github.com/near/near-cli-rs/compare/v0.23.3...v0.23.4) - 2026-01-01
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2362,7 +2362,7 @@ dependencies = [
 
 [[package]]
 name = "near-cli-rs"
-version = "0.23.4"
+version = "0.23.5"
 dependencies = [
  "bip39",
  "borsh",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-cli-rs"
-version = "0.23.4"
+version = "0.23.5"
 authors = ["FroVolod <frol_off@meta.ua>", "Near Inc <hello@nearprotocol.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION



## 🤖 New release

* `near-cli-rs`: 0.23.4 -> 0.23.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.23.5](https://github.com/near/near-cli-rs/compare/v0.23.4...v0.23.5) - 2026-01-01

### Fixed

- Fixed testnet-lava RPC URL ([#542](https://github.com/near/near-cli-rs/pull/542))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).