### PR TITLE
ci: migrate to org-wide NEARPROTOCOL_CI_PR_ACCESS token

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_PLZ_GITHUB_TOKEN }}
+          token: ${{ secrets.NEARPROTOCOL_CI_PR_ACCESS }}
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Install packages (Linux)
@@ -28,5 +28,5 @@ jobs:
         uses: MarcoIeni/release-plz-action@v0.5
         env:
           # https://marcoieni.github.io/release-plz/github-action.html#triggering-further-workflow-runs
-          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.NEARPROTOCOL_CI_PR_ACCESS }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
Migrates from personal `CUSTOM_GITHUB_TOKEN` to org-wide `NEARPROTOCOL_CI_PR_ACCESS` for release-plz workflow.