### PR TITLE
feat: state-init command

### DIFF
--- a/src/commands/contract/mod.rs
+++ b/src/commands/contract/mod.rs
@@ -11,6 +11,7 @@ mod download_abi;
 pub mod download_wasm;
 #[cfg(feature = "inspect_contract")]
 mod inspect;
+pub mod state_init;
 
 #[cfg(feature = "verify_contract")]
 mod verify;
@@ -44,6 +45,11 @@ pub enum ContractActions {
     ))]
     /// Add a global contract code
     DeployAsGlobal(self::deploy_global::Contract),
+    #[strum_discriminants(strum(
+        message = "state-init       - Initialize a deterministic account with a global contract and state data"
+    ))]
+    /// Initialize a deterministic account with a global contract and state data
+    StateInit(self::state_init::StateInit),
     #[strum_discriminants(strum(
         message = "inspect          - Get a list of available function names"
     ))]

--- a/src/commands/contract/state_init/mod.rs
+++ b/src/commands/contract/state_init/mod.rs
@@ -12,22 +12,18 @@ pub struct StateInit {
 #[interactive_clap(context = crate::GlobalContext)]
 #[strum_discriminants(derive(EnumMessage, EnumIter))]
 #[non_exhaustive]
-/// How do you want to identify the global contract code?
 pub enum StateInitModeCommand {
     #[strum_discriminants(strum(
-        message = "use-global-hash       - Use a global contract code hash (immutable)"
+        message = "use-global-hash       - Use a global contract code hash"
     ))]
-    /// Use a global contract code hash (immutable)
     UseGlobalHash(StateInitWithContractHashRef),
     #[strum_discriminants(strum(
-        message = "use-global-account-id - Use a global contract account ID (mutable)"
+        message = "use-global-account-id - Use a global contract account ID"
     ))]
-    /// Use a global contract account ID (mutable)
     UseGlobalAccountId(StateInitWithContractRefByAccount),
     #[strum_discriminants(strum(
         message = "from-borsh-base64     - Provide the entire state init as a borsh+base64 blob"
     ))]
-    /// Provide the entire DeterministicAccountStateInit as a borsh-serialized + base64-encoded blob
     FromBorshBase64(StateInitFromBorshBase64),
 }
 
@@ -35,7 +31,6 @@ pub enum StateInitModeCommand {
 #[interactive_clap(input_context = crate::GlobalContext)]
 #[interactive_clap(output_context = StateInitWithContractHashRefContext)]
 pub struct StateInitWithContractHashRef {
-    /// What is the base58-encoded hash of the global contract?
     pub hash: crate::types::crypto_hash::CryptoHash,
     #[interactive_clap(subcommand)]
     data: Data,
@@ -45,7 +40,6 @@ pub struct StateInitWithContractHashRef {
 #[interactive_clap(input_context = crate::GlobalContext)]
 #[interactive_clap(output_context = StateInitWithContractRefByAccountContext)]
 pub struct StateInitWithContractRefByAccount {
-    /// What is the account ID of the global contract?
     pub account_id: crate::types::account_id::AccountId,
     #[interactive_clap(subcommand)]
     data: Data,
@@ -105,10 +99,8 @@ impl StateInitWithContractRefByAccountContext {
 #[interactive_clap(input_context = crate::GlobalContext)]
 #[interactive_clap(output_context = StateInitFromBorshBase64Context)]
 pub struct StateInitFromBorshBase64 {
-    /// Enter the borsh-serialized + base64-encoded DeterministicAccountStateInit blob:
     pub state_init_base64: String,
     #[interactive_clap(named_arg)]
-    /// Specify deposit
     deposit: Deposit,
 }
 
@@ -141,17 +133,14 @@ impl From<StateInitFromBorshBase64Context> for StateInitDataContext {
 #[interactive_clap(context = StateInitModeContext)]
 #[strum_discriminants(derive(EnumMessage, EnumIter))]
 #[non_exhaustive]
-/// How do you want to provide the initial state data?
 pub enum Data {
     #[strum_discriminants(strum(
         message = "data-from-file - Read base64-encoded key-value JSON data from a file"
     ))]
-    /// Read base64-encoded key-value JSON data from a file
     DataFromFile(DataFromFile),
     #[strum_discriminants(strum(
-        message = "data-from-json - Provide base64-encoded key-value JSON data inline"
+        message = "data-from-json - Provide base64-encoded key-value JSON data inline (e.g. '{\"AAEC\": \"AwQF\"})')"
     ))]
-    /// Provide base64-encoded key-value JSON data inline
     DataFromJson(DataFromJson),
 }
 
@@ -159,10 +148,8 @@ pub enum Data {
 #[interactive_clap(input_context = StateInitModeContext)]
 #[interactive_clap(output_context = DataFromFileContext)]
 pub struct DataFromFile {
-    /// What is the file path of the JSON state data?
     pub file_path: crate::types::path_buf::PathBuf,
     #[interactive_clap(named_arg)]
-    /// Specify deposit
     deposit: Deposit,
 }
 
@@ -170,10 +157,8 @@ pub struct DataFromFile {
 #[interactive_clap(input_context = StateInitModeContext)]
 #[interactive_clap(output_context = DataFromJsonContext)]
 pub struct DataFromJson {
-    /// Enter base64-encoded key-value JSON data (e.g. '{"AAEC": "AwQF"}' or '{}' for empty state):
     pub data: String,
     #[interactive_clap(named_arg)]
-    /// Specify deposit
     deposit: Deposit,
 }
 
@@ -263,13 +248,10 @@ impl DataFromJsonContext {
 #[interactive_clap(input_context = StateInitDataContext)]
 #[interactive_clap(output_context = DepositContext)]
 pub struct Deposit {
-    /// How much do you want to deposit with the state init (e.g. '1 NEAR' or '0 NEAR')?
     pub deposit: crate::types::near_token::NearToken,
     #[interactive_clap(skip_default_input_arg)]
-    /// What is the signer account ID?
     pub signer_account_id: crate::types::account_id::AccountId,
     #[interactive_clap(named_arg)]
-    /// Select network
     network_config: crate::network_for_transaction::NetworkForTransactionArgs,
 }
 

--- a/src/commands/contract/state_init/mod.rs
+++ b/src/commands/contract/state_init/mod.rs
@@ -23,9 +23,13 @@ pub enum StateInitModeCommand {
     ))]
     UseGlobalAccountId(StateInitWithContractRefByAccount),
     #[strum_discriminants(strum(
-        message = "from-borsh-base64     - Provide borsh serialized base64 encoded state init"
+        message = "from-borsh-base64      - Provide borsh serialized base64 encoded state init"
     ))]
     FromBorshBase64(StateInitFromBorshBase64),
+    #[strum_discriminants(strum(
+        message = "from-borsh-base64-file - Read borsh serialized base64 encoded state init from a file"
+    ))]
+    FromBorshBase64File(StateInitFromBorshBase64File),
 }
 
 #[derive(Debug, Clone, interactive_clap::InteractiveClap)]
@@ -141,6 +145,49 @@ impl StateInitFromBorshBase64Context {
 
 impl From<StateInitFromBorshBase64Context> for StateInitDataContext {
     fn from(item: StateInitFromBorshBase64Context) -> Self {
+        item.0
+    }
+}
+
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(input_context = crate::GlobalContext)]
+#[interactive_clap(output_context = StateInitFromBorshBase64FileContext)]
+pub struct StateInitFromBorshBase64File {
+    /// Enter the path to a file containing borsh-base64 encoded StateInit:
+    pub file_path: crate::types::path_buf::PathBuf,
+    #[interactive_clap(named_arg)]
+    deposit: Deposit,
+}
+
+#[derive(Debug, Clone)]
+pub struct StateInitFromBorshBase64FileContext(StateInitDataContext);
+
+impl StateInitFromBorshBase64FileContext {
+    pub fn from_previous_context(
+        previous_context: crate::GlobalContext,
+        scope: &<StateInitFromBorshBase64File as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+    ) -> color_eyre::eyre::Result<Self> {
+        let base64_str = std::fs::read_to_string(&scope.file_path).wrap_err_with(|| {
+            format!(
+                "Failed to open or read the file: {}",
+                scope.file_path.0.display()
+            )
+        })?;
+        let data = near_primitives::serialize::from_base64(base64_str.trim())
+            .wrap_err("Failed to decode base64 from file content")?;
+        let state_init = crate::common::parse_borsh_base64_state_init(&data)?;
+        let receiver_account_id =
+            near_primitives::utils::derive_near_deterministic_account_id(&state_init);
+        Ok(Self(StateInitDataContext {
+            global_context: previous_context,
+            state_init,
+            receiver_account_id,
+        }))
+    }
+}
+
+impl From<StateInitFromBorshBase64FileContext> for StateInitDataContext {
+    fn from(item: StateInitFromBorshBase64FileContext) -> Self {
         item.0
     }
 }

--- a/src/commands/contract/state_init/mod.rs
+++ b/src/commands/contract/state_init/mod.rs
@@ -22,7 +22,7 @@ pub enum StateInitModeCommand {
     ))]
     UseGlobalAccountId(StateInitWithContractRefByAccount),
     #[strum_discriminants(strum(
-        message = "from-borsh-base64     - Provide the entire state init as a borsh+base64 blob"
+        message = "from-borsh-base64     - Provide borsh serialized base64 encoded state init"
     ))]
     FromBorshBase64(StateInitFromBorshBase64),
 }
@@ -350,6 +350,7 @@ impl From<DepositContext> for crate::commands::ActionContext {
             on_after_sending_transaction_callback: std::sync::Arc::new(
                 |_outcome_view, _network_config| Ok(()),
             ),
+            sign_as_delegate_action: false,
         }
     }
 }

--- a/src/commands/contract/state_init/mod.rs
+++ b/src/commands/contract/state_init/mod.rs
@@ -1,0 +1,332 @@
+use color_eyre::eyre::Context;
+use strum::{EnumDiscriminants, EnumIter, EnumMessage};
+
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(context = crate::GlobalContext)]
+pub struct StateInit {
+    #[interactive_clap(subcommand)]
+    state_init: StateInitModeCommand,
+}
+
+#[derive(Debug, EnumDiscriminants, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(context = crate::GlobalContext)]
+#[strum_discriminants(derive(EnumMessage, EnumIter))]
+#[non_exhaustive]
+/// How do you want to identify the global contract code?
+pub enum StateInitModeCommand {
+    #[strum_discriminants(strum(
+        message = "use-global-hash       - Use a global contract code hash (immutable)"
+    ))]
+    /// Use a global contract code hash (immutable)
+    UseGlobalHash(StateInitWithContractHashRef),
+    #[strum_discriminants(strum(
+        message = "use-global-account-id - Use a global contract account ID (mutable)"
+    ))]
+    /// Use a global contract account ID (mutable)
+    UseGlobalAccountId(StateInitWithContractRefByAccount),
+}
+
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(input_context = crate::GlobalContext)]
+#[interactive_clap(output_context = StateInitWithContractHashRefContext)]
+pub struct StateInitWithContractHashRef {
+    /// What is the hash of the global contract?
+    pub hash: crate::types::crypto_hash::CryptoHash,
+    #[interactive_clap(subcommand)]
+    data: Data,
+}
+
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(input_context = crate::GlobalContext)]
+#[interactive_clap(output_context = StateInitWithContractRefByAccountContext)]
+pub struct StateInitWithContractRefByAccount {
+    /// What is the account ID of the global contract?
+    pub account_id: crate::types::account_id::AccountId,
+    #[interactive_clap(subcommand)]
+    data: Data,
+}
+
+#[derive(Debug, Clone)]
+pub struct StateInitModeContext {
+    pub global_context: crate::GlobalContext,
+    pub code: near_primitives::action::GlobalContractIdentifier,
+}
+
+#[derive(Debug, Clone)]
+pub struct StateInitWithContractHashRefContext(StateInitModeContext);
+
+impl StateInitWithContractHashRefContext {
+    pub fn from_previous_context(
+        previous_context: crate::GlobalContext,
+        scope: &<StateInitWithContractHashRef as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+    ) -> color_eyre::eyre::Result<Self> {
+        Ok(Self(StateInitModeContext {
+            global_context: previous_context,
+            code: near_primitives::action::GlobalContractIdentifier::CodeHash(scope.hash.into()),
+        }))
+    }
+}
+
+impl From<StateInitWithContractHashRefContext> for StateInitModeContext {
+    fn from(item: StateInitWithContractHashRefContext) -> Self {
+        item.0
+    }
+}
+
+impl From<StateInitWithContractRefByAccountContext> for StateInitModeContext {
+    fn from(item: StateInitWithContractRefByAccountContext) -> Self {
+        item.0
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct StateInitWithContractRefByAccountContext(StateInitModeContext);
+
+impl StateInitWithContractRefByAccountContext {
+    pub fn from_previous_context(
+        previous_context: crate::GlobalContext,
+        scope: &<StateInitWithContractRefByAccount as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+    ) -> color_eyre::eyre::Result<Self> {
+        Ok(Self(StateInitModeContext {
+            global_context: previous_context,
+            code: near_primitives::action::GlobalContractIdentifier::AccountId(
+                scope.account_id.clone().into(),
+            ),
+        }))
+    }
+}
+
+#[derive(Debug, EnumDiscriminants, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(context = StateInitModeContext)]
+#[strum_discriminants(derive(EnumMessage, EnumIter))]
+#[non_exhaustive]
+/// How do you want to provide the initial state data?
+pub enum Data {
+    #[strum_discriminants(strum(
+        message = "data-from-file - Read hex-encoded key-value JSON data from a file"
+    ))]
+    /// Read hex-encoded key-value JSON data from a file
+    DataFromFile(DataFromFile),
+    #[strum_discriminants(strum(
+        message = "data-from-json - Provide hex-encoded key-value JSON data inline"
+    ))]
+    /// Provide hex-encoded key-value JSON data inline
+    DataFromJson(DataFromJson),
+}
+
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(input_context = StateInitModeContext)]
+#[interactive_clap(output_context = DataFromFileContext)]
+pub struct DataFromFile {
+    /// What is the file path of the JSON state data?
+    pub file_path: crate::types::path_buf::PathBuf,
+    #[interactive_clap(named_arg)]
+    /// Specify deposit
+    deposit: Deposit,
+}
+
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(input_context = StateInitModeContext)]
+#[interactive_clap(output_context = DataFromJsonContext)]
+pub struct DataFromJson {
+    /// Enter hex-encoded key-value JSON data (e.g. '{"deadbeef": "cafebabe"}' or '{}' for empty state):
+    pub data: String,
+    #[interactive_clap(named_arg)]
+    /// Specify deposit
+    deposit: Deposit,
+}
+
+#[derive(Debug, Clone)]
+pub struct StateInitDataContext {
+    pub global_context: crate::GlobalContext,
+    pub state_init: near_primitives::deterministic_account_id::DeterministicAccountStateInit,
+    pub receiver_account_id: near_primitives::types::AccountId,
+}
+
+impl StateInitDataContext {
+    fn build(
+        code: near_primitives::action::GlobalContractIdentifier,
+        global_context: crate::GlobalContext,
+        data: std::collections::BTreeMap<Vec<u8>, Vec<u8>>,
+    ) -> color_eyre::eyre::Result<Self> {
+        let state_init =
+            near_primitives::deterministic_account_id::DeterministicAccountStateInit::V1(
+                near_primitives::deterministic_account_id::DeterministicAccountStateInitV1 {
+                    code,
+                    data,
+                },
+            );
+        let receiver_account_id =
+            near_primitives::utils::derive_near_deterministic_account_id(&state_init);
+        Ok(Self {
+            global_context,
+            state_init,
+            receiver_account_id,
+        })
+    }
+}
+
+impl From<DataFromFileContext> for StateInitDataContext {
+    fn from(item: DataFromFileContext) -> Self {
+        item.0
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DataFromFileContext(StateInitDataContext);
+
+impl DataFromFileContext {
+    pub fn from_previous_context(
+        previous_context: StateInitModeContext,
+        scope: &<DataFromFile as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+    ) -> color_eyre::eyre::Result<Self> {
+        let json_str = std::fs::read_to_string(&scope.file_path).wrap_err_with(|| {
+            format!(
+                "Failed to open or read the file: {}",
+                scope.file_path.0.display()
+            )
+        })?;
+        let data = crate::common::parse_hex_kv_map(&json_str)?;
+        Ok(Self(StateInitDataContext::build(
+            previous_context.code,
+            previous_context.global_context,
+            data,
+        )?))
+    }
+}
+
+impl From<DataFromJsonContext> for StateInitDataContext {
+    fn from(item: DataFromJsonContext) -> Self {
+        item.0
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DataFromJsonContext(StateInitDataContext);
+
+impl DataFromJsonContext {
+    pub fn from_previous_context(
+        previous_context: StateInitModeContext,
+        scope: &<DataFromJson as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+    ) -> color_eyre::eyre::Result<Self> {
+        let data = crate::common::parse_hex_kv_map(&scope.data)?;
+        Ok(Self(StateInitDataContext::build(
+            previous_context.code,
+            previous_context.global_context,
+            data,
+        )?))
+    }
+}
+
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(input_context = StateInitDataContext)]
+#[interactive_clap(output_context = DepositContext)]
+pub struct Deposit {
+    /// How much do you want to deposit with the state init (e.g. '1 NEAR' or '0 NEAR')?
+    pub deposit: crate::types::near_token::NearToken,
+    #[interactive_clap(skip_default_input_arg)]
+    /// What is the signer account ID?
+    pub signer_account_id: crate::types::account_id::AccountId,
+    #[interactive_clap(named_arg)]
+    /// Select network
+    network_config: crate::network_for_transaction::NetworkForTransactionArgs,
+}
+
+impl Deposit {
+    pub fn input_signer_account_id(
+        context: &StateInitDataContext,
+    ) -> color_eyre::eyre::Result<Option<crate::types::account_id::AccountId>> {
+        crate::common::input_signer_account_id_from_used_account_list(
+            &context.global_context.config.credentials_home_dir,
+            "What is the signer account ID?",
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DepositContext {
+    pub global_context: crate::GlobalContext,
+    pub state_init: near_primitives::deterministic_account_id::DeterministicAccountStateInit,
+    pub receiver_account_id: near_primitives::types::AccountId,
+    pub deposit: near_token::NearToken,
+    pub signer_account_id: near_primitives::types::AccountId,
+}
+
+impl DepositContext {
+    pub fn from_previous_context(
+        previous_context: StateInitDataContext,
+        scope: &<Deposit as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+    ) -> color_eyre::eyre::Result<Self> {
+        Ok(Self {
+            global_context: previous_context.global_context,
+            state_init: previous_context.state_init,
+            receiver_account_id: previous_context.receiver_account_id,
+            deposit: scope.deposit.into(),
+            signer_account_id: scope.signer_account_id.clone().into(),
+        })
+    }
+}
+
+impl From<DepositContext> for crate::commands::ActionContext {
+    fn from(item: DepositContext) -> Self {
+        let signer_id = item.signer_account_id.clone();
+        let receiver_id = item.receiver_account_id.clone();
+
+        let get_prepopulated_transaction_after_getting_network_callback: crate::commands::GetPrepopulatedTransactionAfterGettingNetworkCallback =
+            std::sync::Arc::new({
+                move |network_config| {
+                    use crate::common::JsonRpcClientExt as _;
+                    let receiver_id = &item.receiver_account_id;
+                    let result = network_config
+                        .json_rpc_client()
+                        .blocking_call_view_account(
+                            receiver_id,
+                            near_primitives::types::Finality::Final.into(),
+                        );
+                    // Best-effort check — only cancel if we positively confirm account exists.
+                    // All errors (UnknownAccount, network timeout, connection refused, etc.)
+                    // are treated as "proceed" to support the sign-later offline signing flow,
+                    // where the network may be unreachable at transaction construction time.
+                    if result.is_ok() {
+                        eprintln!(
+                            "\nDeterministic account <{}> already exists on <{}> network. No transaction needed.",
+                            receiver_id,
+                            network_config.network_name,
+                        );
+                        return Ok(crate::commands::PrepopulatedTransaction {
+                            signer_id: item.signer_account_id.clone(),
+                            receiver_id: item.receiver_account_id.clone(),
+                            actions: vec![],
+                        });
+                    }
+                    Ok(crate::commands::PrepopulatedTransaction {
+                        signer_id: item.signer_account_id.clone(),
+                        receiver_id: item.receiver_account_id.clone(),
+                        actions: vec![
+                            near_primitives::transaction::Action::DeterministicStateInit(Box::new(
+                                near_primitives::action::DeterministicStateInitAction {
+                                    state_init: item.state_init.clone(),
+                                    deposit: item.deposit,
+                                },
+                            )),
+                        ],
+                    })
+                }
+            });
+
+        Self {
+            global_context: item.global_context,
+            interacting_with_account_ids: vec![signer_id, receiver_id],
+            get_prepopulated_transaction_after_getting_network_callback,
+            on_before_signing_callback: std::sync::Arc::new(
+                |_prepopulated_unsigned_transaction, _network_config| Ok(()),
+            ),
+            on_before_sending_transaction_callback: std::sync::Arc::new(
+                |_signed_transaction, _network_config| Ok(String::new()),
+            ),
+            on_after_sending_transaction_callback: std::sync::Arc::new(
+                |_outcome_view, _network_config| Ok(()),
+            ),
+        }
+    }
+}

--- a/src/commands/contract/state_init/mod.rs
+++ b/src/commands/contract/state_init/mod.rs
@@ -24,11 +24,11 @@ pub enum StateInitModeCommand {
     ))]
     UseGlobalAccountId(StateInitWithContractRefByAccount),
     #[strum_discriminants(strum(
-        message = "from-borsh-base64      - Provide borsh serialized base64 encoded state init"
+        message = "from-borsh-base64     - Provide borsh serialized base64 encoded state init"
     ))]
     FromBorshBase64(StateInitFromBorshBase64),
     #[strum_discriminants(strum(
-        message = "from-borsh-file        - Read borsh-serialized state init from a file"
+        message = "from-borsh-file       - Read borsh-serialized state init from a file"
     ))]
     FromBorshFile(StateInitFromBorshFile),
 }
@@ -309,10 +309,10 @@ impl DataFromJsonContext {
 /// What would you like to do with the state-init?
 pub enum StateInitAction {
     #[strum_discriminants(strum(
-        message = "send  - Submit a transaction to initialize the deterministic account"
+        message = "execute - Submit a transaction to initialize the deterministic account"
     ))]
     /// Submit a transaction to initialize the deterministic account
-    Send(Deposit),
+    Execute(Deposit),
     #[strum_discriminants(strum(message = "inspect - Inspect state-init details"))]
     /// Inspect state-init details
     Inspect(Inspect),

--- a/src/commands/contract/state_init/mod.rs
+++ b/src/commands/contract/state_init/mod.rs
@@ -269,10 +269,9 @@ impl DataFromJsonContext {
 pub struct Deposit {
     #[interactive_clap(skip_default_input_arg)]
     pub deposit: crate::types::near_token::NearToken,
-    #[interactive_clap(skip_default_input_arg)]
-    pub signer_account_id: crate::types::account_id::AccountId,
     #[interactive_clap(named_arg)]
-    network_config: crate::network_for_transaction::NetworkForTransactionArgs,
+    /// What is the signer account ID?
+    sign_as: SignerAccountId,
 }
 
 impl Deposit {
@@ -285,15 +284,6 @@ impl Deposit {
                 .prompt()?,
         ))
     }
