### PR TITLE
chore: release v0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.25.0](https://github.com/near/near-cli-rs/compare/v0.24.0...v0.25.0) - 2026-04-08
+
+### Added
+
+- update function call limits to 1000 TGas ([#559](https://github.com/near/near-cli-rs/pull/559))
+- Improved interactive contract selection option for FT tokens ([#574](https://github.com/near/near-cli-rs/pull/574))
+- Added `send-tf-call` command (`ft_transfer_call` function call) to `tokens` subcommand ([#576](https://github.com/near/near-cli-rs/pull/576))
+- *(ledger)* BLE support ([#570](https://github.com/near/near-cli-rs/pull/570))
+- Allow custom input as method name ([#568](https://github.com/near/near-cli-rs/pull/568))
+
+### Fixed
+
+- wait for block finality before returning from send ([#564](https://github.com/near/near-cli-rs/pull/564))
+- number of shards calculation ([#579](https://github.com/near/near-cli-rs/pull/579))
+- resolve CI test failures from env var race and startup HTTP calls ([#578](https://github.com/near/near-cli-rs/pull/578))
+- Fixed exiting the interactive account verification survey ([#558](https://github.com/near/near-cli-rs/pull/558))
+- typo in `function.kind` check ([#572](https://github.com/near/near-cli-rs/pull/572))
+
+### Other
+
+- bump near crates to 0.35.0 ([#580](https://github.com/near/near-cli-rs/pull/580))
+- *(docs)* extension executable name ([#573](https://github.com/near/near-cli-rs/pull/573))
+
 ## [0.24.0](https://github.com/near/near-cli-rs/compare/v0.23.7...v0.24.0) - 2026-02-27
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2531,7 +2531,7 @@ dependencies = [
 
 [[package]]
 name = "near-cli-rs"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "bip39",
  "borsh",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-cli-rs"
-version = "0.24.0"
+version = "0.25.0"
 authors = ["FroVolod <frol_off@meta.ua>", "Near Inc <hello@nearprotocol.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2024"


### PR DESCRIPTION



## 🤖 New release

* `near-cli-rs`: 0.24.0 -> 0.25.0 (⚠ API breaking changes)

### ⚠ `near-cli-rs` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field CliSignLedger.connection in /tmp/.tmp0yzlyy/near-cli-rs/src/commands/message/sign_nep413/signature_options/sign_with_ledger.rs:5
  field CliSignLedger.connection in /tmp/.tmp0yzlyy/near-cli-rs/src/transaction_signature_options/sign_with_ledger/mod.rs:22
  field CliSend.wait_until in /tmp/.tmp0yzlyy/near-cli-rs/src/transaction_signature_options/send/mod.rs:6
  field InteractiveClapContextScopeForSend.wait_until in /tmp/.tmp0yzlyy/near-cli-rs/src/transaction_signature_options/send/mod.rs:6
  field NetworkConfig.tx_wait_until in /tmp/.tmp0yzlyy/near-cli-rs/src/config/mod.rs:250

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant AccountStateError:Skip in /tmp/.tmp0yzlyy/near-cli-rs/src/common.rs:171

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_parameter_count_changed.ron

Failed in:
  near_cli_rs::transaction_signature_options::send::sending_signed_transaction now takes 3 parameters instead of 2, in /tmp/.tmp0yzlyy/near-cli-rs/src/transaction_signature_options/send/mod.rs:119

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field submit of struct CliSignLedger, previously in file /tmp/.tmpdddLUK/near-cli-rs/src/transaction_signature_options/sign_with_ledger/mod.rs:18
  field signer_public_key of struct InteractiveClapContextScopeForSignLedger, previously in file /tmp/.tmpdddLUK/near-cli-rs/src/transaction_signature_options/sign_with_ledger/mod.rs:18

--- failure unit_struct_changed_kind: unit struct changed kind ---

Description:
A public unit struct has been changed to a normal (curly-braces) struct, which cannot be constructed using the same struct literal syntax.
        ref: https://github.com/rust-lang/cargo/pull/10871
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/unit_struct_changed_kind.ron

Failed in:
  struct SignLedgerContext in /tmp/.tmp0yzlyy/near-cli-rs/src/commands/message/sign_nep413/signature_options/sign_with_ledger.rs:17
  struct Send in /tmp/.tmp0yzlyy/near-cli-rs/src/transaction_signature_options/send/mod.rs:9
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.25.0](https://github.com/near/near-cli-rs/compare/v0.24.0...v0.25.0) - 2026-04-08

### Added

- update function call limits to 1000 TGas ([#559](https://github.com/near/near-cli-rs/pull/559))
- Improved interactive contract selection option for FT tokens ([#574](https://github.com/near/near-cli-rs/pull/574))
- Added `send-tf-call` command (`ft_transfer_call` function call) to `tokens` subcommand ([#576](https://github.com/near/near-cli-rs/pull/576))
- *(ledger)* BLE support ([#570](https://github.com/near/near-cli-rs/pull/570))
- Allow custom input as method name ([#568](https://github.com/near/near-cli-rs/pull/568))

### Fixed

- wait for block finality before returning from send ([#564](https://github.com/near/near-cli-rs/pull/564))
- number of shards calculation ([#579](https://github.com/near/near-cli-rs/pull/579))
- resolve CI test failures from env var race and startup HTTP calls ([#578](https://github.com/near/near-cli-rs/pull/578))
- Fixed exiting the interactive account verification survey ([#558](https://github.com/near/near-cli-rs/pull/558))
- typo in `function.kind` check ([#572](https://github.com/near/near-cli-rs/pull/572))

### Other

- bump near crates to 0.35.0 ([#580](https://github.com/near/near-cli-rs/pull/580))
- *(docs)* extension executable name ([#573](https://github.com/near/near-cli-rs/pull/573))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).