### PR TITLE
chore: release v0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.24.0](https://github.com/near/near-cli-rs/compare/v0.23.7...v0.24.0) - 2026-02-27
+
+### Added
+
+- Add `construct-meta-transaction` command ([#562](https://github.com/near/near-cli-rs/pull/562))
+
 ## [0.23.7](https://github.com/near/near-cli-rs/compare/v0.23.6...v0.23.7) - 2026-02-09
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2365,7 +2365,7 @@ dependencies = [
 
 [[package]]
 name = "near-cli-rs"
-version = "0.23.7"
+version = "0.24.0"
 dependencies = [
  "bip39",
  "borsh",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-cli-rs"
-version = "0.23.7"
+version = "0.24.0"
 authors = ["FroVolod <frol_off@meta.ua>", "Near Inc <hello@nearprotocol.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2024"


### PR DESCRIPTION



## 🤖 New release

* `near-cli-rs`: 0.23.7 -> 0.24.0 (⚠ API breaking changes)

### ⚠ `near-cli-rs` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ActionContext.sign_as_delegate_action in /tmp/.tmpgn12xd/near-cli-rs/src/commands/mod.rs:113
  field AccessKeyPermissionContext.sign_as_delegate_action in /tmp/.tmpgn12xd/near-cli-rs/src/commands/transaction/construct_transaction/add_action_1/add_action/add_key/access_key_type/mod.rs:12
  field ConstructTransactionContext.sign_as_delegate_action in /tmp/.tmpgn12xd/near-cli-rs/src/commands/transaction/construct_transaction/mod.rs:27
  field TransactionContext.sign_as_delegate_action in /tmp/.tmpgn12xd/near-cli-rs/src/commands/mod.rs:127

--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant TransactionActionsDiscriminants::SignTransaction 3 -> 4 in /tmp/.tmpgn12xd/near-cli-rs/src/commands/transaction/mod.rs:48
  variant TransactionActionsDiscriminants::PrintTransaction 4 -> 5 in /tmp/.tmpgn12xd/near-cli-rs/src/commands/transaction/mod.rs:53
  variant TransactionActionsDiscriminants::SendSignedTransaction 5 -> 6 in /tmp/.tmpgn12xd/near-cli-rs/src/commands/transaction/mod.rs:56
  variant TransactionActionsDiscriminants::SendMetaTransaction 6 -> 7 in /tmp/.tmpgn12xd/near-cli-rs/src/commands/transaction/mod.rs:61
  variant TransactionActionsDiscriminants::SignTransaction 3 -> 4 in /tmp/.tmpgn12xd/near-cli-rs/src/commands/transaction/mod.rs:48
  variant TransactionActionsDiscriminants::PrintTransaction 4 -> 5 in /tmp/.tmpgn12xd/near-cli-rs/src/commands/transaction/mod.rs:53
  variant TransactionActionsDiscriminants::SendSignedTransaction 5 -> 6 in /tmp/.tmpgn12xd/near-cli-rs/src/commands/transaction/mod.rs:56
  variant TransactionActionsDiscriminants::SendMetaTransaction 6 -> 7 in /tmp/.tmpgn12xd/near-cli-rs/src/commands/transaction/mod.rs:61

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant TransactionActionsDiscriminants:ConstructMetaTransaction in /tmp/.tmpgn12xd/near-cli-rs/src/commands/transaction/mod.rs:43
  variant TransactionActionsDiscriminants:ConstructMetaTransaction in /tmp/.tmpgn12xd/near-cli-rs/src/commands/transaction/mod.rs:43
  variant CliTransactionActions:ConstructMetaTransaction in /tmp/.tmpgn12xd/near-cli-rs/src/commands/transaction/mod.rs:20
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.24.0](https://github.com/near/near-cli-rs/compare/v0.23.7...v0.24.0) - 2026-02-27

### Added

- Add `construct-meta-transaction` command ([#562](https://github.com/near/near-cli-rs/pull/562))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).