-
-    pub fn input_signer_account_id(
-        context: &StateInitDataContext,
-    ) -> color_eyre::eyre::Result<Option<crate::types::account_id::AccountId>> {
-        crate::common::input_signer_account_id_from_used_account_list(
-            &context.global_context.config.credentials_home_dir,
-            "What is the signer account ID?",
-        )
-    }
 }
 
 #[derive(Debug, Clone)]
@@ -302,7 +292,6 @@ pub struct DepositContext {
     pub state_init: near_primitives::deterministic_account_id::DeterministicAccountStateInit,
     pub receiver_account_id: near_primitives::types::AccountId,
     pub deposit: near_token::NearToken,
-    pub signer_account_id: near_primitives::types::AccountId,
 }
 
 impl DepositContext {
@@ -315,13 +304,59 @@ impl DepositContext {
             state_init: previous_context.state_init,
             receiver_account_id: previous_context.receiver_account_id,
             deposit: scope.deposit.into(),
+        })
+    }
+}
+
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(input_context = DepositContext)]
+#[interactive_clap(output_context = SignerAccountIdContext)]
+pub struct SignerAccountId {
+    #[interactive_clap(skip_default_input_arg)]
+    /// What is the signer account ID?
+    signer_account_id: crate::types::account_id::AccountId,
+    #[interactive_clap(named_arg)]
+    /// Select network
+    network_config: crate::network_for_transaction::NetworkForTransactionArgs,
+}
+
+impl SignerAccountId {
+    pub fn input_signer_account_id(
+        context: &DepositContext,
+    ) -> color_eyre::eyre::Result<Option<crate::types::account_id::AccountId>> {
+        crate::common::input_signer_account_id_from_used_account_list(
+            &context.global_context.config.credentials_home_dir,
+            "What is the signer account ID?",
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SignerAccountIdContext {
+    pub global_context: crate::GlobalContext,
+    pub state_init: near_primitives::deterministic_account_id::DeterministicAccountStateInit,
+    pub receiver_account_id: near_primitives::types::AccountId,
+    pub deposit: near_token::NearToken,
+    pub signer_account_id: near_primitives::types::AccountId,
+}
+
+impl SignerAccountIdContext {
+    pub fn from_previous_context(
+        previous_context: DepositContext,
+        scope: &<SignerAccountId as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+    ) -> color_eyre::eyre::Result<Self> {
+        Ok(Self {
+            global_context: previous_context.global_context,
+            state_init: previous_context.state_init,
+            receiver_account_id: previous_context.receiver_account_id,
+            deposit: previous_context.deposit,
             signer_account_id: scope.signer_account_id.clone().into(),
         })
     }
 }
 
-impl From<DepositContext> for crate::commands::ActionContext {
-    fn from(item: DepositContext) -> Self {
+impl From<SignerAccountIdContext> for crate::commands::ActionContext {
+    fn from(item: SignerAccountIdContext) -> Self {
         let signer_id = item.signer_account_id.clone();
         let receiver_id = item.receiver_account_id.clone();
 

--- a/src/commands/contract/state_init/mod.rs
+++ b/src/commands/contract/state_init/mod.rs
@@ -31,6 +31,14 @@ pub enum StateInitModeCommand {
         message = "from-borsh-file       - Read borsh-serialized state init from a file"
     ))]
     FromBorshFile(StateInitFromBorshFile),
+    #[strum_discriminants(strum(
+        message = "from-json             - Provide JSON-serialized state init inline"
+    ))]
+    FromJson(StateInitFromJson),
+    #[strum_discriminants(strum(
+        message = "from-json-file        - Read JSON-serialized state init from a file"
+    ))]
+    FromJsonFile(StateInitFromJsonFile),
 }
 
 #[derive(Debug, Clone, interactive_clap::InteractiveClap)]
@@ -176,6 +184,80 @@ impl StateInitFromBorshFileContext {
 
 impl From<StateInitFromBorshFileContext> for StateInitDataContext {
     fn from(item: StateInitFromBorshFileContext) -> Self {
+        item.0
+    }
+}
+
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(input_context = crate::GlobalContext)]
+#[interactive_clap(output_context = StateInitFromJsonContext)]
+pub struct StateInitFromJson {
+    /// Enter the JSON-serialized StateInit:
+    pub state_init_json: String,
+    #[interactive_clap(subcommand)]
+    action: StateInitAction,
+}
+
+#[derive(Debug, Clone)]
+pub struct StateInitFromJsonContext(StateInitDataContext);
+
+impl StateInitFromJsonContext {
+    pub fn from_previous_context(
+        previous_context: crate::GlobalContext,
+        scope: &<StateInitFromJson as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+    ) -> color_eyre::eyre::Result<Self> {
+        let state_init: near_primitives::deterministic_account_id::DeterministicAccountStateInit =
+            serde_json::from_str(&scope.state_init_json)
+                .wrap_err("Failed to parse JSON-serialized StateInit")?;
+        Ok(Self(StateInitDataContext::new(
+            previous_context,
+            state_init,
+        )))
+    }
+}
+
+impl From<StateInitFromJsonContext> for StateInitDataContext {
+    fn from(item: StateInitFromJsonContext) -> Self {
+        item.0
+    }
+}
+
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(input_context = crate::GlobalContext)]
+#[interactive_clap(output_context = StateInitFromJsonFileContext)]
+pub struct StateInitFromJsonFile {
+    /// Enter the path to a file containing JSON-serialized StateInit:
+    pub file_path: crate::types::path_buf::PathBuf,
+    #[interactive_clap(subcommand)]
+    action: StateInitAction,
+}
+
+#[derive(Debug, Clone)]
+pub struct StateInitFromJsonFileContext(StateInitDataContext);
+
+impl StateInitFromJsonFileContext {
+    pub fn from_previous_context(
+        previous_context: crate::GlobalContext,
+        scope: &<StateInitFromJsonFile as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+    ) -> color_eyre::eyre::Result<Self> {
+        let json_str = std::fs::read_to_string(&scope.file_path).wrap_err_with(|| {
+            format!(
+                "Failed to open or read the file: {}",
+                scope.file_path.0.display()
+            )
+        })?;
+        let state_init: near_primitives::deterministic_account_id::DeterministicAccountStateInit =
+            serde_json::from_str(&json_str)
+                .wrap_err("Failed to parse JSON-serialized StateInit")?;
+        Ok(Self(StateInitDataContext::new(
+            previous_context,
+            state_init,
+        )))
+    }
+}
+
+impl From<StateInitFromJsonFileContext> for StateInitDataContext {
+    fn from(item: StateInitFromJsonFileContext) -> Self {
         item.0
     }
 }

--- a/src/commands/contract/state_init/mod.rs
+++ b/src/commands/contract/state_init/mod.rs
@@ -127,7 +127,8 @@ impl StateInitFromBorshBase64Context {
         previous_context: crate::GlobalContext,
         scope: &<StateInitFromBorshBase64 as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
     ) -> color_eyre::eyre::Result<Self> {
-        let state_init = crate::common::parse_borsh_base64_state_init(scope.state_init_base64.as_bytes())?;
+        let state_init =
+            crate::common::parse_borsh_base64_state_init(scope.state_init_base64.as_bytes())?;
         let receiver_account_id =
             near_primitives::utils::derive_near_deterministic_account_id(&state_init);
         Ok(Self(StateInitDataContext {
@@ -266,6 +267,7 @@ impl DataFromJsonContext {
 #[interactive_clap(input_context = StateInitDataContext)]
 #[interactive_clap(output_context = DepositContext)]
 pub struct Deposit {
+    #[interactive_clap(skip_default_input_arg)]
     pub deposit: crate::types::near_token::NearToken,
     #[interactive_clap(skip_default_input_arg)]
     pub signer_account_id: crate::types::account_id::AccountId,
@@ -274,6 +276,16 @@ pub struct Deposit {
 }
 
 impl Deposit {
+    pub fn input_deposit(
+        _context: &StateInitDataContext,
+    ) -> color_eyre::eyre::Result<Option<crate::types::near_token::NearToken>> {
+        Ok(Some(
+            inquire::CustomType::new("What is the deposit for the state init call?")
+                .with_starting_input("0 NEAR")
+                .prompt()?,
+        ))
+    }
+
     pub fn input_signer_account_id(
         context: &StateInitDataContext,
     ) -> color_eyre::eyre::Result<Option<crate::types::account_id::AccountId>> {

--- a/src/commands/contract/state_init/mod.rs
+++ b/src/commands/contract/state_init/mod.rs
@@ -24,14 +24,6 @@ pub enum StateInitModeCommand {
     ))]
     UseGlobalAccountId(StateInitWithContractRefByAccount),
     #[strum_discriminants(strum(
-        message = "from-borsh-base64     - Provide borsh serialized base64 encoded state init"
-    ))]
-    FromBorshBase64(StateInitFromBorshBase64),
-    #[strum_discriminants(strum(
-        message = "from-borsh-file       - Read borsh-serialized state init from a file"
-    ))]
-    FromBorshFile(StateInitFromBorshFile),
-    #[strum_discriminants(strum(
         message = "from-json             - Provide JSON-serialized state init inline"
     ))]
     FromJson(StateInitFromJson),
@@ -39,6 +31,14 @@ pub enum StateInitModeCommand {
         message = "from-json-file        - Read JSON-serialized state init from a file"
     ))]
     FromJsonFile(StateInitFromJsonFile),
+    #[strum_discriminants(strum(
+        message = "from-borsh-base64     - Provide borsh serialized base64 encoded state init"
+    ))]
+    FromBorshBase64(StateInitFromBorshBase64),
+    #[strum_discriminants(strum(
+        message = "from-borsh-file       - Read borsh-serialized state init from a file"
+    ))]
+    FromBorshFile(StateInitFromBorshFile),
 }
 
 #[derive(Debug, Clone, interactive_clap::InteractiveClap)]
@@ -456,12 +456,12 @@ pub struct InspectStateInit {
 #[strum_discriminants(derive(EnumMessage, EnumIter))]
 /// In which format would you like to display the state-init?
 pub enum InspectStateInitFormat {
-    #[strum_discriminants(strum(message = "borsh - Borsh-serialized base64"))]
-    /// Borsh-serialized base64
-    Borsh(InspectStateInitBorsh),
     #[strum_discriminants(strum(message = "json  - JSON-serialized"))]
     /// JSON-serialized
     Json(InspectStateInitJson),
+    #[strum_discriminants(strum(message = "borsh - Borsh-serialized base64"))]
+    /// Borsh-serialized base64
+    Borsh(InspectStateInitBorsh),
 }
 
 #[derive(Debug, Clone, interactive_clap::InteractiveClap)]

--- a/src/commands/contract/state_init/mod.rs
+++ b/src/commands/contract/state_init/mod.rs
@@ -119,8 +119,8 @@ impl StateInitWithContractRefByAccountContext {
 pub struct StateInitFromBorshBase64 {
     /// Enter the borsh-base64 encoded StateInit:
     pub state_init_base64: crate::types::base64_bytes::Base64Bytes,
-    #[interactive_clap(named_arg)]
-    deposit: Deposit,
+    #[interactive_clap(subcommand)]
+    action: StateInitAction,
 }
 
 #[derive(Debug, Clone)]
@@ -155,8 +155,8 @@ impl From<StateInitFromBorshBase64Context> for StateInitDataContext {
 pub struct StateInitFromBorshBase64File {
     /// Enter the path to a file containing borsh-base64 encoded StateInit:
     pub file_path: crate::types::path_buf::PathBuf,
-    #[interactive_clap(named_arg)]
-    deposit: Deposit,
+    #[interactive_clap(subcommand)]
+    action: StateInitAction,
 }
 
 #[derive(Debug, Clone)]
@@ -214,8 +214,8 @@ pub enum Data {
 pub struct DataFromFile {
     /// Enter the path to the file with base64-encoded key-value JSON data:
     pub file_path: crate::types::path_buf::PathBuf,
-    #[interactive_clap(named_arg)]
-    deposit: Deposit,
+    #[interactive_clap(subcommand)]
+    action: StateInitAction,
 }
 
 #[derive(Debug, Clone, interactive_clap::InteractiveClap)]
@@ -224,8 +224,8 @@ pub struct DataFromFile {
 pub struct DataFromJson {
     /// Enter the base64-encoded key-value JSON data (e.g. '{"AAEC": "AwQF"}'):
     pub data: String,
-    #[interactive_clap(named_arg)]
-    deposit: Deposit,
+    #[interactive_clap(subcommand)]
+    action: StateInitAction,
 }
 
 #[derive(Debug, Clone)]
@@ -307,6 +307,123 @@ impl DataFromJsonContext {
             previous_context.global_context,
             data,
         )?))
+    }
+}
+
+#[derive(Debug, EnumDiscriminants, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(context = StateInitDataContext)]
+#[strum_discriminants(derive(EnumMessage, EnumIter))]
+#[non_exhaustive]
+/// What would you like to do with the state-init?
+pub enum StateInitAction {
+    #[strum_discriminants(strum(
+        message = "send  - Submit a transaction to initialize the deterministic account"
+    ))]
+    /// Submit a transaction to initialize the deterministic account
+    Send(Deposit),
+    #[strum_discriminants(strum(message = "print - Print state-init details"))]
+    /// Print state-init details
+    Print(Print),
+}
+
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(context = StateInitDataContext)]
+pub struct Print {
+    #[interactive_clap(subcommand)]
+    action: PrintAction,
+}
+
+#[derive(Debug, EnumDiscriminants, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(context = StateInitDataContext)]
+#[strum_discriminants(derive(EnumMessage, EnumIter))]
+#[non_exhaustive]
+/// What would you like to print?
+pub enum PrintAction {
+    #[strum_discriminants(strum(
+        message = "account-id - Print the derived deterministic account ID"
+    ))]
+    /// Print the derived deterministic account ID
+    AccountId(PrintAccountId),
+    #[strum_discriminants(strum(
+        message = "state-init - Print the borsh-base64 encoded state-init"
+    ))]
+    /// Print the borsh-base64 encoded state-init
+    StateInit(PrintStateInit),
+    #[strum_discriminants(strum(message = "kv-map     - Print the key-value data map"))]
+    /// Print the key-value data map
+    KvMap(PrintKvMap),
+}
+
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(input_context = StateInitDataContext)]
+#[interactive_clap(output_context = PrintAccountIdContext)]
+pub struct PrintAccountId {}
+
+#[derive(Debug, Clone)]
+pub struct PrintAccountIdContext;
+
+impl PrintAccountIdContext {
+    pub fn from_previous_context(
+        previous_context: StateInitDataContext,
+        _scope: &<PrintAccountId as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+    ) -> color_eyre::eyre::Result<Self> {
+        println!("{}", previous_context.receiver_account_id);
+        Ok(Self)
+    }
+}
+
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(input_context = StateInitDataContext)]
+#[interactive_clap(output_context = PrintStateInitContext)]
+pub struct PrintStateInit {}
+
+#[derive(Debug, Clone)]
+pub struct PrintStateInitContext;
+
+impl PrintStateInitContext {
+    pub fn from_previous_context(
+        previous_context: StateInitDataContext,
+        _scope: &<PrintStateInit as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+    ) -> color_eyre::eyre::Result<Self> {
+        let bytes = borsh::to_vec(&previous_context.state_init)
+            .map_err(|e| color_eyre::eyre::eyre!("Failed to borsh-serialize state-init: {e}"))?;
+        println!("{}", near_primitives::serialize::to_base64(&bytes));
+        Ok(Self)
+    }
+}
+
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(input_context = StateInitDataContext)]
+#[interactive_clap(output_context = PrintKvMapContext)]
+pub struct PrintKvMap {}
+
+#[derive(Debug, Clone)]
+pub struct PrintKvMapContext;
+
+impl PrintKvMapContext {
+    pub fn from_previous_context(
+        previous_context: StateInitDataContext,
+        _scope: &<PrintKvMap as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+    ) -> color_eyre::eyre::Result<Self> {
+        let data = match &previous_context.state_init {
+            near_primitives::deterministic_account_id::DeterministicAccountStateInit::V1(v1) => {
+                &v1.data
+            }
+        };
+        let map: std::collections::BTreeMap<String, String> = data
+            .iter()
+            .map(|(k, v)| {
+                (
+                    near_primitives::serialize::to_base64(k),
+                    near_primitives::serialize::to_base64(v),
+                )
+            })
+            .collect();
+        println!(
+            "{}",
+            serde_json::to_string(&map).expect("BTreeMap<String, String> should be serializable")
+        );
+        Ok(Self)
     }
 }
 

--- a/src/commands/contract/state_init/mod.rs
+++ b/src/commands/contract/state_init/mod.rs
@@ -336,10 +336,8 @@ pub enum InspectAction {
     ))]
     /// Inspect the derived deterministic account ID
     AccountId(InspectAccountId),
-    #[strum_discriminants(strum(
-        message = "state-init - Inspect the borsh-base64 encoded state-init"
-    ))]
-    /// Inspect the borsh-base64 encoded state-init
+    #[strum_discriminants(strum(message = "state-init - Inspect the state-init"))]
+    /// Inspect the state-init
     StateInit(InspectStateInit),
     #[strum_discriminants(strum(message = "kv-map     - Inspect the key-value data map"))]
     /// Inspect the key-value data map
@@ -365,21 +363,64 @@ impl InspectAccountIdContext {
 }
 
 #[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(context = StateInitDataContext)]
+pub struct InspectStateInit {
+    #[interactive_clap(subcommand)]
+    format: InspectStateInitFormat,
+}
+
+#[derive(Debug, EnumDiscriminants, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(context = StateInitDataContext)]
+#[strum_discriminants(derive(EnumMessage, EnumIter))]
+/// In which format would you like to display the state-init?
+pub enum InspectStateInitFormat {
+    #[strum_discriminants(strum(message = "borsh - Borsh-serialized base64"))]
+    /// Borsh-serialized base64
+    Borsh(InspectStateInitBorsh),
+    #[strum_discriminants(strum(message = "json  - JSON-serialized"))]
+    /// JSON-serialized
+    Json(InspectStateInitJson),
+}
+
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
 #[interactive_clap(input_context = StateInitDataContext)]
-#[interactive_clap(output_context = InspectStateInitContext)]
-pub struct InspectStateInit {}
+#[interactive_clap(output_context = InspectStateInitBorshContext)]
+pub struct InspectStateInitBorsh {}
 
 #[derive(Debug, Clone)]
-pub struct InspectStateInitContext;
+pub struct InspectStateInitBorshContext;
 
-impl InspectStateInitContext {
+impl InspectStateInitBorshContext {
     pub fn from_previous_context(
         previous_context: StateInitDataContext,
-        _scope: &<InspectStateInit as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+        _scope: &<InspectStateInitBorsh as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
     ) -> color_eyre::eyre::Result<Self> {
         let bytes = borsh::to_vec(&previous_context.state_init)
             .map_err(|e| color_eyre::eyre::eyre!("Failed to borsh-serialize state-init: {e}"))?;
         println!("{}", near_primitives::serialize::to_base64(&bytes));
+        Ok(Self)
+    }
+}
+
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(input_context = StateInitDataContext)]
+#[interactive_clap(output_context = InspectStateInitJsonContext)]
+pub struct InspectStateInitJson {}
+
+#[derive(Debug, Clone)]
+pub struct InspectStateInitJsonContext;
+
+impl InspectStateInitJsonContext {
+    pub fn from_previous_context(
+        previous_context: StateInitDataContext,
+        _scope: &<InspectStateInitJson as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+    ) -> color_eyre::eyre::Result<Self> {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&previous_context.state_init).map_err(
+                |e| color_eyre::eyre::eyre!("Failed to serialize state-init to JSON: {e}")
+            )?
+        );
         Ok(Self)
     }
 }

