### PR TITLE
chore(docs): extension executable name 

### DIFF
--- a/extensions/README.md
+++ b/extensions/README.md
@@ -2,8 +2,8 @@
 `NEAR CLI` is built to scale. The number of possible features is endless. Instead of choosing only some of them, we are creating an `Extensions System` that will empower our users to choose, build and share `NEAR CLI` functionality.
 
 ## How it works
-Extensibility is achieved by translating a `NEAR CLI` invocation of the form `near (?<command>[^ ]+)` into an invocation of an external tool `near-cli-${command}` that then needs to be present in one of the user's `$PATH` directories.
-It means that you can write it in any language and with the use of any framework, it just needs to be called `near-cli-{extension-name}` and be installed on your system. This approach is inspired by [Cargo](https://github.com/rust-lang/cargo).
+Extensibility is achieved by translating a `NEAR CLI` invocation of the form `near (?<command>[^ ]+)` into an invocation of an external tool `near-${command}` that then needs to be present in one of the user's `$PATH` directories.
+It means that you can write it in any language and with the use of any framework, it just needs to be called `near-{extension-name}` and be installed on your system. This approach is inspired by [Cargo](https://github.com/rust-lang/cargo).
 
 ## How to build an extension
 As mentioned above, any binary can become an extension, but we are encouraging developers to use [Rust](https://www.rust-lang.org/), [Clap](https://docs.rs/clap/2.33.0/clap/), and a set of libraries developed by NEAR. Here is some of them:
@@ -14,7 +14,7 @@ As mentioned above, any binary can become an extension, but we are encouraging d
 ## Example
 Core `NEAR CLI` does not have validator specific functionality, but we can add it as a simple bash script:
 
-`near-cli-staking-pool-info`
+`near-staking-pool-info`
 ```bash
 #!/bin/sh
 POOL_ID=$1


### PR DESCRIPTION
This PR replaces `near-cli-` prefix with `near-` for extensions executables