### PR TITLE
feat: allow custom input as method name

### DIFF
--- a/src/commands/contract/call_function/mod.rs
+++ b/src/commands/contract/call_function/mod.rs
@@ -1,4 +1,5 @@
 use inquire::Text;
+use near_abi::AbiFunctionKind;
 use strum::{EnumDiscriminants, EnumIter, EnumMessage};
 
 mod as_read_only;
@@ -77,7 +78,9 @@ fn input_function_name(
                 .body
                 .functions
                 .into_iter()
-                .filter(|function| function_kind == function.kind)
+                .filter(|function| {
+                    function_kind == AbiFunctionKind::View || function_kind == function.kind
+                })
                 .map(|function| function.name)
                 .collect();
         }


### PR DESCRIPTION
In current approach methods are filtered out based method kind (view/change) and we can't pass custom method name, so I've changed from Selection to Text + with_autocomplete approach 

<img width="1151" height="463" alt="image" src="https://github.com/user-attachments/assets/2bb4597b-b53f-4b1f-88ce-8f433936f049" />
<img width="1104" height="655" alt="image" src="https://github.com/user-attachments/assets/fce57bda-10cb-45d0-b1fb-eb68d5109b48" />