--- a/src/commands/contract/state_init/mod.rs
+++ b/src/commands/contract/state_init/mod.rs
@@ -12,6 +12,7 @@ pub struct StateInit {
 #[interactive_clap(context = crate::GlobalContext)]
 #[strum_discriminants(derive(EnumMessage, EnumIter))]
 #[non_exhaustive]
+/// Provide state-init details:
 pub enum StateInitModeCommand {
     #[strum_discriminants(strum(
         message = "use-global-hash       - Use a global contract code hash"
@@ -31,18 +32,40 @@ pub enum StateInitModeCommand {
 #[interactive_clap(input_context = crate::GlobalContext)]
 #[interactive_clap(output_context = StateInitWithContractHashRefContext)]
 pub struct StateInitWithContractHashRef {
+    #[interactive_clap(skip_default_input_arg)]
     pub hash: crate::types::crypto_hash::CryptoHash,
     #[interactive_clap(subcommand)]
     data: Data,
+}
+
+impl StateInitWithContractHashRef {
+    pub fn input_hash(
+        _context: &crate::GlobalContext,
+    ) -> color_eyre::eyre::Result<Option<crate::types::crypto_hash::CryptoHash>> {
+        Ok(Some(
+            inquire::CustomType::new("Enter the global contract code hash:").prompt()?,
+        ))
+    }
 }
 
 #[derive(Debug, Clone, interactive_clap::InteractiveClap)]
 #[interactive_clap(input_context = crate::GlobalContext)]
 #[interactive_clap(output_context = StateInitWithContractRefByAccountContext)]
 pub struct StateInitWithContractRefByAccount {
+    #[interactive_clap(skip_default_input_arg)]
     pub account_id: crate::types::account_id::AccountId,
     #[interactive_clap(subcommand)]
     data: Data,
+}
+
+impl StateInitWithContractRefByAccount {
+    pub fn input_account_id(
+        _context: &crate::GlobalContext,
+    ) -> color_eyre::eyre::Result<Option<crate::types::account_id::AccountId>> {
+        Ok(Some(
+            inquire::CustomType::new("Enter the global contract account ID:").prompt()?,
+        ))
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -99,9 +122,20 @@ impl StateInitWithContractRefByAccountContext {
 #[interactive_clap(input_context = crate::GlobalContext)]
 #[interactive_clap(output_context = StateInitFromBorshBase64Context)]
 pub struct StateInitFromBorshBase64 {
+    #[interactive_clap(skip_default_input_arg)]
     pub state_init_base64: String,
     #[interactive_clap(named_arg)]
     deposit: Deposit,
+}
+
+impl StateInitFromBorshBase64 {
+    pub fn input_state_init_base64(
+        _context: &crate::GlobalContext,
+    ) -> color_eyre::eyre::Result<Option<String>> {
+        Ok(Some(
+            inquire::Text::new("Enter the borsh-base64 encoded StateInit:").prompt()?,
+        ))
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -133,6 +167,7 @@ impl From<StateInitFromBorshBase64Context> for StateInitDataContext {
 #[interactive_clap(context = StateInitModeContext)]
 #[strum_discriminants(derive(EnumMessage, EnumIter))]
 #[non_exhaustive]
+/// How would you like to provide the initial state data?
 pub enum Data {
     #[strum_discriminants(strum(
         message = "data-from-file - Read base64-encoded key-value JSON data from a file"
@@ -148,18 +183,44 @@ pub enum Data {
 #[interactive_clap(input_context = StateInitModeContext)]
 #[interactive_clap(output_context = DataFromFileContext)]
 pub struct DataFromFile {
+    #[interactive_clap(skip_default_input_arg)]
     pub file_path: crate::types::path_buf::PathBuf,
     #[interactive_clap(named_arg)]
     deposit: Deposit,
+}
+
+impl DataFromFile {
+    pub fn input_file_path(
+        _context: &StateInitModeContext,
+    ) -> color_eyre::eyre::Result<Option<crate::types::path_buf::PathBuf>> {
+        Ok(Some(
+            inquire::CustomType::new(
+                "Enter the path to the file with base64-encoded key-value JSON data:",
+            )
+            .prompt()?,
+        ))
+    }
 }
 
 #[derive(Debug, Clone, interactive_clap::InteractiveClap)]
 #[interactive_clap(input_context = StateInitModeContext)]
 #[interactive_clap(output_context = DataFromJsonContext)]
 pub struct DataFromJson {
+    #[interactive_clap(skip_default_input_arg)]
     pub data: String,
     #[interactive_clap(named_arg)]
     deposit: Deposit,
+}
+
+impl DataFromJson {
+    pub fn input_data(_context: &StateInitModeContext) -> color_eyre::eyre::Result<Option<String>> {
+        Ok(Some(
+            inquire::Text::new(
+                "Enter the base64-encoded key-value JSON data (e.g. '{\"AAEC\": \"AwQF\"}'):",
+            )
+            .prompt()?,
+        ))
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/commands/contract/state_init/mod.rs
+++ b/src/commands/contract/state_init/mod.rs
@@ -320,51 +320,51 @@ pub enum StateInitAction {
     ))]
     /// Submit a transaction to initialize the deterministic account
     Send(Deposit),
-    #[strum_discriminants(strum(message = "print - Print state-init details"))]
-    /// Print state-init details
-    Print(Print),
+    #[strum_discriminants(strum(message = "inspect - Inspect state-init details"))]
+    /// Inspect state-init details
+    Inspect(Inspect),
 }
 
 #[derive(Debug, Clone, interactive_clap::InteractiveClap)]
 #[interactive_clap(context = StateInitDataContext)]
-pub struct Print {
+pub struct Inspect {
     #[interactive_clap(subcommand)]
-    action: PrintAction,
+    action: InspectAction,
 }
 
 #[derive(Debug, EnumDiscriminants, Clone, interactive_clap::InteractiveClap)]
 #[interactive_clap(context = StateInitDataContext)]
 #[strum_discriminants(derive(EnumMessage, EnumIter))]
 #[non_exhaustive]
-/// What would you like to print?
-pub enum PrintAction {
+/// What would you like to inspect?
+pub enum InspectAction {
     #[strum_discriminants(strum(
-        message = "account-id - Print the derived deterministic account ID"
+        message = "account-id - Inspect the derived deterministic account ID"
     ))]
-    /// Print the derived deterministic account ID
-    AccountId(PrintAccountId),
+    /// Inspect the derived deterministic account ID
+    AccountId(InspectAccountId),
     #[strum_discriminants(strum(
-        message = "state-init - Print the borsh-base64 encoded state-init"
+        message = "state-init - Inspect the borsh-base64 encoded state-init"
     ))]
-    /// Print the borsh-base64 encoded state-init
-    StateInit(PrintStateInit),
-    #[strum_discriminants(strum(message = "kv-map     - Print the key-value data map"))]
-    /// Print the key-value data map
-    KvMap(PrintKvMap),
+    /// Inspect the borsh-base64 encoded state-init
+    StateInit(InspectStateInit),
+    #[strum_discriminants(strum(message = "kv-map     - Inspect the key-value data map"))]
+    /// Inspect the key-value data map
+    KvMap(InspectKvMap),
 }
 
 #[derive(Debug, Clone, interactive_clap::InteractiveClap)]
 #[interactive_clap(input_context = StateInitDataContext)]
-#[interactive_clap(output_context = PrintAccountIdContext)]
-pub struct PrintAccountId {}
+#[interactive_clap(output_context = InspectAccountIdContext)]
+pub struct InspectAccountId {}
 
 #[derive(Debug, Clone)]
-pub struct PrintAccountIdContext;
+pub struct InspectAccountIdContext;
 
-impl PrintAccountIdContext {
+impl InspectAccountIdContext {
     pub fn from_previous_context(
         previous_context: StateInitDataContext,
-        _scope: &<PrintAccountId as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+        _scope: &<InspectAccountId as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
     ) -> color_eyre::eyre::Result<Self> {
         println!("{}", previous_context.receiver_account_id);
         Ok(Self)
@@ -373,16 +373,16 @@ impl PrintAccountIdContext {
 
 #[derive(Debug, Clone, interactive_clap::InteractiveClap)]
 #[interactive_clap(input_context = StateInitDataContext)]
-#[interactive_clap(output_context = PrintStateInitContext)]
-pub struct PrintStateInit {}
+#[interactive_clap(output_context = InspectStateInitContext)]
+pub struct InspectStateInit {}
 
 #[derive(Debug, Clone)]
-pub struct PrintStateInitContext;
+pub struct InspectStateInitContext;
 
-impl PrintStateInitContext {
+impl InspectStateInitContext {
     pub fn from_previous_context(
         previous_context: StateInitDataContext,
-        _scope: &<PrintStateInit as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+        _scope: &<InspectStateInit as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
     ) -> color_eyre::eyre::Result<Self> {
         let bytes = borsh::to_vec(&previous_context.state_init)
             .map_err(|e| color_eyre::eyre::eyre!("Failed to borsh-serialize state-init: {e}"))?;
@@ -393,16 +393,16 @@ impl PrintStateInitContext {
 
 #[derive(Debug, Clone, interactive_clap::InteractiveClap)]
 #[interactive_clap(input_context = StateInitDataContext)]
-#[interactive_clap(output_context = PrintKvMapContext)]
-pub struct PrintKvMap {}
+#[interactive_clap(output_context = InspectKvMapContext)]
+pub struct InspectKvMap {}
 
 #[derive(Debug, Clone)]
-pub struct PrintKvMapContext;
+pub struct InspectKvMapContext;
 
-impl PrintKvMapContext {
+impl InspectKvMapContext {
     pub fn from_previous_context(
         previous_context: StateInitDataContext,
-        _scope: &<PrintKvMap as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+        _scope: &<InspectKvMap as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
     ) -> color_eyre::eyre::Result<Self> {
         let data = match &previous_context.state_init {
             near_primitives::deterministic_account_id::DeterministicAccountStateInit::V1(v1) => {

--- a/src/commands/contract/state_init/mod.rs
+++ b/src/commands/contract/state_init/mod.rs
@@ -32,20 +32,10 @@ pub enum StateInitModeCommand {
 #[interactive_clap(input_context = crate::GlobalContext)]
 #[interactive_clap(output_context = StateInitWithContractHashRefContext)]
 pub struct StateInitWithContractHashRef {
-    #[interactive_clap(skip_default_input_arg)]
+    /// Enter the global contract code hash:
     pub hash: crate::types::crypto_hash::CryptoHash,
     #[interactive_clap(subcommand)]
     data: Data,
-}
-
-impl StateInitWithContractHashRef {
-    pub fn input_hash(
-        _context: &crate::GlobalContext,
-    ) -> color_eyre::eyre::Result<Option<crate::types::crypto_hash::CryptoHash>> {
-        Ok(Some(
-            inquire::CustomType::new("Enter the global contract code hash:").prompt()?,
-        ))
-    }
 }
 
 #[derive(Debug, Clone, interactive_clap::InteractiveClap)]
@@ -60,11 +50,12 @@ pub struct StateInitWithContractRefByAccount {
 
 impl StateInitWithContractRefByAccount {
     pub fn input_account_id(
-        _context: &crate::GlobalContext,
+        context: &crate::GlobalContext,
     ) -> color_eyre::eyre::Result<Option<crate::types::account_id::AccountId>> {
-        Ok(Some(
-            inquire::CustomType::new("Enter the global contract account ID:").prompt()?,
-        ))
+        crate::common::input_non_signer_account_id_from_used_account_list(
+            &context.config.credentials_home_dir,
+            "Enter the global contract account ID:",
+        )
     }
 }
 
@@ -122,20 +113,10 @@ impl StateInitWithContractRefByAccountContext {
 #[interactive_clap(input_context = crate::GlobalContext)]
 #[interactive_clap(output_context = StateInitFromBorshBase64Context)]
 pub struct StateInitFromBorshBase64 {
-    #[interactive_clap(skip_default_input_arg)]
-    pub state_init_base64: String,
+    /// Enter the borsh-base64 encoded StateInit:
+    pub state_init_base64: crate::types::base64_bytes::Base64Bytes,
     #[interactive_clap(named_arg)]
     deposit: Deposit,
-}
-
-impl StateInitFromBorshBase64 {
-    pub fn input_state_init_base64(
-        _context: &crate::GlobalContext,
-    ) -> color_eyre::eyre::Result<Option<String>> {
-        Ok(Some(
-            inquire::Text::new("Enter the borsh-base64 encoded StateInit:").prompt()?,
-        ))
-    }
 }
 
 #[derive(Debug, Clone)]
@@ -146,7 +127,7 @@ impl StateInitFromBorshBase64Context {
         previous_context: crate::GlobalContext,
         scope: &<StateInitFromBorshBase64 as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
     ) -> color_eyre::eyre::Result<Self> {
-        let state_init = crate::common::parse_borsh_base64_state_init(&scope.state_init_base64)?;
+        let state_init = crate::common::parse_borsh_base64_state_init(scope.state_init_base64.as_bytes())?;
         let receiver_account_id =
             near_primitives::utils::derive_near_deterministic_account_id(&state_init);
         Ok(Self(StateInitDataContext {
@@ -183,44 +164,20 @@ pub enum Data {
 #[interactive_clap(input_context = StateInitModeContext)]
 #[interactive_clap(output_context = DataFromFileContext)]
 pub struct DataFromFile {
-    #[interactive_clap(skip_default_input_arg)]
+    /// Enter the path to the file with base64-encoded key-value JSON data :
     pub file_path: crate::types::path_buf::PathBuf,
     #[interactive_clap(named_arg)]
     deposit: Deposit,
-}
-
-impl DataFromFile {
-    pub fn input_file_path(
-        _context: &StateInitModeContext,
-    ) -> color_eyre::eyre::Result<Option<crate::types::path_buf::PathBuf>> {
-        Ok(Some(
-            inquire::CustomType::new(
-                "Enter the path to the file with base64-encoded key-value JSON data:",
-            )
-            .prompt()?,
-        ))
-    }
 }
 
 #[derive(Debug, Clone, interactive_clap::InteractiveClap)]
 #[interactive_clap(input_context = StateInitModeContext)]
 #[interactive_clap(output_context = DataFromJsonContext)]
 pub struct DataFromJson {
-    #[interactive_clap(skip_default_input_arg)]
+    /// Enter the base64-encoded key-value JSON data (e.g. '{\"AAEC\": \"AwQF\"}'):
     pub data: String,
     #[interactive_clap(named_arg)]
     deposit: Deposit,
-}
-
-impl DataFromJson {
-    pub fn input_data(_context: &StateInitModeContext) -> color_eyre::eyre::Result<Option<String>> {
-        Ok(Some(
-            inquire::Text::new(
-                "Enter the base64-encoded key-value JSON data (e.g. '{\"AAEC\": \"AwQF\"}'):",
-            )
-            .prompt()?,
-        ))
-    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/commands/contract/state_init/mod.rs
+++ b/src/commands/contract/state_init/mod.rs
@@ -199,13 +199,13 @@ impl From<StateInitFromBorshBase64FileContext> for StateInitDataContext {
 /// How would you like to provide the initial state data?
 pub enum Data {
     #[strum_discriminants(strum(
-        message = "data-from-file - Read base64-encoded key-value JSON data from a file"
-    ))]
-    DataFromFile(DataFromFile),
-    #[strum_discriminants(strum(
         message = "data-from-json - Provide base64-encoded key-value JSON inline"
     ))]
     DataFromJson(DataFromJson),
+    #[strum_discriminants(strum(
+        message = "data-from-file - Read base64-encoded key-value JSON data from a file"
+    ))]
+    DataFromFile(DataFromFile),
 }
 
 #[derive(Debug, Clone, interactive_clap::InteractiveClap)]

--- a/src/commands/contract/state_init/mod.rs
+++ b/src/commands/contract/state_init/mod.rs
@@ -206,9 +206,11 @@ impl StateInitFromJsonContext {
         previous_context: crate::GlobalContext,
         scope: &<StateInitFromJson as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
     ) -> color_eyre::eyre::Result<Self> {
-        let state_init: near_primitives::deterministic_account_id::DeterministicAccountStateInit =
-            serde_json::from_str(&scope.state_init_json)
-                .wrap_err("Failed to parse JSON-serialized StateInit")?;
+        let state_init = serde_json::from_str::<crate::common::DeterministicAccountStateInitView>(
+            &scope.state_init_json,
+        )
+        .map(Into::into)
+        .wrap_err("Failed to parse JSON-serialized StateInit")?;
         Ok(Self(StateInitDataContext::new(
             previous_context,
             state_init,
@@ -246,8 +248,9 @@ impl StateInitFromJsonFileContext {
                 scope.file_path.0.display()
             )
         })?;
-        let state_init: near_primitives::deterministic_account_id::DeterministicAccountStateInit =
-            serde_json::from_str(&json_str)
+        let state_init =
+            serde_json::from_str::<crate::common::DeterministicAccountStateInitView>(&json_str)
+                .map(Into::into)
                 .wrap_err("Failed to parse JSON-serialized StateInit")?;
         Ok(Self(StateInitDataContext::new(
             previous_context,
@@ -499,9 +502,10 @@ impl InspectStateInitJsonContext {
     ) -> color_eyre::eyre::Result<Self> {
         println!(
             "{}",
-            serde_json::to_string_pretty(&previous_context.state_init).map_err(
-                |e| color_eyre::eyre::eyre!("Failed to serialize state-init to JSON: {e}")
-            )?
+            serde_json::to_string_pretty(&crate::common::DeterministicAccountStateInitView::from(
+                previous_context.state_init
+            ))
+            .map_err(|e| color_eyre::eyre::eyre!("Failed to serialize state-init to JSON: {e}"))?
         );
         Ok(Self)
     }

--- a/src/commands/contract/state_init/mod.rs
+++ b/src/commands/contract/state_init/mod.rs
@@ -1,4 +1,5 @@
 use color_eyre::eyre::Context;
+use serde_with::{base64::Base64, serde_as};
 use strum::{EnumDiscriminants, EnumIter, EnumMessage};
 
 #[derive(Debug, Clone, interactive_clap::InteractiveClap)]
@@ -133,13 +134,10 @@ impl StateInitFromBorshBase64Context {
     ) -> color_eyre::eyre::Result<Self> {
         let state_init =
             crate::common::parse_borsh_base64_state_init(scope.state_init_base64.as_bytes())?;
-        let receiver_account_id =
-            near_primitives::utils::derive_near_deterministic_account_id(&state_init);
-        Ok(Self(StateInitDataContext {
-            global_context: previous_context,
+        Ok(Self(StateInitDataContext::new(
+            previous_context,
             state_init,
-            receiver_account_id,
-        }))
+        )))
     }
 }
 
@@ -176,13 +174,10 @@ impl StateInitFromBorshBase64FileContext {
         let data = near_primitives::serialize::from_base64(base64_str.trim())
             .wrap_err("Failed to decode base64 from file content")?;
         let state_init = crate::common::parse_borsh_base64_state_init(&data)?;
-        let receiver_account_id =
-            near_primitives::utils::derive_near_deterministic_account_id(&state_init);
-        Ok(Self(StateInitDataContext {
-            global_context: previous_context,
+        Ok(Self(StateInitDataContext::new(
+            previous_context,
             state_init,
-            receiver_account_id,
-        }))
+        )))
     }
 }
 
@@ -236,25 +231,17 @@ pub struct StateInitDataContext {
 }
 
 impl StateInitDataContext {
-    fn build(
-        code: near_primitives::action::GlobalContractIdentifier,
+    fn new(
         global_context: crate::GlobalContext,
-        data: std::collections::BTreeMap<Vec<u8>, Vec<u8>>,
-    ) -> color_eyre::eyre::Result<Self> {
-        let state_init =
-            near_primitives::deterministic_account_id::DeterministicAccountStateInit::V1(
-                near_primitives::deterministic_account_id::DeterministicAccountStateInitV1 {
-                    code,
-                    data,
-                },
-            );
+        state_init: near_primitives::deterministic_account_id::DeterministicAccountStateInit,
+    ) -> Self {
         let receiver_account_id =
             near_primitives::utils::derive_near_deterministic_account_id(&state_init);
-        Ok(Self {
+        Self {
             global_context,
             state_init,
             receiver_account_id,
-        })
+        }
     }
 }
 
@@ -279,11 +266,17 @@ impl DataFromFileContext {
             )
         })?;
         let data = crate::common::parse_base64_kv_map(&json_str)?;
-        Ok(Self(StateInitDataContext::build(
-            previous_context.code,
+        let state_init =
+            near_primitives::deterministic_account_id::DeterministicAccountStateInit::V1(
+                near_primitives::deterministic_account_id::DeterministicAccountStateInitV1 {
+                    code: previous_context.code,
+                    data,
+                },
+            );
+        Ok(Self(StateInitDataContext::new(
             previous_context.global_context,
-            data,
-        )?))
+            state_init,
+        )))
     }
 }
 
@@ -302,11 +295,17 @@ impl DataFromJsonContext {
         scope: &<DataFromJson as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
     ) -> color_eyre::eyre::Result<Self> {
         let data = crate::common::parse_base64_kv_map(&scope.data)?;
-        Ok(Self(StateInitDataContext::build(
-            previous_context.code,
+        let state_init =
+            near_primitives::deterministic_account_id::DeterministicAccountStateInit::V1(
+                near_primitives::deterministic_account_id::DeterministicAccountStateInitV1 {
+                    code: previous_context.code,
+                    data,
+                },
+            );
+        Ok(Self(StateInitDataContext::new(
             previous_context.global_context,
-            data,
-        )?))
+            state_init,
+        )))
     }
 }
 
@@ -410,18 +409,18 @@ impl PrintKvMapContext {
                 &v1.data
             }
         };
-        let map: std::collections::BTreeMap<String, String> = data
-            .iter()
-            .map(|(k, v)| {
-                (
-                    near_primitives::serialize::to_base64(k),
-                    near_primitives::serialize::to_base64(v),
-                )
-            })
-            .collect();
+
+        #[serde_as]
+        #[derive(serde::Serialize)]
+        struct Data(
+            #[serde_as(as = "std::collections::BTreeMap<Base64, Base64>")]
+            std::collections::BTreeMap<Vec<u8>, Vec<u8>>,
+        );
+
+        let data = Data(data.clone());
         println!(
             "{}",
-            serde_json::to_string(&map).expect("BTreeMap<String, String> should be serializable")
+            serde_json::to_string(&data).expect("Data should be serializable")
         );
         Ok(Self)
     }

--- a/src/commands/contract/state_init/mod.rs
+++ b/src/commands/contract/state_init/mod.rs
@@ -28,9 +28,9 @@ pub enum StateInitModeCommand {
     ))]
     FromBorshBase64(StateInitFromBorshBase64),
     #[strum_discriminants(strum(
-        message = "from-borsh-base64-file - Read borsh serialized base64 encoded state init from a file"
+        message = "from-borsh-file        - Read borsh-serialized state init from a file"
     ))]
-    FromBorshBase64File(StateInitFromBorshBase64File),
+    FromBorshFile(StateInitFromBorshFile),
 }
 
 #[derive(Debug, Clone, interactive_clap::InteractiveClap)]
@@ -149,30 +149,23 @@ impl From<StateInitFromBorshBase64Context> for StateInitDataContext {
 
 #[derive(Debug, Clone, interactive_clap::InteractiveClap)]
 #[interactive_clap(input_context = crate::GlobalContext)]
-#[interactive_clap(output_context = StateInitFromBorshBase64FileContext)]
-pub struct StateInitFromBorshBase64File {
-    /// Enter the path to a file containing borsh-base64 encoded StateInit:
+#[interactive_clap(output_context = StateInitFromBorshFileContext)]
+pub struct StateInitFromBorshFile {
+    /// Enter the path to a file containing borsh-serialized StateInit:
     pub file_path: crate::types::path_buf::PathBuf,
     #[interactive_clap(subcommand)]
     action: StateInitAction,
 }
 
 #[derive(Debug, Clone)]
-pub struct StateInitFromBorshBase64FileContext(StateInitDataContext);
+pub struct StateInitFromBorshFileContext(StateInitDataContext);
 
-impl StateInitFromBorshBase64FileContext {
+impl StateInitFromBorshFileContext {
     pub fn from_previous_context(
         previous_context: crate::GlobalContext,
-        scope: &<StateInitFromBorshBase64File as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+        scope: &<StateInitFromBorshFile as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
     ) -> color_eyre::eyre::Result<Self> {
-        let base64_str = std::fs::read_to_string(&scope.file_path).wrap_err_with(|| {
-            format!(
-                "Failed to open or read the file: {}",
-                scope.file_path.0.display()
-            )
-        })?;
-        let data = near_primitives::serialize::from_base64(base64_str.trim())
-            .wrap_err("Failed to decode base64 from file content")?;
+        let data = scope.file_path.read_bytes()?;
         let state_init = crate::common::parse_borsh_base64_state_init(&data)?;
         Ok(Self(StateInitDataContext::new(
             previous_context,
@@ -181,8 +174,8 @@ impl StateInitFromBorshBase64FileContext {
     }
 }
 
-impl From<StateInitFromBorshBase64FileContext> for StateInitDataContext {
-    fn from(item: StateInitFromBorshBase64FileContext) -> Self {
+impl From<StateInitFromBorshFileContext> for StateInitDataContext {
+    fn from(item: StateInitFromBorshFileContext) -> Self {
         item.0
     }
 }

--- a/src/commands/contract/state_init/mod.rs
+++ b/src/commands/contract/state_init/mod.rs
@@ -156,7 +156,7 @@ pub enum Data {
     ))]
     DataFromFile(DataFromFile),
     #[strum_discriminants(strum(
-        message = "data-from-json - Provide base64-encoded key-value JSON data inline (e.g. '{\"AAEC\": \"AwQF\"})')"
+        message = "data-from-json - Provide base64-encoded key-value JSON inline"
     ))]
     DataFromJson(DataFromJson),
 }
@@ -165,7 +165,7 @@ pub enum Data {
 #[interactive_clap(input_context = StateInitModeContext)]
 #[interactive_clap(output_context = DataFromFileContext)]
 pub struct DataFromFile {
-    /// Enter the path to the file with base64-encoded key-value JSON data :
+    /// Enter the path to the file with base64-encoded key-value JSON data:
     pub file_path: crate::types::path_buf::PathBuf,
     #[interactive_clap(named_arg)]
     deposit: Deposit,
@@ -175,7 +175,7 @@ pub struct DataFromFile {
 #[interactive_clap(input_context = StateInitModeContext)]
 #[interactive_clap(output_context = DataFromJsonContext)]
 pub struct DataFromJson {
-    /// Enter the base64-encoded key-value JSON data (e.g. '{\"AAEC\": \"AwQF\"}'):
+    /// Enter the base64-encoded key-value JSON data (e.g. '{"AAEC": "AwQF"}'):
     pub data: String,
     #[interactive_clap(named_arg)]
     deposit: Deposit,

--- a/src/commands/contract/state_init/mod.rs
+++ b/src/commands/contract/state_init/mod.rs
@@ -24,13 +24,18 @@ pub enum StateInitModeCommand {
     ))]
     /// Use a global contract account ID (mutable)
     UseGlobalAccountId(StateInitWithContractRefByAccount),
+    #[strum_discriminants(strum(
+        message = "from-borsh-base64     - Provide the entire state init as a borsh+base64 blob"
+    ))]
+    /// Provide the entire DeterministicAccountStateInit as a borsh-serialized + base64-encoded blob
+    FromBorshBase64(StateInitFromBorshBase64),
 }
 
 #[derive(Debug, Clone, interactive_clap::InteractiveClap)]
 #[interactive_clap(input_context = crate::GlobalContext)]
 #[interactive_clap(output_context = StateInitWithContractHashRefContext)]
 pub struct StateInitWithContractHashRef {
-    /// What is the hash of the global contract?
+    /// What is the base58-encoded hash of the global contract?
     pub hash: crate::types::crypto_hash::CryptoHash,
     #[interactive_clap(subcommand)]
     data: Data,
@@ -96,6 +101,42 @@ impl StateInitWithContractRefByAccountContext {
     }
 }
 
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(input_context = crate::GlobalContext)]
+#[interactive_clap(output_context = StateInitFromBorshBase64Context)]
+pub struct StateInitFromBorshBase64 {
+    /// Enter the borsh-serialized + base64-encoded DeterministicAccountStateInit blob:
+    pub state_init_base64: String,
+    #[interactive_clap(named_arg)]
+    /// Specify deposit
+    deposit: Deposit,
+}
+
+#[derive(Debug, Clone)]
+pub struct StateInitFromBorshBase64Context(StateInitDataContext);
+
+impl StateInitFromBorshBase64Context {
+    pub fn from_previous_context(
+        previous_context: crate::GlobalContext,
+        scope: &<StateInitFromBorshBase64 as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+    ) -> color_eyre::eyre::Result<Self> {
+        let state_init = crate::common::parse_borsh_base64_state_init(&scope.state_init_base64)?;
+        let receiver_account_id =
+            near_primitives::utils::derive_near_deterministic_account_id(&state_init);
+        Ok(Self(StateInitDataContext {
+            global_context: previous_context,
+            state_init,
+            receiver_account_id,
+        }))
+    }
+}
+
+impl From<StateInitFromBorshBase64Context> for StateInitDataContext {
+    fn from(item: StateInitFromBorshBase64Context) -> Self {
+        item.0
+    }
+}
+
 #[derive(Debug, EnumDiscriminants, Clone, interactive_clap::InteractiveClap)]
 #[interactive_clap(context = StateInitModeContext)]
 #[strum_discriminants(derive(EnumMessage, EnumIter))]
@@ -103,14 +144,14 @@ impl StateInitWithContractRefByAccountContext {
 /// How do you want to provide the initial state data?
 pub enum Data {
     #[strum_discriminants(strum(
-        message = "data-from-file - Read hex-encoded key-value JSON data from a file"
+        message = "data-from-file - Read base64-encoded key-value JSON data from a file"
     ))]
-    /// Read hex-encoded key-value JSON data from a file
+    /// Read base64-encoded key-value JSON data from a file
     DataFromFile(DataFromFile),
     #[strum_discriminants(strum(
-        message = "data-from-json - Provide hex-encoded key-value JSON data inline"
+        message = "data-from-json - Provide base64-encoded key-value JSON data inline"
     ))]
-    /// Provide hex-encoded key-value JSON data inline
+    /// Provide base64-encoded key-value JSON data inline
     DataFromJson(DataFromJson),
 }
 
@@ -129,7 +170,7 @@ pub struct DataFromFile {
 #[interactive_clap(input_context = StateInitModeContext)]
 #[interactive_clap(output_context = DataFromJsonContext)]
 pub struct DataFromJson {
-    /// Enter hex-encoded key-value JSON data (e.g. '{"deadbeef": "cafebabe"}' or '{}' for empty state):
+    /// Enter base64-encoded key-value JSON data (e.g. '{"AAEC": "AwQF"}' or '{}' for empty state):
     pub data: String,
     #[interactive_clap(named_arg)]
     /// Specify deposit
@@ -186,7 +227,7 @@ impl DataFromFileContext {
                 scope.file_path.0.display()
             )
         })?;
-        let data = crate::common::parse_hex_kv_map(&json_str)?;
+        let data = crate::common::parse_base64_kv_map(&json_str)?;
         Ok(Self(StateInitDataContext::build(
             previous_context.code,
             previous_context.global_context,
@@ -209,7 +250,7 @@ impl DataFromJsonContext {
         previous_context: StateInitModeContext,
         scope: &<DataFromJson as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
     ) -> color_eyre::eyre::Result<Self> {
-        let data = crate::common::parse_hex_kv_map(&scope.data)?;
+        let data = crate::common::parse_base64_kv_map(&scope.data)?;
         Ok(Self(StateInitDataContext::build(
             previous_context.code,
             previous_context.global_context,

--- a/src/commands/transaction/construct_transaction/mod.rs
+++ b/src/commands/transaction/construct_transaction/mod.rs
@@ -50,6 +50,7 @@ impl ConstructTransaction {
 #[derive(Debug, EnumDiscriminants, Clone, interactive_clap::InteractiveClap)]
 #[interactive_clap(context = ConstructTransactionSenderContext)]
 #[strum_discriminants(derive(EnumMessage, EnumIter))]
+/// How would you like to specify the receiver?
 pub enum ReceiverMode {
     #[strum_discriminants(strum(message = "account-id  - Specify receiver account ID directly"))]
     AccountId(DirectReceiver),

--- a/src/commands/transaction/construct_transaction/mod.rs
+++ b/src/commands/transaction/construct_transaction/mod.rs
@@ -55,7 +55,7 @@ pub enum ReceiverMode {
     #[strum_discriminants(strum(message = "receiver-id  - Specify receiver account ID directly"))]
     ReceiverId(DirectReceiver),
     #[strum_discriminants(strum(
-        message = "state-init  - Derive receiver from deterministic state init (NEP-616)"
+        message = "state-init  - Derive receiver ID from deterministic StateInit (NEP-616)"
     ))]
     StateInit(self::state_init_receiver::StateInitReceiver),
 }

--- a/src/commands/transaction/construct_transaction/mod.rs
+++ b/src/commands/transaction/construct_transaction/mod.rs
@@ -52,8 +52,8 @@ impl ConstructTransaction {
 #[strum_discriminants(derive(EnumMessage, EnumIter))]
 /// How would you like to specify the receiver?
 pub enum ReceiverMode {
-    #[strum_discriminants(strum(message = "account-id  - Specify receiver account ID directly"))]
-    AccountId(DirectReceiver),
+    #[strum_discriminants(strum(message = "receiver-id  - Specify receiver account ID directly"))]
+    ReceiverId(DirectReceiver),
     #[strum_discriminants(strum(
         message = "state-init  - Derive receiver from deterministic state init (NEP-616)"
     ))]

--- a/src/commands/transaction/construct_transaction/mod.rs
+++ b/src/commands/transaction/construct_transaction/mod.rs
@@ -3,30 +3,28 @@ pub mod add_action_2;
 pub mod add_action_3;
 pub mod add_action_last;
 pub mod skip_action;
+pub mod state_init_receiver;
+
+use strum::{EnumDiscriminants, EnumIter, EnumMessage};
 
 #[derive(Debug, Clone, interactive_clap::InteractiveClap)]
 #[interactive_clap(input_context = crate::GlobalContext)]
-#[interactive_clap(output_context = ConstructTransactionContext)]
+#[interactive_clap(output_context = ConstructTransactionSenderContext)]
 pub struct ConstructTransaction {
     #[interactive_clap(skip_default_input_arg)]
     /// What is the sender account ID?
     pub sender_account_id: crate::types::account_id::AccountId,
-    #[interactive_clap(skip_default_input_arg)]
-    /// What is the receiver account ID?
-    pub receiver_account_id: crate::types::account_id::AccountId,
     #[interactive_clap(subcommand)]
-    pub next_actions: self::add_action_1::NextAction,
+    pub receiver: ReceiverMode,
 }
 
 #[derive(Debug, Clone)]
-pub struct ConstructTransactionContext {
+pub struct ConstructTransactionSenderContext {
     pub global_context: crate::GlobalContext,
     pub signer_account_id: near_primitives::types::AccountId,
-    pub receiver_account_id: near_primitives::types::AccountId,
-    pub actions: Vec<near_primitives::transaction::Action>,
 }
 
-impl ConstructTransactionContext {
+impl ConstructTransactionSenderContext {
     pub fn from_previous_context(
         previous_context: crate::GlobalContext,
         scope: &<ConstructTransaction as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
@@ -34,8 +32,6 @@ impl ConstructTransactionContext {
         Ok(Self {
             global_context: previous_context,
             signer_account_id: scope.sender_account_id.clone().into(),
-            receiver_account_id: scope.receiver_account_id.clone().into(),
-            actions: vec![],
         })
     }
 }
@@ -49,13 +45,63 @@ impl ConstructTransaction {
             "What is the sender account ID?",
         )
     }
+}
 
+#[derive(Debug, EnumDiscriminants, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(context = ConstructTransactionSenderContext)]
+#[strum_discriminants(derive(EnumMessage, EnumIter))]
+/// How do you want to specify the receiver?
+pub enum ReceiverMode {
+    #[strum_discriminants(strum(message = "account-id  - Specify receiver account ID directly"))]
+    /// Specify receiver account ID directly
+    AccountId(DirectReceiver),
+    #[strum_discriminants(strum(
+        message = "state-init  - Derive receiver from deterministic state init (NEP-616)"
+    ))]
+    /// Derive receiver from deterministic state init (NEP-616)
+    StateInit(self::state_init_receiver::StateInitReceiver),
+}
+
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(input_context = ConstructTransactionSenderContext)]
+#[interactive_clap(output_context = ConstructTransactionContext)]
+pub struct DirectReceiver {
+    #[interactive_clap(skip_default_input_arg)]
+    /// What is the receiver account ID?
+    pub receiver_account_id: crate::types::account_id::AccountId,
+    #[interactive_clap(subcommand)]
+    pub next_actions: self::add_action_1::NextAction,
+}
+
+impl DirectReceiver {
     pub fn input_receiver_account_id(
-        context: &crate::GlobalContext,
+        context: &ConstructTransactionSenderContext,
     ) -> color_eyre::eyre::Result<Option<crate::types::account_id::AccountId>> {
         crate::common::input_non_signer_account_id_from_used_account_list(
-            &context.config.credentials_home_dir,
+            &context.global_context.config.credentials_home_dir,
             "What is the receiver account ID?",
         )
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ConstructTransactionContext {
+    pub global_context: crate::GlobalContext,
+    pub signer_account_id: near_primitives::types::AccountId,
+    pub receiver_account_id: near_primitives::types::AccountId,
+    pub actions: Vec<near_primitives::transaction::Action>,
+}
+
+impl ConstructTransactionContext {
+    pub fn from_previous_context(
+        previous_context: ConstructTransactionSenderContext,
+        scope: &<DirectReceiver as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+    ) -> color_eyre::eyre::Result<Self> {
+        Ok(Self {
+            global_context: previous_context.global_context,
+            signer_account_id: previous_context.signer_account_id,
+            receiver_account_id: scope.receiver_account_id.clone().into(),
+            actions: vec![],
+        })
     }
 }

--- a/src/commands/transaction/construct_transaction/mod.rs
+++ b/src/commands/transaction/construct_transaction/mod.rs
@@ -50,15 +50,12 @@ impl ConstructTransaction {
 #[derive(Debug, EnumDiscriminants, Clone, interactive_clap::InteractiveClap)]
 #[interactive_clap(context = ConstructTransactionSenderContext)]
 #[strum_discriminants(derive(EnumMessage, EnumIter))]
-/// How do you want to specify the receiver?
 pub enum ReceiverMode {
     #[strum_discriminants(strum(message = "account-id  - Specify receiver account ID directly"))]
-    /// Specify receiver account ID directly
     AccountId(DirectReceiver),
     #[strum_discriminants(strum(
         message = "state-init  - Derive receiver from deterministic state init (NEP-616)"
     ))]
-    /// Derive receiver from deterministic state init (NEP-616)
     StateInit(self::state_init_receiver::StateInitReceiver),
 }
 
@@ -67,7 +64,6 @@ pub enum ReceiverMode {
 #[interactive_clap(output_context = ConstructTransactionContext)]
 pub struct DirectReceiver {
     #[interactive_clap(skip_default_input_arg)]
-    /// What is the receiver account ID?
     pub receiver_account_id: crate::types::account_id::AccountId,
     #[interactive_clap(subcommand)]
     pub next_actions: self::add_action_1::NextAction,
@@ -90,6 +86,7 @@ pub struct ConstructTransactionContext {
     pub signer_account_id: near_primitives::types::AccountId,
     pub receiver_account_id: near_primitives::types::AccountId,
     pub actions: Vec<near_primitives::transaction::Action>,
+    pub sign_as_delegate_action: bool,
 }
 
 impl ConstructTransactionContext {
@@ -102,6 +99,7 @@ impl ConstructTransactionContext {
             signer_account_id: previous_context.signer_account_id,
             receiver_account_id: scope.receiver_account_id.clone().into(),
             actions: vec![],
+            sign_as_delegate_action: false,
         })
     }
 }

--- a/src/commands/transaction/construct_transaction/state_init_receiver/mod.rs
+++ b/src/commands/transaction/construct_transaction/state_init_receiver/mod.rs
@@ -130,7 +130,8 @@ impl StateInitFromBorshBase64Context {
         previous_context: super::ConstructTransactionSenderContext,
         scope: &<StateInitFromBorshBase64 as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
     ) -> color_eyre::eyre::Result<Self> {
-        let state_init = crate::common::parse_borsh_base64_state_init(scope.state_init_base64.as_bytes())?;
+        let state_init =
+            crate::common::parse_borsh_base64_state_init(scope.state_init_base64.as_bytes())?;
         let receiver_account_id =
             near_primitives::utils::derive_near_deterministic_account_id(&state_init);
         Ok(Self(StateInitDataContext {
@@ -299,9 +300,22 @@ impl DataFromJsonContext {
 #[interactive_clap(input_context = StateInitDataContext)]
 #[interactive_clap(output_context = DepositContext)]
 pub struct Deposit {
+    #[interactive_clap(skip_default_input_arg)]
     pub deposit: crate::types::near_token::NearToken,
     #[interactive_clap(subcommand)]
     pub next_actions: super::add_action_1::NextAction,
+}
+
+impl Deposit {
+    pub fn input_deposit(
+        _context: &StateInitDataContext,
+    ) -> color_eyre::eyre::Result<Option<crate::types::near_token::NearToken>> {
+        Ok(Some(
+            inquire::CustomType::new("What is the deposit for the state init call?")
+                .with_starting_input("0 NEAR")
+                .prompt()?,
+        ))
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/commands/transaction/construct_transaction/state_init_receiver/mod.rs
+++ b/src/commands/transaction/construct_transaction/state_init_receiver/mod.rs
@@ -30,6 +30,14 @@ pub enum StateInitModeCommand {
         message = "from-borsh-file        - Read borsh-serialized state init from a file"
     ))]
     FromBorshFile(StateInitFromBorshFile),
+    #[strum_discriminants(strum(
+        message = "from-json              - Provide JSON-serialized state init inline"
+    ))]
+    FromJson(StateInitFromJson),
+    #[strum_discriminants(strum(
+        message = "from-json-file         - Read JSON-serialized state init from a file"
+    ))]
+    FromJsonFile(StateInitFromJsonFile),
 }
 
 #[derive(Debug, Clone, interactive_clap::InteractiveClap)]
@@ -186,6 +194,88 @@ impl StateInitFromBorshFileContext {
 
 impl From<StateInitFromBorshFileContext> for StateInitDataContext {
     fn from(item: StateInitFromBorshFileContext) -> Self {
+        item.0
+    }
+}
+
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(input_context = super::ConstructTransactionSenderContext)]
+#[interactive_clap(output_context = StateInitFromJsonContext)]
+pub struct StateInitFromJson {
+    /// Enter the JSON-serialized StateInit:
+    pub state_init_json: String,
+    #[interactive_clap(named_arg)]
+    deposit: Deposit,
+}
+
+#[derive(Debug, Clone)]
+pub struct StateInitFromJsonContext(StateInitDataContext);
+
+impl StateInitFromJsonContext {
+    pub fn from_previous_context(
+        previous_context: super::ConstructTransactionSenderContext,
+        scope: &<StateInitFromJson as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+    ) -> color_eyre::eyre::Result<Self> {
+        let state_init: near_primitives::deterministic_account_id::DeterministicAccountStateInit =
+            serde_json::from_str(&scope.state_init_json)
+                .wrap_err("Failed to parse JSON-serialized StateInit")?;
+        let receiver_account_id =
+            near_primitives::utils::derive_near_deterministic_account_id(&state_init);
+        Ok(Self(StateInitDataContext {
+            global_context: previous_context.global_context,
+            signer_account_id: previous_context.signer_account_id,
+            state_init,
+            receiver_account_id,
+        }))
+    }
+}
+
+impl From<StateInitFromJsonContext> for StateInitDataContext {
+    fn from(item: StateInitFromJsonContext) -> Self {
+        item.0
+    }
+}
+
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(input_context = super::ConstructTransactionSenderContext)]
+#[interactive_clap(output_context = StateInitFromJsonFileContext)]
+pub struct StateInitFromJsonFile {
+    /// Enter the path to a file containing JSON-serialized StateInit:
+    pub file_path: crate::types::path_buf::PathBuf,
+    #[interactive_clap(named_arg)]
+    deposit: Deposit,
+}
+
+#[derive(Debug, Clone)]
+pub struct StateInitFromJsonFileContext(StateInitDataContext);
+
+impl StateInitFromJsonFileContext {
+    pub fn from_previous_context(
+        previous_context: super::ConstructTransactionSenderContext,
+        scope: &<StateInitFromJsonFile as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+    ) -> color_eyre::eyre::Result<Self> {
+        let json_str = std::fs::read_to_string(&scope.file_path).wrap_err_with(|| {
+            format!(
+                "Failed to open or read the file: {}",
+                scope.file_path.0.display()
+            )
+        })?;
+        let state_init: near_primitives::deterministic_account_id::DeterministicAccountStateInit =
+            serde_json::from_str(&json_str)
+                .wrap_err("Failed to parse JSON-serialized StateInit")?;
+        let receiver_account_id =
+            near_primitives::utils::derive_near_deterministic_account_id(&state_init);
+        Ok(Self(StateInitDataContext {
+            global_context: previous_context.global_context,
+            signer_account_id: previous_context.signer_account_id,
+            state_init,
+            receiver_account_id,
+        }))
+    }
+}
+
+impl From<StateInitFromJsonFileContext> for StateInitDataContext {
+    fn from(item: StateInitFromJsonFileContext) -> Self {
         item.0
     }
 }

--- a/src/commands/transaction/construct_transaction/state_init_receiver/mod.rs
+++ b/src/commands/transaction/construct_transaction/state_init_receiver/mod.rs
@@ -356,12 +356,8 @@ pub struct Deposit {
 
 impl Deposit {
     pub fn input_deposit(
-        context: &StateInitDataContext,
+        _context: &StateInitDataContext,
     ) -> color_eyre::eyre::Result<Option<crate::types::near_token::NearToken>> {
-        eprintln!(
-            "\nDerived deterministic AccountId: {}",
-            context.receiver_account_id
-        );
         Ok(Some(
             inquire::CustomType::new("What is the deposit for the state init call?")
                 .with_starting_input("0 NEAR")

--- a/src/commands/transaction/construct_transaction/state_init_receiver/mod.rs
+++ b/src/commands/transaction/construct_transaction/state_init_receiver/mod.rs
@@ -1,0 +1,268 @@
+use color_eyre::eyre::Context;
+use strum::{EnumDiscriminants, EnumIter, EnumMessage};
+
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(context = super::ConstructTransactionSenderContext)]
+pub struct StateInitReceiver {
+    #[interactive_clap(subcommand)]
+    state_init: StateInitModeCommand,
+}
+
+#[derive(Debug, EnumDiscriminants, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(context = super::ConstructTransactionSenderContext)]
+#[strum_discriminants(derive(EnumMessage, EnumIter))]
+#[non_exhaustive]
+/// How do you want to identify the global contract code?
+pub enum StateInitModeCommand {
+    #[strum_discriminants(strum(
+        message = "use-global-hash       - Use a global contract code hash (immutable)"
+    ))]
+    /// Use a global contract code hash (immutable)
+    UseGlobalHash(StateInitWithContractHashRef),
+    #[strum_discriminants(strum(
+        message = "use-global-account-id - Use a global contract account ID (mutable)"
+    ))]
+    /// Use a global contract account ID (mutable)
+    UseGlobalAccountId(StateInitWithContractRefByAccount),
+}
+
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(input_context = super::ConstructTransactionSenderContext)]
+#[interactive_clap(output_context = StateInitWithContractHashRefContext)]
+pub struct StateInitWithContractHashRef {
+    /// What is the hash of the global contract?
+    pub hash: crate::types::crypto_hash::CryptoHash,
+    #[interactive_clap(subcommand)]
+    data: Data,
+}
+
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(input_context = super::ConstructTransactionSenderContext)]
+#[interactive_clap(output_context = StateInitWithContractRefByAccountContext)]
+pub struct StateInitWithContractRefByAccount {
+    /// What is the account ID of the global contract?
+    pub account_id: crate::types::account_id::AccountId,
+    #[interactive_clap(subcommand)]
+    data: Data,
+}
+
+#[derive(Debug, Clone)]
+pub struct StateInitModeContext {
+    pub global_context: crate::GlobalContext,
+    pub signer_account_id: near_primitives::types::AccountId,
+    pub code: near_primitives::action::GlobalContractIdentifier,
+}
+
+#[derive(Debug, Clone)]
+pub struct StateInitWithContractHashRefContext(StateInitModeContext);
+
+impl StateInitWithContractHashRefContext {
+    pub fn from_previous_context(
+        previous_context: super::ConstructTransactionSenderContext,
+        scope: &<StateInitWithContractHashRef as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+    ) -> color_eyre::eyre::Result<Self> {
+        Ok(Self(StateInitModeContext {
+            global_context: previous_context.global_context,
+            signer_account_id: previous_context.signer_account_id,
+            code: near_primitives::action::GlobalContractIdentifier::CodeHash(scope.hash.into()),
+        }))
+    }
+}
+
+impl From<StateInitWithContractHashRefContext> for StateInitModeContext {
+    fn from(item: StateInitWithContractHashRefContext) -> Self {
+        item.0
+    }
+}
+
+impl From<StateInitWithContractRefByAccountContext> for StateInitModeContext {
+    fn from(item: StateInitWithContractRefByAccountContext) -> Self {
+        item.0
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct StateInitWithContractRefByAccountContext(StateInitModeContext);
+
+impl StateInitWithContractRefByAccountContext {
+    pub fn from_previous_context(
+        previous_context: super::ConstructTransactionSenderContext,
+        scope: &<StateInitWithContractRefByAccount as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+    ) -> color_eyre::eyre::Result<Self> {
+        Ok(Self(StateInitModeContext {
+            global_context: previous_context.global_context,
+            signer_account_id: previous_context.signer_account_id,
+            code: near_primitives::action::GlobalContractIdentifier::AccountId(
+                scope.account_id.clone().into(),
+            ),
+        }))
+    }
+}
+
+#[derive(Debug, EnumDiscriminants, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(context = StateInitModeContext)]
+#[strum_discriminants(derive(EnumMessage, EnumIter))]
+#[non_exhaustive]
+/// How do you want to provide the initial state data?
+pub enum Data {
+    #[strum_discriminants(strum(
+        message = "data-from-file - Read hex-encoded key-value JSON data from a file"
+    ))]
+    /// Read hex-encoded key-value JSON data from a file
+    DataFromFile(DataFromFile),
+    #[strum_discriminants(strum(
+        message = "data-from-json - Provide hex-encoded key-value JSON data inline"
+    ))]
+    /// Provide hex-encoded key-value JSON data inline
+    DataFromJson(DataFromJson),
+}
+
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(input_context = StateInitModeContext)]
+#[interactive_clap(output_context = DataFromFileContext)]
+pub struct DataFromFile {
+    /// What is the file path of the JSON state data?
+    pub file_path: crate::types::path_buf::PathBuf,
+    #[interactive_clap(named_arg)]
+    /// Specify deposit
+    deposit: Deposit,
+}
+
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(input_context = StateInitModeContext)]
+#[interactive_clap(output_context = DataFromJsonContext)]
+pub struct DataFromJson {
+    /// Enter hex-encoded key-value JSON data (e.g. '{"deadbeef": "cafebabe"}' or '{}' for empty state):
+    pub data: String,
+    #[interactive_clap(named_arg)]
+    /// Specify deposit
+    deposit: Deposit,
+}
+
+#[derive(Debug, Clone)]
+pub struct StateInitDataContext {
+    pub global_context: crate::GlobalContext,
+    pub signer_account_id: near_primitives::types::AccountId,
+    pub state_init: near_primitives::deterministic_account_id::DeterministicAccountStateInit,
+    pub receiver_account_id: near_primitives::types::AccountId,
+}
+
+impl StateInitDataContext {
+    fn build(
+        code: near_primitives::action::GlobalContractIdentifier,
+        global_context: crate::GlobalContext,
+        signer_account_id: near_primitives::types::AccountId,
+        data: std::collections::BTreeMap<Vec<u8>, Vec<u8>>,
+    ) -> color_eyre::eyre::Result<Self> {
+        let state_init =
+            near_primitives::deterministic_account_id::DeterministicAccountStateInit::V1(
+                near_primitives::deterministic_account_id::DeterministicAccountStateInitV1 {
+                    code,
+                    data,
+                },
+            );
+        let receiver_account_id =
+            near_primitives::utils::derive_near_deterministic_account_id(&state_init);
+        Ok(Self {
+            global_context,
+            signer_account_id,
+            state_init,
+            receiver_account_id,
+        })
+    }
+}
+
+impl From<DataFromFileContext> for StateInitDataContext {
+    fn from(item: DataFromFileContext) -> Self {
+        item.0
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DataFromFileContext(StateInitDataContext);
+
+impl DataFromFileContext {
+    pub fn from_previous_context(
+        previous_context: StateInitModeContext,
+        scope: &<DataFromFile as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+    ) -> color_eyre::eyre::Result<Self> {
+        let json_str = std::fs::read_to_string(&scope.file_path).wrap_err_with(|| {
+            format!(
+                "Failed to open or read the file: {}",
+                scope.file_path.0.display()
+            )
+        })?;
+        let data = crate::common::parse_hex_kv_map(&json_str)?;
+        Ok(Self(StateInitDataContext::build(
+            previous_context.code,
+            previous_context.global_context,
+            previous_context.signer_account_id,
+            data,
+        )?))
+    }
+}
+
+impl From<DataFromJsonContext> for StateInitDataContext {
+    fn from(item: DataFromJsonContext) -> Self {
+        item.0
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct DataFromJsonContext(StateInitDataContext);
+
+impl DataFromJsonContext {
+    pub fn from_previous_context(
+        previous_context: StateInitModeContext,
+        scope: &<DataFromJson as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+    ) -> color_eyre::eyre::Result<Self> {
+        let data = crate::common::parse_hex_kv_map(&scope.data)?;
+        Ok(Self(StateInitDataContext::build(
+            previous_context.code,
+            previous_context.global_context,
+            previous_context.signer_account_id,
+            data,
+        )?))
+    }
+}
+
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(input_context = StateInitDataContext)]
+#[interactive_clap(output_context = DepositContext)]
+pub struct Deposit {
+    /// How much do you want to deposit with the state init (e.g. '1 NEAR' or '0 NEAR')?
+    pub deposit: crate::types::near_token::NearToken,
+    #[interactive_clap(subcommand)]
+    pub next_actions: super::add_action_1::NextAction,
+}
+
+#[derive(Debug, Clone)]
+pub struct DepositContext(super::ConstructTransactionContext);
+
+impl DepositContext {
+    pub fn from_previous_context(
+        previous_context: StateInitDataContext,
+        scope: &<Deposit as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+    ) -> color_eyre::eyre::Result<Self> {
+        let deposit: near_token::NearToken = scope.deposit.into();
+        Ok(Self(super::ConstructTransactionContext {
+            global_context: previous_context.global_context,
+            signer_account_id: previous_context.signer_account_id,
+            receiver_account_id: previous_context.receiver_account_id,
+            actions: vec![
+                near_primitives::transaction::Action::DeterministicStateInit(Box::new(
+                    near_primitives::action::DeterministicStateInitAction {
+                        state_init: previous_context.state_init,
+                        deposit,
+                    },
+                )),
+            ],
+        }))
+    }
+}
+
+impl From<DepositContext> for super::ConstructTransactionContext {
+    fn from(item: DepositContext) -> Self {
+        item.0
+    }
+}

--- a/src/commands/transaction/construct_transaction/state_init_receiver/mod.rs
+++ b/src/commands/transaction/construct_transaction/state_init_receiver/mod.rs
@@ -23,14 +23,6 @@ pub enum StateInitModeCommand {
     ))]
     UseGlobalAccountId(StateInitWithContractRefByAccount),
     #[strum_discriminants(strum(
-        message = "from-borsh-base64      - Provide borsh serialized base64 encoded state init"
-    ))]
-    FromBorshBase64(StateInitFromBorshBase64),
-    #[strum_discriminants(strum(
-        message = "from-borsh-file        - Read borsh-serialized state init from a file"
-    ))]
-    FromBorshFile(StateInitFromBorshFile),
-    #[strum_discriminants(strum(
         message = "from-json              - Provide JSON-serialized state init inline"
     ))]
     FromJson(StateInitFromJson),
