### PR TITLE
chore: release v0.23.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.23.7](https://github.com/near/near-cli-rs/compare/v0.23.6...v0.23.7) - 2026-02-09
+
+### Fixed
+
+- Speed up startup time from 5s -> 10ms (500x faster) ([#557](https://github.com/near/near-cli-rs/pull/557))
+
+### Other
+
+- set MSRV to 1.88 ([#556](https://github.com/near/near-cli-rs/pull/556))
+- migrate to org-wide NEARPROTOCOL_CI_PR_ACCESS token ([#552](https://github.com/near/near-cli-rs/pull/552))
+
 ## [0.23.6](https://github.com/near/near-cli-rs/compare/v0.23.5...v0.23.6) - 2026-02-06
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2365,7 +2365,7 @@ dependencies = [
 
 [[package]]
 name = "near-cli-rs"
-version = "0.23.6"
+version = "0.23.7"
 dependencies = [
  "bip39",
  "borsh",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-cli-rs"
-version = "0.23.6"
+version = "0.23.7"
 authors = ["FroVolod <frol_off@meta.ua>", "Near Inc <hello@nearprotocol.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2024"


### PR DESCRIPTION



## 🤖 New release

* `near-cli-rs`: 0.23.6 -> 0.23.7 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.23.7](https://github.com/near/near-cli-rs/compare/v0.23.6...v0.23.7) - 2026-02-09

### Fixed

- Speed up startup time from 5s -> 10ms (500x faster) ([#557](https://github.com/near/near-cli-rs/pull/557))

### Other

- set MSRV to 1.88 ([#556](https://github.com/near/near-cli-rs/pull/556))
- migrate to org-wide NEARPROTOCOL_CI_PR_ACCESS token ([#552](https://github.com/near/near-cli-rs/pull/552))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).