@@ -38,6 +30,14 @@ pub enum StateInitModeCommand {
         message = "from-json-file         - Read JSON-serialized state init from a file"
     ))]
     FromJsonFile(StateInitFromJsonFile),
+    #[strum_discriminants(strum(
+        message = "from-borsh-base64      - Provide borsh serialized base64 encoded state init"
+    ))]
+    FromBorshBase64(StateInitFromBorshBase64),
+    #[strum_discriminants(strum(
+        message = "from-borsh-file        - Read borsh-serialized state init from a file"
+    ))]
+    FromBorshFile(StateInitFromBorshFile),
 }
 
 #[derive(Debug, Clone, interactive_clap::InteractiveClap)]

--- a/src/commands/transaction/construct_transaction/state_init_receiver/mod.rs
+++ b/src/commands/transaction/construct_transaction/state_init_receiver/mod.rs
@@ -204,13 +204,13 @@ impl From<StateInitFromBorshBase64FileContext> for StateInitDataContext {
 /// How would you like to provide the initial state data?
 pub enum Data {
     #[strum_discriminants(strum(
-        message = "data-from-file - Read base64-encoded key-value JSON data from a file"
-    ))]
-    DataFromFile(DataFromFile),
-    #[strum_discriminants(strum(
         message = "data-from-json - Provide base64-encoded key-value JSON inline"
     ))]
     DataFromJson(DataFromJson),
+    #[strum_discriminants(strum(
+        message = "data-from-file - Read base64-encoded key-value JSON data from a file"
+    ))]
+    DataFromFile(DataFromFile),
 }
 
 #[derive(Debug, Clone, interactive_clap::InteractiveClap)]

--- a/src/commands/transaction/construct_transaction/state_init_receiver/mod.rs
+++ b/src/commands/transaction/construct_transaction/state_init_receiver/mod.rs
@@ -160,7 +160,7 @@ pub enum Data {
     ))]
     DataFromFile(DataFromFile),
     #[strum_discriminants(strum(
-        message = "data-from-json - Provide base64-encoded key-value JSON data inline (e.g. '{\"AAEC\": \"AwQF\"})')"
+        message = "data-from-json - Provide base64-encoded key-value JSON inline"
     ))]
     DataFromJson(DataFromJson),
 }

--- a/src/commands/transaction/construct_transaction/state_init_receiver/mod.rs
+++ b/src/commands/transaction/construct_transaction/state_init_receiver/mod.rs
@@ -23,9 +23,13 @@ pub enum StateInitModeCommand {
     ))]
     UseGlobalAccountId(StateInitWithContractRefByAccount),
     #[strum_discriminants(strum(
-        message = "from-borsh-base64     - Provide borsh serialized base64 encoded state init"
+        message = "from-borsh-base64      - Provide borsh serialized base64 encoded state init"
     ))]
     FromBorshBase64(StateInitFromBorshBase64),
+    #[strum_discriminants(strum(
+        message = "from-borsh-base64-file - Read borsh serialized base64 encoded state init from a file"
+    ))]
+    FromBorshBase64File(StateInitFromBorshBase64File),
 }
 
 #[derive(Debug, Clone, interactive_clap::InteractiveClap)]
@@ -145,6 +149,50 @@ impl StateInitFromBorshBase64Context {
 
 impl From<StateInitFromBorshBase64Context> for StateInitDataContext {
     fn from(item: StateInitFromBorshBase64Context) -> Self {
+        item.0
+    }
+}
+
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(input_context = super::ConstructTransactionSenderContext)]
+#[interactive_clap(output_context = StateInitFromBorshBase64FileContext)]
+pub struct StateInitFromBorshBase64File {
+    /// Enter the path to a file containing borsh-base64 encoded StateInit:
+    pub file_path: crate::types::path_buf::PathBuf,
+    #[interactive_clap(named_arg)]
+    deposit: Deposit,
+}
+
+#[derive(Debug, Clone)]
+pub struct StateInitFromBorshBase64FileContext(StateInitDataContext);
+
+impl StateInitFromBorshBase64FileContext {
+    pub fn from_previous_context(
+        previous_context: super::ConstructTransactionSenderContext,
+        scope: &<StateInitFromBorshBase64File as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+    ) -> color_eyre::eyre::Result<Self> {
+        let base64_str = std::fs::read_to_string(&scope.file_path).wrap_err_with(|| {
+            format!(
+                "Failed to open or read the file: {}",
+                scope.file_path.0.display()
+            )
+        })?;
+        let data = near_primitives::serialize::from_base64(base64_str.trim())
+            .wrap_err("Failed to decode base64 from file content")?;
+        let state_init = crate::common::parse_borsh_base64_state_init(&data)?;
+        let receiver_account_id =
+            near_primitives::utils::derive_near_deterministic_account_id(&state_init);
+        Ok(Self(StateInitDataContext {
+            global_context: previous_context.global_context,
+            signer_account_id: previous_context.signer_account_id,
+            state_init,
+            receiver_account_id,
+        }))
+    }
+}
+
+impl From<StateInitFromBorshBase64FileContext> for StateInitDataContext {
+    fn from(item: StateInitFromBorshBase64FileContext) -> Self {
         item.0
     }
 }

--- a/src/commands/transaction/construct_transaction/state_init_receiver/mod.rs
+++ b/src/commands/transaction/construct_transaction/state_init_receiver/mod.rs
@@ -32,20 +32,10 @@ pub enum StateInitModeCommand {
 #[interactive_clap(input_context = super::ConstructTransactionSenderContext)]
 #[interactive_clap(output_context = StateInitWithContractHashRefContext)]
 pub struct StateInitWithContractHashRef {
-    #[interactive_clap(skip_default_input_arg)]
+    /// Enter the global contract code hash:
     pub hash: crate::types::crypto_hash::CryptoHash,
     #[interactive_clap(subcommand)]
     data: Data,
-}
-
-impl StateInitWithContractHashRef {
-    pub fn input_hash(
-        _context: &super::ConstructTransactionSenderContext,
-    ) -> color_eyre::eyre::Result<Option<crate::types::crypto_hash::CryptoHash>> {
-        Ok(Some(
-            inquire::CustomType::new("Enter the global contract code hash:").prompt()?,
-        ))
-    }
 }
 
 #[derive(Debug, Clone, interactive_clap::InteractiveClap)]
@@ -60,11 +50,12 @@ pub struct StateInitWithContractRefByAccount {
 
 impl StateInitWithContractRefByAccount {
     pub fn input_account_id(
-        _context: &super::ConstructTransactionSenderContext,
+        context: &super::ConstructTransactionSenderContext,
     ) -> color_eyre::eyre::Result<Option<crate::types::account_id::AccountId>> {
-        Ok(Some(
-            inquire::CustomType::new("Enter the global contract account ID:").prompt()?,
-        ))
+        crate::common::input_signer_account_id_from_used_account_list(
+            &context.global_context.config.credentials_home_dir,
+            "Enter the global contract account ID: ",
+        )
     }
 }
 
@@ -125,20 +116,10 @@ impl StateInitWithContractRefByAccountContext {
 #[interactive_clap(input_context = super::ConstructTransactionSenderContext)]
 #[interactive_clap(output_context = StateInitFromBorshBase64Context)]
 pub struct StateInitFromBorshBase64 {
-    #[interactive_clap(skip_default_input_arg)]
-    pub state_init_base64: String,
+    /// Enter the borsh-base64 encoded StateInit:
+    pub state_init_base64: crate::types::base64_bytes::Base64Bytes,
     #[interactive_clap(named_arg)]
     deposit: Deposit,
-}
-
-impl StateInitFromBorshBase64 {
-    pub fn input_state_init_base64(
-        _context: &super::ConstructTransactionSenderContext,
-    ) -> color_eyre::eyre::Result<Option<String>> {
-        Ok(Some(
-            inquire::Text::new("Enter the borsh-base64 encoded StateInit:").prompt()?,
-        ))
-    }
 }
 
 #[derive(Debug, Clone)]
@@ -149,7 +130,7 @@ impl StateInitFromBorshBase64Context {
         previous_context: super::ConstructTransactionSenderContext,
         scope: &<StateInitFromBorshBase64 as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
     ) -> color_eyre::eyre::Result<Self> {
-        let state_init = crate::common::parse_borsh_base64_state_init(&scope.state_init_base64)?;
+        let state_init = crate::common::parse_borsh_base64_state_init(scope.state_init_base64.as_bytes())?;
         let receiver_account_id =
             near_primitives::utils::derive_near_deterministic_account_id(&state_init);
         Ok(Self(StateInitDataContext {

--- a/src/commands/transaction/construct_transaction/state_init_receiver/mod.rs
+++ b/src/commands/transaction/construct_transaction/state_init_receiver/mod.rs
@@ -12,22 +12,18 @@ pub struct StateInitReceiver {
 #[interactive_clap(context = super::ConstructTransactionSenderContext)]
 #[strum_discriminants(derive(EnumMessage, EnumIter))]
 #[non_exhaustive]
-/// How do you want to identify the global contract code?
 pub enum StateInitModeCommand {
     #[strum_discriminants(strum(
-        message = "use-global-hash       - Use a global contract code hash (immutable)"
+        message = "use-global-hash       - Use a global contract code hash"
     ))]
-    /// Use a global contract code hash (immutable)
     UseGlobalHash(StateInitWithContractHashRef),
     #[strum_discriminants(strum(
-        message = "use-global-account-id - Use a global contract account ID (mutable)"
+        message = "use-global-account-id - Use a global contract account ID"
     ))]
-    /// Use a global contract account ID (mutable)
     UseGlobalAccountId(StateInitWithContractRefByAccount),
     #[strum_discriminants(strum(
         message = "from-borsh-base64     - Provide the entire state init as a borsh+base64 blob"
     ))]
-    /// Provide the entire DeterministicAccountStateInit as a borsh-serialized + base64-encoded blob
     FromBorshBase64(StateInitFromBorshBase64),
 }
 
@@ -35,7 +31,6 @@ pub enum StateInitModeCommand {
 #[interactive_clap(input_context = super::ConstructTransactionSenderContext)]
 #[interactive_clap(output_context = StateInitWithContractHashRefContext)]
 pub struct StateInitWithContractHashRef {
-    /// What is the base58-encoded hash of the global contract?
     pub hash: crate::types::crypto_hash::CryptoHash,
     #[interactive_clap(subcommand)]
     data: Data,
@@ -45,7 +40,6 @@ pub struct StateInitWithContractHashRef {
 #[interactive_clap(input_context = super::ConstructTransactionSenderContext)]
 #[interactive_clap(output_context = StateInitWithContractRefByAccountContext)]
 pub struct StateInitWithContractRefByAccount {
-    /// What is the account ID of the global contract?
     pub account_id: crate::types::account_id::AccountId,
     #[interactive_clap(subcommand)]
     data: Data,
@@ -108,10 +102,8 @@ impl StateInitWithContractRefByAccountContext {
 #[interactive_clap(input_context = super::ConstructTransactionSenderContext)]
 #[interactive_clap(output_context = StateInitFromBorshBase64Context)]
 pub struct StateInitFromBorshBase64 {
-    /// Enter the borsh-serialized + base64-encoded DeterministicAccountStateInit blob:
     pub state_init_base64: String,
     #[interactive_clap(named_arg)]
-    /// Specify deposit
     deposit: Deposit,
 }
 
@@ -145,17 +137,14 @@ impl From<StateInitFromBorshBase64Context> for StateInitDataContext {
 #[interactive_clap(context = StateInitModeContext)]
 #[strum_discriminants(derive(EnumMessage, EnumIter))]
 #[non_exhaustive]
-/// How do you want to provide the initial state data?
 pub enum Data {
     #[strum_discriminants(strum(
         message = "data-from-file - Read base64-encoded key-value JSON data from a file"
     ))]
-    /// Read base64-encoded key-value JSON data from a file
     DataFromFile(DataFromFile),
     #[strum_discriminants(strum(
-        message = "data-from-json - Provide base64-encoded key-value JSON data inline"
+        message = "data-from-json - Provide base64-encoded key-value JSON data inline (e.g. '{\"AAEC\": \"AwQF\"})')"
     ))]
-    /// Provide base64-encoded key-value JSON data inline
     DataFromJson(DataFromJson),
 }
 
@@ -163,10 +152,8 @@ pub enum Data {
 #[interactive_clap(input_context = StateInitModeContext)]
 #[interactive_clap(output_context = DataFromFileContext)]
 pub struct DataFromFile {
-    /// What is the file path of the JSON state data?
     pub file_path: crate::types::path_buf::PathBuf,
     #[interactive_clap(named_arg)]
-    /// Specify deposit
     deposit: Deposit,
 }
 
@@ -174,10 +161,8 @@ pub struct DataFromFile {
 #[interactive_clap(input_context = StateInitModeContext)]
 #[interactive_clap(output_context = DataFromJsonContext)]
 pub struct DataFromJson {
-    /// Enter base64-encoded key-value JSON data (e.g. '{"AAEC": "AwQF"}' or '{}' for empty state):
     pub data: String,
     #[interactive_clap(named_arg)]
-    /// Specify deposit
     deposit: Deposit,
 }
 
@@ -272,7 +257,6 @@ impl DataFromJsonContext {
 #[interactive_clap(input_context = StateInitDataContext)]
 #[interactive_clap(output_context = DepositContext)]
 pub struct Deposit {
-    /// How much do you want to deposit with the state init (e.g. '1 NEAR' or '0 NEAR')?
     pub deposit: crate::types::near_token::NearToken,
     #[interactive_clap(subcommand)]
     pub next_actions: super::add_action_1::NextAction,

--- a/src/commands/transaction/construct_transaction/state_init_receiver/mod.rs
+++ b/src/commands/transaction/construct_transaction/state_init_receiver/mod.rs
@@ -12,6 +12,7 @@ pub struct StateInitReceiver {
 #[interactive_clap(context = super::ConstructTransactionSenderContext)]
 #[strum_discriminants(derive(EnumMessage, EnumIter))]
 #[non_exhaustive]
+/// Provide state-init details:
 pub enum StateInitModeCommand {
     #[strum_discriminants(strum(
         message = "use-global-hash       - Use a global contract code hash"
@@ -31,18 +32,40 @@ pub enum StateInitModeCommand {
 #[interactive_clap(input_context = super::ConstructTransactionSenderContext)]
 #[interactive_clap(output_context = StateInitWithContractHashRefContext)]
 pub struct StateInitWithContractHashRef {
+    #[interactive_clap(skip_default_input_arg)]
     pub hash: crate::types::crypto_hash::CryptoHash,
     #[interactive_clap(subcommand)]
     data: Data,
+}
+
+impl StateInitWithContractHashRef {
+    pub fn input_hash(
+        _context: &super::ConstructTransactionSenderContext,
+    ) -> color_eyre::eyre::Result<Option<crate::types::crypto_hash::CryptoHash>> {
+        Ok(Some(
+            inquire::CustomType::new("Enter the global contract code hash:").prompt()?,
+        ))
+    }
 }
 
 #[derive(Debug, Clone, interactive_clap::InteractiveClap)]
 #[interactive_clap(input_context = super::ConstructTransactionSenderContext)]
 #[interactive_clap(output_context = StateInitWithContractRefByAccountContext)]
 pub struct StateInitWithContractRefByAccount {
+    #[interactive_clap(skip_default_input_arg)]
     pub account_id: crate::types::account_id::AccountId,
     #[interactive_clap(subcommand)]
     data: Data,
+}
+
+impl StateInitWithContractRefByAccount {
+    pub fn input_account_id(
+        _context: &super::ConstructTransactionSenderContext,
+    ) -> color_eyre::eyre::Result<Option<crate::types::account_id::AccountId>> {
+        Ok(Some(
+            inquire::CustomType::new("Enter the global contract account ID:").prompt()?,
+        ))
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -102,9 +125,20 @@ impl StateInitWithContractRefByAccountContext {
 #[interactive_clap(input_context = super::ConstructTransactionSenderContext)]
 #[interactive_clap(output_context = StateInitFromBorshBase64Context)]
 pub struct StateInitFromBorshBase64 {
+    #[interactive_clap(skip_default_input_arg)]
     pub state_init_base64: String,
     #[interactive_clap(named_arg)]
     deposit: Deposit,
+}
+
+impl StateInitFromBorshBase64 {
+    pub fn input_state_init_base64(
+        _context: &super::ConstructTransactionSenderContext,
+    ) -> color_eyre::eyre::Result<Option<String>> {
+        Ok(Some(
+            inquire::Text::new("Enter the borsh-base64 encoded StateInit:").prompt()?,
+        ))
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -137,6 +171,7 @@ impl From<StateInitFromBorshBase64Context> for StateInitDataContext {
 #[interactive_clap(context = StateInitModeContext)]
 #[strum_discriminants(derive(EnumMessage, EnumIter))]
 #[non_exhaustive]
+/// How would you like to provide the initial state data?
 pub enum Data {
     #[strum_discriminants(strum(
         message = "data-from-file - Read base64-encoded key-value JSON data from a file"
@@ -152,18 +187,44 @@ pub enum Data {
 #[interactive_clap(input_context = StateInitModeContext)]
 #[interactive_clap(output_context = DataFromFileContext)]
 pub struct DataFromFile {
+    #[interactive_clap(skip_default_input_arg)]
     pub file_path: crate::types::path_buf::PathBuf,
     #[interactive_clap(named_arg)]
     deposit: Deposit,
+}
+
+impl DataFromFile {
+    pub fn input_file_path(
+        _context: &StateInitModeContext,
+    ) -> color_eyre::eyre::Result<Option<crate::types::path_buf::PathBuf>> {
+        Ok(Some(
+            inquire::CustomType::new(
+                "Enter the path to the file with base64-encoded key-value JSON data:",
+            )
+            .prompt()?,
+        ))
+    }
 }
 
 #[derive(Debug, Clone, interactive_clap::InteractiveClap)]
 #[interactive_clap(input_context = StateInitModeContext)]
 #[interactive_clap(output_context = DataFromJsonContext)]
 pub struct DataFromJson {
+    #[interactive_clap(skip_default_input_arg)]
     pub data: String,
     #[interactive_clap(named_arg)]
     deposit: Deposit,
+}
+
+impl DataFromJson {
+    pub fn input_data(_context: &StateInitModeContext) -> color_eyre::eyre::Result<Option<String>> {
+        Ok(Some(
+            inquire::Text::new(
+                "Enter the base64-encoded key-value JSON data (e.g. '{\"AAEC\": \"AwQF\"}'):",
+            )
+            .prompt()?,
+        ))
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/commands/transaction/construct_transaction/state_init_receiver/mod.rs
+++ b/src/commands/transaction/construct_transaction/state_init_receiver/mod.rs
@@ -356,8 +356,12 @@ pub struct Deposit {
 
 impl Deposit {
     pub fn input_deposit(
-        _context: &StateInitDataContext,
+        context: &StateInitDataContext,
     ) -> color_eyre::eyre::Result<Option<crate::types::near_token::NearToken>> {
+        eprintln!(
+            "\nDerived deterministic AccountId: {}",
+            context.receiver_account_id
+        );
         Ok(Some(
             inquire::CustomType::new("What is the deposit for the state init call?")
                 .with_starting_input("0 NEAR")

--- a/src/commands/transaction/construct_transaction/state_init_receiver/mod.rs
+++ b/src/commands/transaction/construct_transaction/state_init_receiver/mod.rs
@@ -216,9 +216,11 @@ impl StateInitFromJsonContext {
         previous_context: super::ConstructTransactionSenderContext,
         scope: &<StateInitFromJson as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
     ) -> color_eyre::eyre::Result<Self> {
-        let state_init: near_primitives::deterministic_account_id::DeterministicAccountStateInit =
-            serde_json::from_str(&scope.state_init_json)
-                .wrap_err("Failed to parse JSON-serialized StateInit")?;
+        let state_init = serde_json::from_str::<crate::common::DeterministicAccountStateInitView>(
+            &scope.state_init_json,
+        )
+        .map(Into::into)
+        .wrap_err("Failed to parse JSON-serialized StateInit")?;
         let receiver_account_id =
             near_primitives::utils::derive_near_deterministic_account_id(&state_init);
         Ok(Self(StateInitDataContext {
@@ -260,8 +262,9 @@ impl StateInitFromJsonFileContext {
                 scope.file_path.0.display()
             )
         })?;
-        let state_init: near_primitives::deterministic_account_id::DeterministicAccountStateInit =
-            serde_json::from_str(&json_str)
+        let state_init =
+            serde_json::from_str::<crate::common::DeterministicAccountStateInitView>(&json_str)
+                .map(Into::into)
                 .wrap_err("Failed to parse JSON-serialized StateInit")?;
         let receiver_account_id =
             near_primitives::utils::derive_near_deterministic_account_id(&state_init);

--- a/src/commands/transaction/construct_transaction/state_init_receiver/mod.rs
+++ b/src/commands/transaction/construct_transaction/state_init_receiver/mod.rs
@@ -22,7 +22,7 @@ pub enum StateInitModeCommand {
     ))]
     UseGlobalAccountId(StateInitWithContractRefByAccount),
     #[strum_discriminants(strum(
-        message = "from-borsh-base64     - Provide the entire state init as a borsh+base64 blob"
+        message = "from-borsh-base64     - Provide borsh serialized base64 encoded state init"
     ))]
     FromBorshBase64(StateInitFromBorshBase64),
 }
@@ -283,6 +283,7 @@ impl DepositContext {
                     },
                 )),
             ],
+            sign_as_delegate_action: false,
         }))
     }
 }

--- a/src/commands/transaction/construct_transaction/state_init_receiver/mod.rs
+++ b/src/commands/transaction/construct_transaction/state_init_receiver/mod.rs
@@ -27,9 +27,9 @@ pub enum StateInitModeCommand {
     ))]
     FromBorshBase64(StateInitFromBorshBase64),
     #[strum_discriminants(strum(
-        message = "from-borsh-base64-file - Read borsh serialized base64 encoded state init from a file"
+        message = "from-borsh-file        - Read borsh-serialized state init from a file"
     ))]
-    FromBorshBase64File(StateInitFromBorshBase64File),
+    FromBorshFile(StateInitFromBorshFile),
 }
 
 #[derive(Debug, Clone, interactive_clap::InteractiveClap)]
@@ -155,30 +155,23 @@ impl From<StateInitFromBorshBase64Context> for StateInitDataContext {
 
 #[derive(Debug, Clone, interactive_clap::InteractiveClap)]
 #[interactive_clap(input_context = super::ConstructTransactionSenderContext)]
-#[interactive_clap(output_context = StateInitFromBorshBase64FileContext)]
-pub struct StateInitFromBorshBase64File {
-    /// Enter the path to a file containing borsh-base64 encoded StateInit:
+#[interactive_clap(output_context = StateInitFromBorshFileContext)]
+pub struct StateInitFromBorshFile {
+    /// Enter the path to a file containing borsh-serialized StateInit:
     pub file_path: crate::types::path_buf::PathBuf,
     #[interactive_clap(named_arg)]
     deposit: Deposit,
 }
 
 #[derive(Debug, Clone)]
-pub struct StateInitFromBorshBase64FileContext(StateInitDataContext);
+pub struct StateInitFromBorshFileContext(StateInitDataContext);
 
-impl StateInitFromBorshBase64FileContext {
+impl StateInitFromBorshFileContext {
     pub fn from_previous_context(
         previous_context: super::ConstructTransactionSenderContext,
-        scope: &<StateInitFromBorshBase64File as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+        scope: &<StateInitFromBorshFile as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
     ) -> color_eyre::eyre::Result<Self> {
-        let base64_str = std::fs::read_to_string(&scope.file_path).wrap_err_with(|| {
-            format!(
-                "Failed to open or read the file: {}",
-                scope.file_path.0.display()
-            )
-        })?;
-        let data = near_primitives::serialize::from_base64(base64_str.trim())
-            .wrap_err("Failed to decode base64 from file content")?;
+        let data = scope.file_path.read_bytes()?;
         let state_init = crate::common::parse_borsh_base64_state_init(&data)?;
         let receiver_account_id =
             near_primitives::utils::derive_near_deterministic_account_id(&state_init);
@@ -191,8 +184,8 @@ impl StateInitFromBorshBase64FileContext {
     }
 }
 
-impl From<StateInitFromBorshBase64FileContext> for StateInitDataContext {
-    fn from(item: StateInitFromBorshBase64FileContext) -> Self {
+impl From<StateInitFromBorshFileContext> for StateInitDataContext {
+    fn from(item: StateInitFromBorshFileContext) -> Self {
         item.0
     }
 }

--- a/src/commands/transaction/construct_transaction/state_init_receiver/mod.rs
+++ b/src/commands/transaction/construct_transaction/state_init_receiver/mod.rs
@@ -24,13 +24,18 @@ pub enum StateInitModeCommand {
     ))]
     /// Use a global contract account ID (mutable)
     UseGlobalAccountId(StateInitWithContractRefByAccount),
+    #[strum_discriminants(strum(
+        message = "from-borsh-base64     - Provide the entire state init as a borsh+base64 blob"
+    ))]
+    /// Provide the entire DeterministicAccountStateInit as a borsh-serialized + base64-encoded blob
+    FromBorshBase64(StateInitFromBorshBase64),
 }
 
 #[derive(Debug, Clone, interactive_clap::InteractiveClap)]
 #[interactive_clap(input_context = super::ConstructTransactionSenderContext)]
 #[interactive_clap(output_context = StateInitWithContractHashRefContext)]
 pub struct StateInitWithContractHashRef {
-    /// What is the hash of the global contract?
+    /// What is the base58-encoded hash of the global contract?
     pub hash: crate::types::crypto_hash::CryptoHash,
     #[interactive_clap(subcommand)]
     data: Data,
@@ -99,6 +104,43 @@ impl StateInitWithContractRefByAccountContext {
     }
 }
 
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(input_context = super::ConstructTransactionSenderContext)]
+#[interactive_clap(output_context = StateInitFromBorshBase64Context)]
+pub struct StateInitFromBorshBase64 {
+    /// Enter the borsh-serialized + base64-encoded DeterministicAccountStateInit blob:
+    pub state_init_base64: String,
+    #[interactive_clap(named_arg)]
+    /// Specify deposit
+    deposit: Deposit,
+}
+
+#[derive(Debug, Clone)]
+pub struct StateInitFromBorshBase64Context(StateInitDataContext);
+
+impl StateInitFromBorshBase64Context {
+    pub fn from_previous_context(
+        previous_context: super::ConstructTransactionSenderContext,
+        scope: &<StateInitFromBorshBase64 as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+    ) -> color_eyre::eyre::Result<Self> {
+        let state_init = crate::common::parse_borsh_base64_state_init(&scope.state_init_base64)?;
+        let receiver_account_id =
+            near_primitives::utils::derive_near_deterministic_account_id(&state_init);
+        Ok(Self(StateInitDataContext {
+            global_context: previous_context.global_context,
+            signer_account_id: previous_context.signer_account_id,
+            state_init,
+            receiver_account_id,
+        }))
+    }
+}
+
+impl From<StateInitFromBorshBase64Context> for StateInitDataContext {
+    fn from(item: StateInitFromBorshBase64Context) -> Self {
+        item.0
+    }
+}
+
 #[derive(Debug, EnumDiscriminants, Clone, interactive_clap::InteractiveClap)]
 #[interactive_clap(context = StateInitModeContext)]
 #[strum_discriminants(derive(EnumMessage, EnumIter))]
@@ -106,14 +148,14 @@ impl StateInitWithContractRefByAccountContext {
 /// How do you want to provide the initial state data?
 pub enum Data {
     #[strum_discriminants(strum(
-        message = "data-from-file - Read hex-encoded key-value JSON data from a file"
+        message = "data-from-file - Read base64-encoded key-value JSON data from a file"
     ))]
-    /// Read hex-encoded key-value JSON data from a file
+    /// Read base64-encoded key-value JSON data from a file
     DataFromFile(DataFromFile),
     #[strum_discriminants(strum(
-        message = "data-from-json - Provide hex-encoded key-value JSON data inline"
+        message = "data-from-json - Provide base64-encoded key-value JSON data inline"
     ))]
-    /// Provide hex-encoded key-value JSON data inline
+    /// Provide base64-encoded key-value JSON data inline
     DataFromJson(DataFromJson),
 }
 
@@ -132,7 +174,7 @@ pub struct DataFromFile {
 #[interactive_clap(input_context = StateInitModeContext)]
 #[interactive_clap(output_context = DataFromJsonContext)]
 pub struct DataFromJson {
-    /// Enter hex-encoded key-value JSON data (e.g. '{"deadbeef": "cafebabe"}' or '{}' for empty state):
+    /// Enter base64-encoded key-value JSON data (e.g. '{"AAEC": "AwQF"}' or '{}' for empty state):
     pub data: String,
     #[interactive_clap(named_arg)]
     /// Specify deposit
@@ -192,7 +234,7 @@ impl DataFromFileContext {
                 scope.file_path.0.display()
             )
         })?;
-        let data = crate::common::parse_hex_kv_map(&json_str)?;
+        let data = crate::common::parse_base64_kv_map(&json_str)?;
         Ok(Self(StateInitDataContext::build(
             previous_context.code,
             previous_context.global_context,
@@ -216,7 +258,7 @@ impl DataFromJsonContext {
         previous_context: StateInitModeContext,
         scope: &<DataFromJson as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
     ) -> color_eyre::eyre::Result<Self> {
-        let data = crate::common::parse_hex_kv_map(&scope.data)?;
+        let data = crate::common::parse_base64_kv_map(&scope.data)?;
         Ok(Self(StateInitDataContext::build(
             previous_context.code,
             previous_context.global_context,

--- a/src/commands/transaction/reconstruct_transaction/mod.rs
+++ b/src/commands/transaction/reconstruct_transaction/mod.rs
@@ -80,12 +80,14 @@ impl TransactionInfoContext {
                                     sender_account_id: Some(
                                         prepopulated_transaction.signer_id.into(),
                                     ),
-                                    receiver: Some(CliReceiverMode::ReceiverId(CliDirectReceiver {
-                                        receiver_account_id: Some(
-                                            prepopulated_transaction.receiver_id.clone().into(),
-                                        ),
-                                        next_actions: None,
-                                    })),
+                                    receiver: Some(CliReceiverMode::ReceiverId(
+                                        CliDirectReceiver {
+                                            receiver_account_id: Some(
+                                                prepopulated_transaction.receiver_id.clone().into(),
+                                            ),
+                                            next_actions: None,
+                                        },
+                                    )),
                                 },
                             )),
                         });

--- a/src/commands/transaction/reconstruct_transaction/mod.rs
+++ b/src/commands/transaction/reconstruct_transaction/mod.rs
@@ -21,7 +21,9 @@ impl TransactionInfoContext {
         previous_context: crate::GlobalContext,
         scope: &<TransactionInfo as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
     ) -> color_eyre::eyre::Result<Self> {
-        use super::construct_transaction::{CliConstructTransaction, add_action_1, skip_action};
+        use super::construct_transaction::{
+            CliConstructTransaction, CliDirectReceiver, CliReceiverMode, add_action_1, skip_action,
+        };
         use super::{CliTransactionActions, CliTransactionCommands};
 
         let on_after_getting_network_callback: crate::network::OnAfterGettingNetworkCallback =
@@ -78,10 +80,12 @@ impl TransactionInfoContext {
                                     sender_account_id: Some(
                                         prepopulated_transaction.signer_id.into(),
                                     ),
-                                    receiver_account_id: Some(
-                                        prepopulated_transaction.receiver_id.clone().into(),
-                                    ),
-                                    next_actions: None,
+                                    receiver: Some(CliReceiverMode::AccountId(CliDirectReceiver {
+                                        receiver_account_id: Some(
+                                            prepopulated_transaction.receiver_id.clone().into(),
+                                        ),
+                                        next_actions: None,
+                                    })),
                                 },
                             )),
                         });

--- a/src/commands/transaction/reconstruct_transaction/mod.rs
+++ b/src/commands/transaction/reconstruct_transaction/mod.rs
@@ -80,7 +80,7 @@ impl TransactionInfoContext {
                                     sender_account_id: Some(
                                         prepopulated_transaction.signer_id.into(),
                                     ),
-                                    receiver: Some(CliReceiverMode::AccountId(CliDirectReceiver {
+                                    receiver: Some(CliReceiverMode::ReceiverId(CliDirectReceiver {
                                         receiver_account_id: Some(
                                             prepopulated_transaction.receiver_id.clone().into(),
                                         ),

--- a/src/common.rs
+++ b/src/common.rs
@@ -885,9 +885,14 @@ pub fn print_unsigned_transaction(
             near_primitives::transaction::Action::DeterministicStateInit(
                 deterministic_init_action,
             ) => {
+                let deterministic_account_id =
+                    near_primitives::utils::derive_near_deterministic_account_id(
+                        &deterministic_init_action.state_init,
+                    );
                 info_str.push_str(&format!(
                     "\n{:>5} {:<20}",
-                    "--", "initizalize deterministic account id:"
+                    "--",
+                    format!("create deterministic account <{deterministic_account_id}>:")
                 ));
                 info_str.push_str(&format!(
                     "\n{:>18} {:<13} {}",
@@ -896,13 +901,26 @@ pub fn print_unsigned_transaction(
                 let state_init = match &deterministic_init_action.state_init {
                     near_primitives::deterministic_account_id::DeterministicAccountStateInit::V1(deterministic_account_state_init_v1) => {
                         let mut ret = "V1".to_string();
-                        ret.push_str(&format!("\n{:>31} {:<13} {:?}", "", "data", deterministic_account_state_init_v1.data));
+                        if deterministic_account_state_init_v1.data.is_empty() {
+                            ret.push_str(&format!("\n{:>31} {:<13} {{}}", "", "data"));
+                        } else {
+                            ret.push_str(&format!("\n{:>31} {:<13} {{", "", "data"));
+                            let last_idx = deterministic_account_state_init_v1.data.len() - 1;
+                            for (i, (key, value)) in deterministic_account_state_init_v1.data.iter().enumerate() {
+                                let comma = if i < last_idx { "," } else { "" };
+                                ret.push_str(&format!(
+                                    "\n{:>45} \"{}\" : \"{}\"{}",
+                                    "", hex::encode(key), hex::encode(value), comma,
+                                ));
+                            }
+                            ret.push_str(&format!("\n{:>31} {:<13} }}", "", ""));
+                        }
                         ret.push_str(&format!("\n{:>31} {:<13} {}", "", "code", match deterministic_account_state_init_v1.code {
                             GlobalContractIdentifier::CodeHash(hash) => {
-                                format!("use global <{hash}> code to deploy from")
+                                format!("hash: {hash}")
                             }
                             GlobalContractIdentifier::AccountId(ref account_id) => {
-                                format!("use global <{account_id}> code to deploy from")
+                                format!("account ref: {account_id}")
                             }
                         }));
 
@@ -3132,4 +3150,24 @@ pub fn save_cli_command(cli_cmd_str: &str) {
     if let Err(err) = writeln!(tmp_file, "{cli_cmd_str}") {
         eprintln!("Failed to store a cli command in a temporary file: {err}");
     }
+}
+
+/// Parses a JSON object with hex-encoded keys and values (no `0x` prefix) into a `BTreeMap<Vec<u8>, Vec<u8>>`.
+///
+/// Example input: `{"deadbeef": "cafebabe", "0102": "0304"}`
+/// Empty state: `{}`
+pub fn parse_hex_kv_map(
+    input: &str,
+) -> color_eyre::eyre::Result<std::collections::BTreeMap<Vec<u8>, Vec<u8>>> {
+    let map: std::collections::BTreeMap<String, String> = serde_json::from_str(input)
+        .map_err(|e| color_eyre::eyre::eyre!("Failed to parse JSON: {e}"))?;
+    let mut result = std::collections::BTreeMap::new();
+    for (k, v) in map {
+        let key = hex::decode(&k)
+            .map_err(|e| color_eyre::eyre::eyre!("Failed to hex-decode key '{k}': {e}"))?;
+        let value = hex::decode(&v)
+            .map_err(|e| color_eyre::eyre::eyre!("Failed to hex-decode value '{v}': {e}"))?;
+        result.insert(key, value);
+    }
+    Ok(result)
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -3172,15 +3172,13 @@ pub fn parse_base64_kv_map(
     Ok(result)
 }
 
-/// Deserializes a `DeterministicAccountStateInit` from a borsh-serialized + base64-encoded string.
+/// Deserializes a `DeterministicAccountStateInit` from borsh-serialized bytes.
 pub fn parse_borsh_base64_state_init(
-    input: &str,
+    bytes: &[u8],
 ) -> color_eyre::eyre::Result<
     near_primitives::deterministic_account_id::DeterministicAccountStateInit,
 > {
     use borsh::BorshDeserialize;
-    let bytes = near_primitives::serialize::from_base64(input.trim())
-        .map_err(|e| color_eyre::eyre::eyre!("Failed to base64-decode state init: {e}"))?;
-    near_primitives::deterministic_account_id::DeterministicAccountStateInit::try_from_slice(&bytes)
+    near_primitives::deterministic_account_id::DeterministicAccountStateInit::try_from_slice(bytes)
         .map_err(|e| color_eyre::eyre::eyre!("Failed to borsh-deserialize state init: {e}"))
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -954,11 +954,17 @@ pub fn print_unsigned_transaction(
                     "\n{:>18} {:<12}: {}",
                     "", "deposit", deterministic_init_action.deposit
                 ));
-                let state_init_json = serde_json::to_string_pretty(&deterministic_init_action.state_init)
-                    .expect("DeterministicAccountStateInit is always serializable");
+                let state_init_json =
+                    serde_json::to_string_pretty(&DeterministicAccountStateInitView::from(
+                        deterministic_init_action.state_init.clone(),
+                    ))
+                    .expect("DeterministicAccountStateInitView is always serializable");
                 let state_init_indented = state_init_json.replace('\n', &format!("\n{:33}", ""));
 
-                info_str.push_str(&format!("\n{:>18} {:<12}: {}", "", "state-init", state_init_indented));
+                info_str.push_str(&format!(
+                    "\n{:>18} {:<12}: {}",
+                    "", "state-init", state_init_indented
+                ));
             }
             near_primitives::transaction::Action::TransferToGasKey(transfer_to_gas_key) => {
                 info_str.push_str(&format!("\n{:>5} {:<20}", "--", "transfer to gas key:"));
@@ -3453,6 +3459,48 @@ pub fn parse_base64_kv_map(
     let data: Data = serde_json::from_str(input)
         .map_err(|e| color_eyre::eyre::eyre!("Failed to parse base64 KV map: {e}"))?;
     Ok(data.0)
+}
+
+// NOTE: workaround for not yet released version of near-primitives that accounts for proper
+// serialization of GlobalContractIdentifier
+// ref: https://github.com/near/nearcore/commit/1bcb01fb09ada9243182d061b8b2e2ad7bf544c3
+#[serde_as]
+#[derive(serde::Serialize, serde::Deserialize)]
+pub(crate) struct DeterministicAccountStateInitV1View {
+    code: near_primitives::views::GlobalContractIdentifierView,
+    #[serde_as(as = "std::collections::BTreeMap<Base64, Base64>")]
+    data: std::collections::BTreeMap<Vec<u8>, Vec<u8>>,
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+pub(crate) enum DeterministicAccountStateInitView {
+    V1(DeterministicAccountStateInitV1View),
+}
+
+impl From<near_primitives::deterministic_account_id::DeterministicAccountStateInit>
+    for DeterministicAccountStateInitView
+{
+    fn from(
+        near_primitives::deterministic_account_id::DeterministicAccountStateInit::V1(v1): near_primitives::deterministic_account_id::DeterministicAccountStateInit,
+    ) -> Self {
+        Self::V1(DeterministicAccountStateInitV1View {
+            code: v1.code.into(),
+            data: v1.data,
+        })
+    }
+}
+
+impl From<DeterministicAccountStateInitView>
+    for near_primitives::deterministic_account_id::DeterministicAccountStateInit
+{
+    fn from(DeterministicAccountStateInitView::V1(v1): DeterministicAccountStateInitView) -> Self {
+        Self::V1(
+            near_primitives::deterministic_account_id::DeterministicAccountStateInitV1 {
+                code: v1.code.into(),
+                data: v1.data,
+            },
+        )
+    }
 }
 
 /// Deserializes a `DeterministicAccountStateInit` from borsh-serialized bytes.

--- a/src/common.rs
+++ b/src/common.rs
@@ -951,40 +951,14 @@ pub fn print_unsigned_transaction(
                     format!("create deterministic account <{deterministic_account_id}>:")
                 ));
                 info_str.push_str(&format!(
-                    "\n{:>18} {:<13} {}",
-                    "", "deposit:", deterministic_init_action.deposit
+                    "\n{:>18} {:<12}: {}",
+                    "", "deposit", deterministic_init_action.deposit
                 ));
-                let state_init = match &deterministic_init_action.state_init {
-                    near_primitives::deterministic_account_id::DeterministicAccountStateInit::V1(deterministic_account_state_init_v1) => {
-                        let mut ret = "V1".to_string();
-                        if deterministic_account_state_init_v1.data.is_empty() {
-                            ret.push_str(&format!("\n{:>31} {:<13} {{}}", "", "data:"));
-                        } else {
-                            ret.push_str(&format!("\n{:>31} {:<13} {{", "", "data:"));
-                            let last_idx = deterministic_account_state_init_v1.data.len() - 1;
-                            for (i, (key, value)) in deterministic_account_state_init_v1.data.iter().enumerate() {
-                                let comma = if i < last_idx { "," } else { "" };
-                                ret.push_str(&format!(
-                                    "\n{:>45} \"{}\" : \"{}\"{}",
-                                    "", near_primitives::serialize::to_base64(key), near_primitives::serialize::to_base64(value), comma,
-                                ));
-                            }
-                            ret.push_str(&format!("\n{:>31} {:<13} }}", "", ""));
-                        }
-                        ret.push_str(&format!("\n{:>31} {:<13} {}", "", "code:", match deterministic_account_state_init_v1.code {
-                            GlobalContractIdentifier::CodeHash(hash) => {
-                                format!("hash: {hash}")
-                            }
-                            GlobalContractIdentifier::AccountId(ref account_id) => {
-                                format!("account ref: {account_id}")
-                            }
-                        }));
+                let state_init_json = serde_json::to_string_pretty(&deterministic_init_action.state_init)
+                    .expect("DeterministicAccountStateInit is always serializable");
+                let state_init_indented = state_init_json.replace('\n', &format!("\n{:33}", ""));
 
-                        ret
-                    },
-                };
-
-                info_str.push_str(&format!("\n{:>18} {:<13} {}", "", "state:", state_init));
+                info_str.push_str(&format!("\n{:>18} {:<12}: {}", "", "state-init", state_init_indented));
             }
             near_primitives::transaction::Action::TransferToGasKey(transfer_to_gas_key) => {
                 info_str.push_str(&format!("\n{:>5} {:<20}", "--", "transfer to gas key:"));

--- a/src/common.rs
+++ b/src/common.rs
@@ -910,7 +910,7 @@ pub fn print_unsigned_transaction(
                                 let comma = if i < last_idx { "," } else { "" };
                                 ret.push_str(&format!(
                                     "\n{:>45} \"{}\" : \"{}\"{}",
-                                    "", hex::encode(key), hex::encode(value), comma,
+                                    "", near_primitives::serialize::to_base64(key), near_primitives::serialize::to_base64(value), comma,
                                 ));
                             }
                             ret.push_str(&format!("\n{:>31} {:<13} }}", "", ""));
@@ -3152,22 +3152,35 @@ pub fn save_cli_command(cli_cmd_str: &str) {
     }
 }
 
-/// Parses a JSON object with hex-encoded keys and values (no `0x` prefix) into a `BTreeMap<Vec<u8>, Vec<u8>>`.
+/// Parses a JSON object with base64-encoded keys and values into a `BTreeMap<Vec<u8>, Vec<u8>>`.
 ///
-/// Example input: `{"deadbeef": "cafebabe", "0102": "0304"}`
+/// Example input: `{"AAEC": "AwQF"}` (standard base64, padding optional)
 /// Empty state: `{}`
-pub fn parse_hex_kv_map(
+pub fn parse_base64_kv_map(
     input: &str,
 ) -> color_eyre::eyre::Result<std::collections::BTreeMap<Vec<u8>, Vec<u8>>> {
     let map: std::collections::BTreeMap<String, String> = serde_json::from_str(input)
         .map_err(|e| color_eyre::eyre::eyre!("Failed to parse JSON: {e}"))?;
     let mut result = std::collections::BTreeMap::new();
     for (k, v) in map {
-        let key = hex::decode(&k)
-            .map_err(|e| color_eyre::eyre::eyre!("Failed to hex-decode key '{k}': {e}"))?;
-        let value = hex::decode(&v)
-            .map_err(|e| color_eyre::eyre::eyre!("Failed to hex-decode value '{v}': {e}"))?;
+        let key = near_primitives::serialize::from_base64(&k)
+            .map_err(|e| color_eyre::eyre::eyre!("Failed to base64-decode key '{k}': {e}"))?;
+        let value = near_primitives::serialize::from_base64(&v)
+            .map_err(|e| color_eyre::eyre::eyre!("Failed to base64-decode value '{v}': {e}"))?;
         result.insert(key, value);
     }
     Ok(result)
+}
+
+/// Deserializes a `DeterministicAccountStateInit` from a borsh-serialized + base64-encoded string.
+pub fn parse_borsh_base64_state_init(
+    input: &str,
+) -> color_eyre::eyre::Result<
+    near_primitives::deterministic_account_id::DeterministicAccountStateInit,
+> {
+    use borsh::BorshDeserialize;
+    let bytes = near_primitives::serialize::from_base64(input.trim())
+        .map_err(|e| color_eyre::eyre::eyre!("Failed to base64-decode state init: {e}"))?;
+    near_primitives::deterministic_account_id::DeterministicAccountStateInit::try_from_slice(&bytes)
+        .map_err(|e| color_eyre::eyre::eyre!("Failed to borsh-deserialize state init: {e}"))
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -10,6 +10,7 @@ use futures::{StreamExt, TryStreamExt};
 use near_primitives::action::{GlobalContractDeployMode, GlobalContractIdentifier};
 use prettytable::Table;
 use rust_decimal::prelude::FromPrimitive;
+use serde_with::{base64::Base64, serde_as};
 use tracing_indicatif::span_ext::IndicatifSpanExt;
 use tracing_indicatif::suspend_tracing_indicatif;
 
@@ -3210,17 +3211,16 @@ pub fn save_cli_command(cli_cmd_str: &str) {
 pub fn parse_base64_kv_map(
     input: &str,
 ) -> color_eyre::eyre::Result<std::collections::BTreeMap<Vec<u8>, Vec<u8>>> {
-    let map: std::collections::BTreeMap<String, String> = serde_json::from_str(input)
-        .map_err(|e| color_eyre::eyre::eyre!("Failed to parse JSON: {e}"))?;
-    let mut result = std::collections::BTreeMap::new();
-    for (k, v) in map {
-        let key = near_primitives::serialize::from_base64(&k)
-            .map_err(|e| color_eyre::eyre::eyre!("Failed to base64-decode key '{k}': {e}"))?;
-        let value = near_primitives::serialize::from_base64(&v)
-            .map_err(|e| color_eyre::eyre::eyre!("Failed to base64-decode value '{v}': {e}"))?;
-        result.insert(key, value);
-    }
-    Ok(result)
+    #[serde_as]
+    #[derive(serde::Deserialize)]
+    struct Data(
+        #[serde_as(as = "std::collections::BTreeMap<Base64, Base64>")]
+        std::collections::BTreeMap<Vec<u8>, Vec<u8>>,
+    );
+
+    let data: Data = serde_json::from_str(input)
+        .map_err(|e| color_eyre::eyre::eyre!("Failed to parse base64 KV map: {e}"))?;
+    Ok(data.0)
 }
 
 /// Deserializes a `DeterministicAccountStateInit` from borsh-serialized bytes.

--- a/src/common.rs
+++ b/src/common.rs
@@ -954,9 +954,9 @@ pub fn print_unsigned_transaction(
                     near_primitives::deterministic_account_id::DeterministicAccountStateInit::V1(deterministic_account_state_init_v1) => {
                         let mut ret = "V1".to_string();
                         if deterministic_account_state_init_v1.data.is_empty() {
-                            ret.push_str(&format!("\n{:>31} {:<13} {{}}", "", "data"));
+                            ret.push_str(&format!("\n{:>31} {:<13} {{}}", "", "data:"));
                         } else {
-                            ret.push_str(&format!("\n{:>31} {:<13} {{", "", "data"));
+                            ret.push_str(&format!("\n{:>31} {:<13} {{", "", "data:"));
                             let last_idx = deterministic_account_state_init_v1.data.len() - 1;
                             for (i, (key, value)) in deterministic_account_state_init_v1.data.iter().enumerate() {
                                 let comma = if i < last_idx { "," } else { "" };
@@ -967,7 +967,7 @@ pub fn print_unsigned_transaction(
                             }
                             ret.push_str(&format!("\n{:>31} {:<13} }}", "", ""));
                         }
-                        ret.push_str(&format!("\n{:>31} {:<13} {}", "", "code", match deterministic_account_state_init_v1.code {
+ret.push_str(&format!("\n{:>31} {:<13} {}", "", "code:", match deterministic_account_state_init_v1.code {
                             GlobalContractIdentifier::CodeHash(hash) => {
                                 format!("hash: {hash}")
                             }

--- a/src/common.rs
+++ b/src/common.rs
@@ -967,7 +967,7 @@ pub fn print_unsigned_transaction(
                             }
                             ret.push_str(&format!("\n{:>31} {:<13} }}", "", ""));
                         }
-ret.push_str(&format!("\n{:>31} {:<13} {}", "", "code:", match deterministic_account_state_init_v1.code {
+                        ret.push_str(&format!("\n{:>31} {:<13} {}", "", "code:", match deterministic_account_state_init_v1.code {
                             GlobalContractIdentifier::CodeHash(hash) => {
                                 format!("hash: {hash}")
                             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -258,7 +258,10 @@ fn try_rewrite_construct_transaction_args() -> Option<Vec<String>> {
     // Check if receiver_arg matches any ReceiverMode subcommand name.
     use clap::Subcommand;
     let receiver_cmd = clap::Command::new("tmp");
-    let receiver_cmd = commands::transaction::construct_transaction::CliReceiverMode::augment_subcommands(receiver_cmd);
+    let receiver_cmd =
+        commands::transaction::construct_transaction::CliReceiverMode::augment_subcommands(
+            receiver_cmd,
+        );
     let is_receiver_subcommand = receiver_cmd
         .get_subcommands()
         .any(|sc| sc.get_name() == receiver_arg);

--- a/src/main.rs
+++ b/src/main.rs
@@ -280,6 +280,6 @@ fn try_rewrite_construct_transaction_args() -> Option<Vec<String>> {
     }
     // Insert "account-id" before the receiver.
     let mut rewritten = args;
-    rewritten.insert(receiver_idx, "account-id".to_string());
+    rewritten.insert(receiver_idx, "receiver-id".to_string());
     Some(rewritten)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -255,9 +255,34 @@ fn try_rewrite_construct_transaction_args() -> Option<Vec<String>> {
         return None;
     }
     let receiver_arg = &args[receiver_idx];
-    // If it's already the new syntax subcommand, no rewrite needed.
-    if receiver_arg == "account-id" || receiver_arg == "state-init" {
-        return None;
+    // Check if receiver_arg matches any ReceiverMode subcommand name.
+    use clap::Subcommand;
+    let receiver_cmd = clap::Command::new("tmp");
+    let receiver_cmd = commands::transaction::construct_transaction::CliReceiverMode::augment_subcommands(receiver_cmd);
+    let is_receiver_subcommand = receiver_cmd
+        .get_subcommands()
+        .any(|sc| sc.get_name() == receiver_arg);
+    if is_receiver_subcommand {
+        if receiver_arg == "state-init" {
+            // Look ahead: only treat "state-init" as the subcommand if the next arg
+            // is a valid state-init sub-subcommand (or there is no next arg, i.e.
+            // interactive mode). Otherwise "state-init" is a literal account ID.
+            let next_idx = receiver_idx + 1;
+            if next_idx >= args.len() {
+                return None; // No more args → interactive state-init mode
+            }
+            let state_init_cmd = clap::Command::new("tmp");
+            let state_init_cmd = commands::transaction::construct_transaction::state_init_receiver::CliStateInitModeCommand::augment_subcommands(state_init_cmd);
+            let is_state_init_subcommand = state_init_cmd
+                .get_subcommands()
+                .any(|sc| sc.get_name() == args[next_idx]);
+            if is_state_init_subcommand {
+                return None; // New state-init syntax
+            }
+            // Next arg doesn't match any state-init subcommand → "state-init" is an account ID
+        } else {
+            return None; // Already new syntax (e.g. "account-id")
+        }
     }
     // Only rewrite if it looks like a valid account ID (not a flag).
     if receiver_arg.starts_with('-') {

--- a/src/main.rs
+++ b/src/main.rs
@@ -263,26 +263,7 @@ fn try_rewrite_construct_transaction_args() -> Option<Vec<String>> {
         .get_subcommands()
         .any(|sc| sc.get_name() == receiver_arg);
     if is_receiver_subcommand {
-        if receiver_arg == "state-init" {
-            // Look ahead: only treat "state-init" as the subcommand if the next arg
-            // is a valid state-init sub-subcommand (or there is no next arg, i.e.
-            // interactive mode). Otherwise "state-init" is a literal account ID.
-            let next_idx = receiver_idx + 1;
-            if next_idx >= args.len() {
-                return None; // No more args → interactive state-init mode
-            }
-            let state_init_cmd = clap::Command::new("tmp");
-            let state_init_cmd = commands::transaction::construct_transaction::state_init_receiver::CliStateInitModeCommand::augment_subcommands(state_init_cmd);
-            let is_state_init_subcommand = state_init_cmd
-                .get_subcommands()
-                .any(|sc| sc.get_name() == args[next_idx]);
-            if is_state_init_subcommand {
-                return None; // New state-init syntax
-            }
-            // Next arg doesn't match any state-init subcommand → "state-init" is an account ID
-        } else {
-            return None; // Already new syntax (e.g. "account-id")
-        }
+        return None; // Already new syntax (e.g. "account-id" or "state-init")
     }
     // Only rewrite if it looks like a valid account ID (not a flag).
     if receiver_arg.starts_with('-') {

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,26 +102,35 @@ fn main() -> crate::common::CliResult {
                 cmd_error.exit()
             }
             _ => {
-                match crate::js_command_match::JsCmd::try_parse() {
-                    Ok(js_cmd) => {
-                        let vec_cmd = js_cmd.rust_command_generation();
-                        let cmd = std::iter::once(near_cli_exec_path.to_owned()).chain(vec_cmd);
-                        Parser::parse_from(cmd)
+                // Backward compat: old `construct-transaction <sender> <receiver>` syntax
+                // Insert "account-id" subcommand before the bare receiver account ID.
+                if let Some(rewritten) = try_rewrite_construct_transaction_args() {
+                    match Cmd::try_parse_from(rewritten) {
+                        Ok(cli) => cli,
+                        Err(_) => cmd_error.exit(),
                     }
-                    Err(js_cmd_error) => {
-                        // js and rust both don't understand the subcommand
-                        if cmd_error.kind() == clap::error::ErrorKind::InvalidSubcommand
-                            && js_cmd_error.kind() == clap::error::ErrorKind::InvalidSubcommand
-                        {
-                            return crate::common::try_external_subcommand_execution(cmd_error);
+                } else {
+                    match crate::js_command_match::JsCmd::try_parse() {
+                        Ok(js_cmd) => {
+                            let vec_cmd = js_cmd.rust_command_generation();
+                            let cmd = std::iter::once(near_cli_exec_path.to_owned()).chain(vec_cmd);
+                            Parser::parse_from(cmd)
                         }
+                        Err(js_cmd_error) => {
+                            // js and rust both don't understand the subcommand
+                            if cmd_error.kind() == clap::error::ErrorKind::InvalidSubcommand
+                                && js_cmd_error.kind() == clap::error::ErrorKind::InvalidSubcommand
+                            {
+                                return crate::common::try_external_subcommand_execution(cmd_error);
+                            }
 
-                        // js understand the subcommand
-                        if js_cmd_error.kind() != clap::error::ErrorKind::InvalidSubcommand {
-                            js_cmd_error.exit();
+                            // js understand the subcommand
+                            if js_cmd_error.kind() != clap::error::ErrorKind::InvalidSubcommand {
+                                js_cmd_error.exit();
+                            }
+
+                            cmd_error.exit();
                         }
-
-                        cmd_error.exit();
                     }
                 }
             }
@@ -233,4 +242,35 @@ fn main() -> crate::common::CliResult {
     };
 
     cli_cmd.map(|_| ())
+}
+
+/// Detect the old `construct-transaction <sender> <bare-account-id>` syntax and
+/// rewrite it to `construct-transaction <sender> account-id <bare-account-id>`.
+fn try_rewrite_construct_transaction_args() -> Option<Vec<String>> {
+    let args: Vec<String> = std::env::args().collect();
+    let ct_idx = args.iter().position(|a| a == "construct-transaction")?;
+    // We expect at least: ... construct-transaction <sender> <receiver> ...
+    let receiver_idx = ct_idx + 2;
+    if receiver_idx >= args.len() {
+        return None;
+    }
+    let receiver_arg = &args[receiver_idx];
+    // If it's already the new syntax subcommand, no rewrite needed.
+    if receiver_arg == "account-id" || receiver_arg == "state-init" {
+        return None;
+    }
+    // Only rewrite if it looks like a valid account ID (not a flag).
+    if receiver_arg.starts_with('-') {
+        return None;
+    }
+    if receiver_arg
+        .parse::<near_primitives::types::AccountId>()
+        .is_err()
+    {
+        return None;
+    }
+    // Insert "account-id" before the receiver.
+    let mut rewritten = args;
+    rewritten.insert(receiver_idx, "account-id".to_string());
+    Some(rewritten)
 }

--- a/tests/construct_transaction.rs
+++ b/tests/construct_transaction.rs
@@ -28,7 +28,7 @@ fn normalize_output(output: &str) -> String {
 
 #[tokio::test]
 async fn test_construct_transaction_old_syntax() -> Result<(), Box<dyn std::error::Error>> {
-    let _ctx = common::prepare_tests().await?;
+    let ctx = common::prepare_tests().await?;
 
     let mut args = vec![
         "transaction",
@@ -42,7 +42,12 @@ async fn test_construct_transaction_old_syntax() -> Result<(), Box<dyn std::erro
     ];
     args.extend(sign_later_args());
 
-    let output = Command::new("target/debug/near").args(&args).output()?;
+    let output = Command::new("target/debug/near")
+        .env("XDG_CONFIG_HOME", &ctx.config_home)
+        .env("HOME", &ctx.config_home)
+        .env("APPDATA", &ctx.config_home)
+        .args(&args)
+        .output()?;
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
@@ -61,7 +66,7 @@ async fn test_construct_transaction_old_syntax() -> Result<(), Box<dyn std::erro
 
 #[tokio::test]
 async fn test_construct_transaction_new_syntax() -> Result<(), Box<dyn std::error::Error>> {
-    let _ctx = common::prepare_tests().await?;
+    let ctx = common::prepare_tests().await?;
 
     let mut args = vec![
         "transaction",
@@ -76,7 +81,12 @@ async fn test_construct_transaction_new_syntax() -> Result<(), Box<dyn std::erro
     ];
     args.extend(sign_later_args());
 
-    let output = Command::new("target/debug/near").args(&args).output()?;
+    let output = Command::new("target/debug/near")
+        .env("XDG_CONFIG_HOME", &ctx.config_home)
+        .env("HOME", &ctx.config_home)
+        .env("APPDATA", &ctx.config_home)
+        .args(&args)
+        .output()?;
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
@@ -96,7 +106,7 @@ async fn test_construct_transaction_new_syntax() -> Result<(), Box<dyn std::erro
 
 #[tokio::test]
 async fn test_construct_transaction_state_init() -> Result<(), Box<dyn std::error::Error>> {
-    let _ctx = common::prepare_tests().await?;
+    let ctx = common::prepare_tests().await?;
 
     // A valid base58-encoded CryptoHash (32 zero bytes in base58)
     let hash = DUMMY_BLOCK_HASH;
@@ -116,7 +126,12 @@ async fn test_construct_transaction_state_init() -> Result<(), Box<dyn std::erro
     ];
     args.extend(sign_later_args());
 
-    let output = Command::new("target/debug/near").args(&args).output()?;
+    let output = Command::new("target/debug/near")
+        .env("XDG_CONFIG_HOME", &ctx.config_home)
+        .env("HOME", &ctx.config_home)
+        .env("APPDATA", &ctx.config_home)
+        .args(&args)
+        .output()?;
 
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(

--- a/tests/construct_transaction.rs
+++ b/tests/construct_transaction.rs
@@ -51,7 +51,10 @@ async fn test_construct_transaction_old_syntax() -> Result<(), Box<dyn std::erro
         String::from_utf8_lossy(&output.stderr)
     );
 
-    insta::assert_snapshot!("construct_transaction_old_syntax", normalize_output(&stdout));
+    insta::assert_snapshot!(
+        "construct_transaction_old_syntax",
+        normalize_output(&stdout)
+    );
 
     Ok(())
 }
@@ -83,7 +86,10 @@ async fn test_construct_transaction_new_syntax() -> Result<(), Box<dyn std::erro
     );
 
     // Old syntax and new syntax should produce identical output
-    insta::assert_snapshot!("construct_transaction_new_syntax", normalize_output(&stdout));
+    insta::assert_snapshot!(
+        "construct_transaction_new_syntax",
+        normalize_output(&stdout)
+    );
 
     Ok(())
 }
@@ -119,7 +125,10 @@ async fn test_construct_transaction_state_init() -> Result<(), Box<dyn std::erro
         String::from_utf8_lossy(&output.stderr)
     );
 
-    insta::assert_snapshot!("construct_transaction_state_init", normalize_output(&stdout));
+    insta::assert_snapshot!(
+        "construct_transaction_state_init",
+        normalize_output(&stdout)
+    );
 
     Ok(())
 }

--- a/tests/construct_transaction.rs
+++ b/tests/construct_transaction.rs
@@ -67,7 +67,7 @@ async fn test_construct_transaction_new_syntax() -> Result<(), Box<dyn std::erro
         "transaction",
         "construct-transaction",
         "test.near",
-        "account-id",
+        "receiver-id",
         "test.near",
         "add-action",
         "transfer",

--- a/tests/construct_transaction.rs
+++ b/tests/construct_transaction.rs
@@ -1,0 +1,125 @@
+mod common;
+use std::process::Command;
+
+const DUMMY_PUBLIC_KEY: &str = "ed25519:6E8sCci9badyRkXb3JoRpBj5p8C6Tw41ELDZoiihKEtp";
+const DUMMY_BLOCK_HASH: &str = "11111111111111111111111111111111";
+
+fn sign_later_args() -> Vec<&'static str> {
+    vec![
+        "network-config",
+        "sandbox",
+        "sign-later",
+        "--signer-public-key",
+        DUMMY_PUBLIC_KEY,
+        "--nonce",
+        "0",
+        "--block-hash",
+        DUMMY_BLOCK_HASH,
+        "display",
+    ]
+}
+
+/// Replace the binary path in output with a stable placeholder
+fn normalize_output(output: &str) -> String {
+    let re = regex::Regex::new(r"\$ .+ transaction sign-transaction").unwrap();
+    re.replace_all(output, "$ near transaction sign-transaction")
+        .to_string()
+}
+
+#[tokio::test]
+async fn test_construct_transaction_old_syntax() -> Result<(), Box<dyn std::error::Error>> {
+    let (_sandbox, _temp_dir) = common::prepare_tests().await?;
+
+    let mut args = vec![
+        "transaction",
+        "construct-transaction",
+        "test.near",
+        "test.near",
+        "add-action",
+        "transfer",
+        "1 NEAR",
+        "skip",
+    ];
+    args.extend(sign_later_args());
+
+    let output = Command::new("target/debug/near").args(&args).output()?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        output.status.success(),
+        "Command failed. stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    insta::assert_snapshot!("construct_transaction_old_syntax", normalize_output(&stdout));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_construct_transaction_new_syntax() -> Result<(), Box<dyn std::error::Error>> {
+    let (_sandbox, _temp_dir) = common::prepare_tests().await?;
+
+    let mut args = vec![
+        "transaction",
+        "construct-transaction",
+        "test.near",
+        "account-id",
+        "test.near",
+        "add-action",
+        "transfer",
+        "1 NEAR",
+        "skip",
+    ];
+    args.extend(sign_later_args());
+
+    let output = Command::new("target/debug/near").args(&args).output()?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        output.status.success(),
+        "Command failed. stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Old syntax and new syntax should produce identical output
+    insta::assert_snapshot!("construct_transaction_new_syntax", normalize_output(&stdout));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_construct_transaction_state_init() -> Result<(), Box<dyn std::error::Error>> {
+    let (_sandbox, _temp_dir) = common::prepare_tests().await?;
+
+    // A valid base58-encoded CryptoHash (32 zero bytes in base58)
+    let hash = DUMMY_BLOCK_HASH;
+
+    let mut args = vec![
+        "transaction",
+        "construct-transaction",
+        "test.near",
+        "state-init",
+        "use-global-hash",
+        hash,
+        "data-from-json",
+        "{}",
+        "deposit",
+        "0 NEAR",
+        "skip",
+    ];
+    args.extend(sign_later_args());
+
+    let output = Command::new("target/debug/near").args(&args).output()?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        output.status.success(),
+        "Command failed. stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    insta::assert_snapshot!("construct_transaction_state_init", normalize_output(&stdout));
+
+    Ok(())
+}

--- a/tests/construct_transaction.rs
+++ b/tests/construct_transaction.rs
@@ -28,7 +28,7 @@ fn normalize_output(output: &str) -> String {
 
 #[tokio::test]
 async fn test_construct_transaction_old_syntax() -> Result<(), Box<dyn std::error::Error>> {
-    let (_sandbox, _temp_dir) = common::prepare_tests().await?;
+    let _ctx = common::prepare_tests().await?;
 
     let mut args = vec![
         "transaction",
@@ -61,7 +61,7 @@ async fn test_construct_transaction_old_syntax() -> Result<(), Box<dyn std::erro
 
 #[tokio::test]
 async fn test_construct_transaction_new_syntax() -> Result<(), Box<dyn std::error::Error>> {
-    let (_sandbox, _temp_dir) = common::prepare_tests().await?;
+    let _ctx = common::prepare_tests().await?;
 
     let mut args = vec![
         "transaction",
@@ -96,7 +96,7 @@ async fn test_construct_transaction_new_syntax() -> Result<(), Box<dyn std::erro
 
 #[tokio::test]
 async fn test_construct_transaction_state_init() -> Result<(), Box<dyn std::error::Error>> {
-    let (_sandbox, _temp_dir) = common::prepare_tests().await?;
+    let _ctx = common::prepare_tests().await?;
 
     // A valid base58-encoded CryptoHash (32 zero bytes in base58)
     let hash = DUMMY_BLOCK_HASH;

--- a/tests/find_network_where_account_exist.rs
+++ b/tests/find_network_where_account_exist.rs
@@ -320,7 +320,7 @@ fn test_for_mainnet_find_network_account_exists_with_default_context() {
 
     // Expected result: Account does not exist on the mainnet
     let non_existent_account_id: near_primitives::types::AccountId =
-        "nonexistent.near".parse().unwrap();
+        "nonexistent.dummy".parse().unwrap();
     let result = find_network_where_account_exist(&context, non_existent_account_id.clone());
     assert!(result.unwrap().is_none());
 }
@@ -349,7 +349,7 @@ fn test_for_mainnet_find_network_account_exists_with_context_with_failed_rpc_on_
 
     // Expected result: Error, because testnet RPC is failed, so it's impossible to be sure that account does not exist on the testnet
     let non_existent_account_id: near_primitives::types::AccountId =
-        "nonexistent.near".parse().unwrap();
+        "nonexistent.dummy".parse().unwrap();
     let result = find_network_where_account_exist(&context, non_existent_account_id.clone());
     assert!(result.is_err());
 }
@@ -398,7 +398,7 @@ fn test_for_mainnet_find_network_account_exists_with_context_with_failed_rpc_on_
 
     // Expected result: Error, because mainnet RPC is failed, so it's impossible to be sure that account does not exist on the mainnet
     let non_existent_account_id: near_primitives::types::AccountId =
-        "nonexistent.near".parse().unwrap();
+        "nonexistent.dummy".parse().unwrap();
     let result = find_network_where_account_exist(&context, non_existent_account_id.clone());
     assert!(result.is_err());
 }
@@ -468,7 +468,7 @@ fn test_for_mainnet_find_network_account_exists_with_context_with_failed_rpc() {
 
     // Expected result: Error, because RPC is failed on all networks
     let non_existent_account_id_mainnet: near_primitives::types::AccountId =
-        "nonexistent.near".parse().unwrap();
+        "nonexistent.dummy".parse().unwrap();
     let result =
         find_network_where_account_exist(&context, non_existent_account_id_mainnet.clone());
     assert!(result.is_err());

--- a/tests/snapshots/construct_transaction__construct_transaction_new_syntax.snap
+++ b/tests/snapshots/construct_transaction__construct_transaction_new_syntax.snap
@@ -1,0 +1,14 @@
+---
+source: tests/construct_transaction.rs
+assertion_line: 86
+expression: normalize_output(&stdout)
+---
+
+Transaction hash to sign:
+597bf3586ac2cb435509b08d4b7f5c9bb77365df62f86a29919feb3d9936a30a.
+
+Unsigned transaction (serialized as base64):
+CQAAAHRlc3QubmVhcgBNp+D0CWqvLOVeNxZXzTCJuh6fWfTW4nvQLkcqFqYdwQAAAAAAAAAACQAAAHRlc3QubmVhcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAMAAACh7czOG8LTAAAAAAAA
+
+This base64-encoded transaction can be signed and sent later. There is a helper command on near CLI that can do that:
+$ near transaction sign-transaction

--- a/tests/snapshots/construct_transaction__construct_transaction_old_syntax.snap
+++ b/tests/snapshots/construct_transaction__construct_transaction_old_syntax.snap
@@ -1,0 +1,14 @@
+---
+source: tests/construct_transaction.rs
+assertion_line: 54
+expression: normalize_output(&stdout)
+---
+
+Transaction hash to sign:
+597bf3586ac2cb435509b08d4b7f5c9bb77365df62f86a29919feb3d9936a30a.
+
+Unsigned transaction (serialized as base64):
+CQAAAHRlc3QubmVhcgBNp+D0CWqvLOVeNxZXzTCJuh6fWfTW4nvQLkcqFqYdwQAAAAAAAAAACQAAAHRlc3QubmVhcgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAMAAACh7czOG8LTAAAAAAAA
+
+This base64-encoded transaction can be signed and sent later. There is a helper command on near CLI that can do that:
+$ near transaction sign-transaction

--- a/tests/snapshots/construct_transaction__construct_transaction_state_init.snap
+++ b/tests/snapshots/construct_transaction__construct_transaction_state_init.snap
@@ -1,0 +1,14 @@
+---
+source: tests/construct_transaction.rs
+assertion_line: 122
+expression: normalize_output(&stdout)
+---
+
+Transaction hash to sign:
+b693c3a8d82e696c3751d07a4e5c164d078a3bb4d7d0e8a040c29faf1a118ccc.
+
+Unsigned transaction (serialized as base64):
+CQAAAHRlc3QubmVhcgBNp+D0CWqvLOVeNxZXzTCJuh6fWfTW4nvQLkcqFqYdwQAAAAAAAAAAKgAAADBzMmRhMWZmMmY2ZmQ2MTcwYWMzMDk0YmUwNDA1Y2RjYzU1NTJlMWE3OAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAAAAsAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+
+This base64-encoded transaction can be signed and sent later. There is a helper command on near CLI that can do that:
+$ near transaction sign-transaction

--- a/tests/state_init_inspect.rs
+++ b/tests/state_init_inspect.rs
@@ -102,6 +102,204 @@ fn test_inspect_state_init_borsh_roundtrip() {
     );
 }
 
+#[test]
+fn test_inspect_state_init_from_json_roundtrip() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let config_home = setup_config(temp_dir.path());
+
+    // Step 1: build and serialise to JSON
+    let output1 = near_cmd(&config_home)
+        .args([
+            "contract",
+            "state-init",
+            "use-global-hash",
+            ZERO_HASH,
+            "data-from-json",
+            r#"{"AAEC": "AwQF"}"#,
+            "inspect",
+            "state-init",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output1.status.success(),);
+    let json = String::from_utf8_lossy(&output1.stdout).trim().to_string();
+
+    // Step 2: re-parse from-json and serialise back to JSON
+    let output2 = near_cmd(&config_home)
+        .args([
+            "contract",
+            "state-init",
+            "from-json",
+            &json,
+            "inspect",
+            "state-init",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(output2.status.success(),);
+    let json_roundtrip = String::from_utf8_lossy(&output2.stdout).trim().to_string();
+
+    assert_eq!(
+        json, json_roundtrip,
+        "from-json round-trip produced different output"
+    );
+}
+
+#[test]
+fn test_inspect_state_init_from_json_file_roundtrip() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let config_home = setup_config(temp_dir.path());
+
+    let output1 = near_cmd(&config_home)
+        .args([
+            "contract",
+            "state-init",
+            "use-global-hash",
+            ZERO_HASH,
+            "data-from-json",
+            r#"{"AAEC": "AwQF"}"#,
+            "inspect",
+            "state-init",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output1.status.success(),
+        "step1 stderr: {}",
+        String::from_utf8_lossy(&output1.stderr)
+    );
+    let json = String::from_utf8_lossy(&output1.stdout).trim().to_string();
+
+    let json_file = temp_dir.path().join("state_init.json");
+    std::fs::write(&json_file, &json).unwrap();
+
+    let output2 = near_cmd(&config_home)
+        .args([
+            "contract",
+            "state-init",
+            "from-json-file",
+            json_file.to_str().unwrap(),
+            "inspect",
+            "state-init",
+            "json",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output2.status.success(),
+        "step3 stderr: {}",
+        String::from_utf8_lossy(&output2.stderr)
+    );
+    let json_roundtrip = String::from_utf8_lossy(&output2.stdout).trim().to_string();
+
+    assert_eq!(
+        json, json_roundtrip,
+        "from-json-file round-trip produced different output"
+    );
+}
+
+#[test]
+fn test_inspect_state_init_json_and_borsh_paths_consistent() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let config_home = setup_config(temp_dir.path());
+
+    // Path A: build directly → JSON
+    let output_a = near_cmd(&config_home)
+        .args([
+            "contract",
+            "state-init",
+            "use-global-hash",
+            ZERO_HASH,
+            "data-from-json",
+            r#"{"AAEC": "AwQF"}"#,
+            "inspect",
+            "state-init",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output_a.status.success(),
+        "path A stderr: {}",
+        String::from_utf8_lossy(&output_a.stderr)
+    );
+    let json_a = String::from_utf8_lossy(&output_a.stdout).trim().to_string();
+
+    // Path B: build → borsh → from-borsh-base64 → JSON
+    let borsh_output = near_cmd(&config_home)
+        .args([
+            "contract",
+            "state-init",
+            "use-global-hash",
+            ZERO_HASH,
+            "data-from-json",
+            r#"{"AAEC": "AwQF"}"#,
+            "inspect",
+            "state-init",
+            "borsh",
+        ])
+        .output()
+        .unwrap();
+    let borsh_b64 = String::from_utf8_lossy(&borsh_output.stdout)
+        .trim()
+        .to_string();
+
+    let output_b = near_cmd(&config_home)
+        .args([
+            "contract",
+            "state-init",
+            "from-borsh-base64",
+            &borsh_b64,
+            "inspect",
+            "state-init",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output_b.status.success(),
+        "path B stderr: {}",
+        String::from_utf8_lossy(&output_b.stderr)
+    );
+    let json_b = String::from_utf8_lossy(&output_b.stdout).trim().to_string();
+
+    // Path C: build → JSON → from-json → JSON
+    let output_c = near_cmd(&config_home)
+        .args([
+            "contract",
+            "state-init",
+            "from-json",
+            &json_a,
+            "inspect",
+            "state-init",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output_c.status.success(),
+        "path C stderr: {}",
+        String::from_utf8_lossy(&output_c.stderr)
+    );
+    let json_c = String::from_utf8_lossy(&output_c.stdout).trim().to_string();
+
+    assert_eq!(
+        json_a, json_b,
+        "JSON differs between direct and borsh paths"
+    );
+    assert_eq!(
+        json_a, json_c,
+        "JSON differs between direct and from-json paths"
+    );
+}
+
 /// Cross-format round-trip: two input paths for the same StateInit must
 /// produce identical JSON.
 #[test]

--- a/tests/state_init_inspect.rs
+++ b/tests/state_init_inspect.rs
@@ -1,0 +1,173 @@
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Creates a minimal config pointing to a fake network.
+/// Inspect commands never contact the network, so the URL doesn't matter.
+fn setup_config(temp_dir: &Path) -> PathBuf {
+    let config_home = temp_dir.to_path_buf();
+
+    let near_cli_config_dir = if cfg!(target_os = "macos") {
+        config_home.join("Library/Application Support/near-cli")
+    } else {
+        config_home.join("near-cli")
+    };
+    std::fs::create_dir_all(&near_cli_config_dir).unwrap();
+
+    let credentials_dir = temp_dir.join("credentials");
+    std::fs::create_dir_all(&credentials_dir).unwrap();
+    std::fs::write(credentials_dir.join("ft_contracts.json"), "[]").unwrap();
+
+    let config_content = format!(
+        r#"version = "4"
+credentials_home_dir = "{}"
+
+[network_connection.sandbox]
+network_name = "sandbox"
+rpc_url = "http://localhost:3030/"
+wallet_url = "http://localhost:3030/"
+explorer_transaction_url = "http://localhost:3030/transactions/"
+"#,
+        credentials_dir.to_string_lossy()
+    );
+    std::fs::write(near_cli_config_dir.join("config.toml"), config_content).unwrap();
+
+    config_home
+}
+
+fn near_cmd(config_home: &Path) -> Command {
+    let mut cmd = Command::new("target/debug/near");
+    cmd.env("XDG_CONFIG_HOME", config_home)
+        .env("HOME", config_home)
+        .env("APPDATA", config_home);
+    cmd
+}
+
+/// A known all-zero code hash (valid bs58 for 32 zero bytes).
+const ZERO_HASH: &str = "11111111111111111111111111111111";
+
+/// True round-trip: build → borsh-base64 → re-parse via from-borsh-base64 → borsh-base64.
+/// Both outputs must be identical.
+#[test]
+fn test_inspect_state_init_borsh_roundtrip() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let config_home = setup_config(temp_dir.path());
+
+    // Step 1: build and serialise to borsh-base64
+    let output1 = near_cmd(&config_home)
+        .args([
+            "contract",
+            "state-init",
+            "use-global-hash",
+            ZERO_HASH,
+            "data-from-json",
+            r#"{"AAEC": "AwQF"}"#,
+            "inspect",
+            "state-init",
+            "borsh",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output1.status.success(),
+        "step1 stderr: {}",
+        String::from_utf8_lossy(&output1.stderr)
+    );
+    let borsh_b64 = String::from_utf8_lossy(&output1.stdout).trim().to_string();
+
+    // Step 2: re-parse the borsh-base64 and serialise back to borsh-base64
+    let output2 = near_cmd(&config_home)
+        .args([
+            "contract",
+            "state-init",
+            "from-borsh-base64",
+            &borsh_b64,
+            "inspect",
+            "state-init",
+            "borsh",
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output2.status.success(),
+        "step2 stderr: {}",
+        String::from_utf8_lossy(&output2.stderr)
+    );
+    let borsh_b64_roundtrip = String::from_utf8_lossy(&output2.stdout).trim().to_string();
+
+    assert_eq!(
+        borsh_b64, borsh_b64_roundtrip,
+        "borsh round-trip produced different output"
+    );
+}
+
+/// Cross-format round-trip: two input paths for the same StateInit must
+/// produce identical JSON.
+#[test]
+fn test_inspect_state_init_json_consistent_across_input_paths() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let config_home = setup_config(temp_dir.path());
+
+    // Path A: build directly → JSON
+    let output_a = near_cmd(&config_home)
+        .args([
+            "contract",
+            "state-init",
+            "use-global-hash",
+            ZERO_HASH,
+            "data-from-json",
+            r#"{"AAEC": "AwQF"}"#,
+            "inspect",
+            "state-init",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output_a.status.success(),
+        "path A stderr: {}",
+        String::from_utf8_lossy(&output_a.stderr)
+    );
+    let json_a = String::from_utf8_lossy(&output_a.stdout).to_string();
+
+    // Path B: build → borsh → from-borsh-base64 → JSON
+    let borsh_output = near_cmd(&config_home)
+        .args([
+            "contract",
+            "state-init",
+            "use-global-hash",
+            ZERO_HASH,
+            "data-from-json",
+            r#"{"AAEC": "AwQF"}"#,
+            "inspect",
+            "state-init",
+            "borsh",
+        ])
+        .output()
+        .unwrap();
+    let borsh_b64 = String::from_utf8_lossy(&borsh_output.stdout)
+        .trim()
+        .to_string();
+
+    let output_b = near_cmd(&config_home)
+        .args([
+            "contract",
+            "state-init",
+            "from-borsh-base64",
+            &borsh_b64,
+            "inspect",
+            "state-init",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output_b.status.success(),
+        "path B stderr: {}",
+        String::from_utf8_lossy(&output_b.stderr)
+    );
+    let json_b = String::from_utf8_lossy(&output_b.stdout).to_string();
+
+    assert_eq!(json_a, json_b, "JSON output differs between input paths");
+}


### PR DESCRIPTION
  Add StateInit support for deterministic account creation (NEP-616)

  This PR adds support for creating deterministic accounts via DeterministicAccountStateInit as specified in https://github.com/near/NEPs/blob/master/neps/nep-0616.md.

  New command: contract state-init

  Creates a deterministic account by providing a state init. The state init can be specified in three ways:

  - use-global-hash <hash> — reference a globally deployed contract by its code hash
  - use-global-account-id <account_id> — reference a globally deployed contract by the account that deployed it
  - from-borsh-base64 <base64> — provide a pre-serialized DeterministicAccountStateInit directly

  For the first two modes, the initialization data (a key-value map with base64-encoded keys and values) is provided separately:

  - data-from-json '<json>' — inline JSON, e.g. data-from-json '{"AAEC": "AwQF"}'
  - data-from-file <path> — read the same JSON format from a file

  The receiver account ID is automatically derived from the state init contents (deterministic keccak256-based address with 0s prefix).

  Changes to transaction construct-transaction

  The receiver is now selected via a ReceiverMode enum:

  - account-id — specify the receiver account ID directly (existing behavior)
  - state-init — derive the receiver from a deterministic state init, using the same three input modes described above

  This was achieved by splitting the old ConstructTransactionContext into two stages: ConstructTransactionSenderContext (sender only) → ConstructTransactionContext (sender + receiver +
  actions). The receiver selection step sits between the two.

 Example usage

  Create a deterministic account and deploy via state-init:

```
  near transaction construct-transaction signer.near \
    state-init use-global-hash FaJXVgS82fXhrvvC8yXV4ibHujW63KvL7dVvJiZ9naga \
    data-from-json '{"":"EAAAAHBpdHlqbGxrLnRlc3RuZXQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAANiLmaE3mtdPRW1WVXs6pXbGdg5/4OmhjI6pswq6Nr/j"}' \
    deposit '0 NEAR' \
    add-action function-call gd_deploy \
      file-args /path/to/contract.wasm.borsh \
      prepaid-gas '300.0 Tgas' attached-deposit '14.5 NEAR' \
    skip network-config testnet sign-with-keychain send
```
  Call a function on a deterministic account (receiver specified directly):
```
  near transaction construct-transaction matdeployer.testnet \
    account-id 0s49b604786a4a44077ef5a450ddf59e90ae3d95d0 \
    add-action function-call gd_approve \
      json-args '{"old_hash":"d88b99a...","new_hash":"d88b99a..."}' \
      prepaid-gas '100.0 Tgas' attached-deposit '1 yoctoNEAR' \
    skip network-config testnet sign-with-keychain send
```
  The account-id keyword is optional — the old positional syntax still works:
```
  near transaction construct-transaction matdeployer.testnet \
    0s49b604786a4a44077ef5a450ddf59e90ae3d95d0 \
    add-action function-call gd_approve \
      json-args '{"old_hash":"d88b99a...","new_hash":"d88b99a..."}' \
      prepaid-gas '100.0 Tgas' attached-deposit '1 yoctoNEAR' \
    skip network-config testnet sign-with-keychain send
```
  Backward compatibility

  The old CLI syntax (construct-transaction <sender> <receiver> add-action ...) continues to work — it's treated as the
  account-id receiver variant. Snapshot tests verify that both old and new syntaxes produce identical transactions (same hash,
  same serialized bytes).


