### PR TITLE
feat: validate receiver account before sending tokens

### DIFF
--- a/src/commands/tokens/send_ft/amount_ft.rs
+++ b/src/commands/tokens/send_ft/amount_ft.rs
@@ -109,6 +109,17 @@ impl FtTransferParamsContext {
                 let deposit = scope.deposit.unwrap_or(crate::types::near_token::NearToken::from_yoctonear(1));
 
                 move |network_config| {
+                    if !crate::common::validate_receiver_account_id(
+                        network_config,
+                        &receiver_account_id,
+                    )? {
+                        return Ok(crate::commands::PrepopulatedTransaction {
+                            signer_id: signer_account_id.clone(),
+                            receiver_id: ft_contract_account_id.clone(),
+                            actions: vec![],
+                        });
+                    }
+
                     let amount_ft = if let crate::types::ft_properties::FungibleTokenTransferAmount::ExactAmount(ft) = &ft_transfer_amount {
                         ft
                     } else {

--- a/src/commands/tokens/send_ft/amount_ft.rs
+++ b/src/commands/tokens/send_ft/amount_ft.rs
@@ -114,6 +114,7 @@ impl FtTransferParamsContext {
                         network_config,
                         &receiver_account_id,
                         verbosity,
+                        previous_context.global_context.offline,
                     )? {
                         return Ok(crate::commands::PrepopulatedTransaction {
                             signer_id: signer_account_id.clone(),

--- a/src/commands/tokens/send_ft/amount_ft.rs
+++ b/src/commands/tokens/send_ft/amount_ft.rs
@@ -107,11 +107,13 @@ impl FtTransferParamsContext {
                 let memo = scope.memo.trim().to_string();
                 let gas = scope.gas.unwrap_or(near_gas::NearGas::from_tgas(100));
                 let deposit = scope.deposit.unwrap_or(crate::types::near_token::NearToken::from_yoctonear(1));
+                let verbosity = previous_context.global_context.verbosity;
 
                 move |network_config| {
                     if !crate::common::validate_receiver_account_id(
                         network_config,
                         &receiver_account_id,
+                        verbosity,
                     )? {
                         return Ok(crate::commands::PrepopulatedTransaction {
                             signer_id: signer_account_id.clone(),

--- a/src/commands/tokens/send_ft_call/amount_ft.rs
+++ b/src/commands/tokens/send_ft_call/amount_ft.rs
@@ -224,6 +224,7 @@ fn build_action_context(
                     network_config,
                     &receiver_account_id,
                     verbosity,
+                    previous_context.global_context.offline,
                 )? {
                     return Ok(crate::commands::PrepopulatedTransaction {
                         signer_id: signer_account_id.clone(),

--- a/src/commands/tokens/send_ft_call/amount_ft.rs
+++ b/src/commands/tokens/send_ft_call/amount_ft.rs
@@ -217,11 +217,13 @@ fn build_action_context(
             let msg = msg.clone();
             let gas = previous_context.gas;
             let deposit = previous_context.deposit;
+            let verbosity = previous_context.global_context.verbosity;
 
             move |network_config| {
                 if !crate::common::validate_receiver_account_id(
                     network_config,
                     &receiver_account_id,
+                    verbosity,
                 )? {
                     return Ok(crate::commands::PrepopulatedTransaction {
                         signer_id: signer_account_id.clone(),

--- a/src/commands/tokens/send_ft_call/amount_ft.rs
+++ b/src/commands/tokens/send_ft_call/amount_ft.rs
@@ -219,6 +219,17 @@ fn build_action_context(
             let deposit = previous_context.deposit;
 
             move |network_config| {
+                if !crate::common::validate_receiver_account_id(
+                    network_config,
+                    &receiver_account_id,
+                )? {
+                    return Ok(crate::commands::PrepopulatedTransaction {
+                        signer_id: signer_account_id.clone(),
+                        receiver_id: ft_contract_account_id.clone(),
+                        actions: vec![],
+                    });
+                }
+
                 let amount_ft = if let crate::types::ft_properties::FungibleTokenTransferAmount::ExactAmount(ft) = &ft_transfer_amount {
                     ft
                 } else {

--- a/src/commands/tokens/send_near/mod.rs
+++ b/src/commands/tokens/send_near/mod.rs
@@ -41,7 +41,17 @@ impl From<SendNearCommandContext> for crate::commands::ActionContext {
                 let signer_account_id = item.signer_account_id.clone();
                 let receiver_account_id = item.receiver_account_id.clone();
 
-                move |_network_config| {
+                move |network_config| {
+                    if !crate::common::validate_receiver_account_id(
+                        network_config,
+                        &receiver_account_id,
+                    )? {
+                        return Ok(crate::commands::PrepopulatedTransaction {
+                            signer_id: signer_account_id.clone(),
+                            receiver_id: receiver_account_id.clone(),
+                            actions: vec![],
+                        });
+                    }
                     Ok(crate::commands::PrepopulatedTransaction {
                         signer_id: signer_account_id.clone(),
                         receiver_id: receiver_account_id.clone(),

--- a/src/commands/tokens/send_near/mod.rs
+++ b/src/commands/tokens/send_near/mod.rs
@@ -47,6 +47,7 @@ impl From<SendNearCommandContext> for crate::commands::ActionContext {
                         network_config,
                         &receiver_account_id,
                         verbosity,
+                        item.global_context.offline,
                     )? {
                         return Ok(crate::commands::PrepopulatedTransaction {
                             signer_id: signer_account_id.clone(),

--- a/src/commands/tokens/send_near/mod.rs
+++ b/src/commands/tokens/send_near/mod.rs
@@ -40,11 +40,13 @@ impl From<SendNearCommandContext> for crate::commands::ActionContext {
             std::sync::Arc::new({
                 let signer_account_id = item.signer_account_id.clone();
                 let receiver_account_id = item.receiver_account_id.clone();
+                let verbosity = item.global_context.verbosity;
 
                 move |network_config| {
                     if !crate::common::validate_receiver_account_id(
                         network_config,
                         &receiver_account_id,
+                        verbosity,
                     )? {
                         return Ok(crate::commands::PrepopulatedTransaction {
                             signer_id: signer_account_id.clone(),

--- a/src/commands/tokens/send_nft/mod.rs
+++ b/src/commands/tokens/send_nft/mod.rs
@@ -61,11 +61,13 @@ impl From<SendNftCommandContext> for crate::commands::ActionContext {
                 let nft_contract_account_id = item.nft_contract_account_id.clone();
                 let receiver_account_id = item.receiver_account_id.clone();
                 let token_id = item.token_id.clone();
+                let verbosity = item.global_context.verbosity;
 
                 move |network_config| {
                     if !crate::common::validate_receiver_account_id(
                         network_config,
                         &receiver_account_id,
+                        verbosity,
                     )? {
                         return Ok(crate::commands::PrepopulatedTransaction {
                             signer_id: signer_account_id.clone(),

--- a/src/commands/tokens/send_nft/mod.rs
+++ b/src/commands/tokens/send_nft/mod.rs
@@ -62,7 +62,17 @@ impl From<SendNftCommandContext> for crate::commands::ActionContext {
                 let receiver_account_id = item.receiver_account_id.clone();
                 let token_id = item.token_id.clone();
 
-                move |_network_config| {
+                move |network_config| {
+                    if !crate::common::validate_receiver_account_id(
+                        network_config,
+                        &receiver_account_id,
+                    )? {
+                        return Ok(crate::commands::PrepopulatedTransaction {
+                            signer_id: signer_account_id.clone(),
+                            receiver_id: nft_contract_account_id.clone(),
+                            actions: vec![],
+                        });
+                    }
                     Ok(crate::commands::PrepopulatedTransaction {
                         signer_id: signer_account_id.clone(),
                         receiver_id: nft_contract_account_id.clone(),

--- a/src/commands/tokens/send_nft/mod.rs
+++ b/src/commands/tokens/send_nft/mod.rs
@@ -68,6 +68,7 @@ impl From<SendNftCommandContext> for crate::commands::ActionContext {
                         network_config,
                         &receiver_account_id,
                         verbosity,
+                        item.global_context.offline,
                     )? {
                         return Ok(crate::commands::PrepopulatedTransaction {
                             signer_id: signer_account_id.clone(),

--- a/src/common.rs
+++ b/src/common.rs
@@ -462,7 +462,11 @@ pub fn is_receiver_on_wrong_network(
 pub fn validate_receiver_account_id(
     network_config: &crate::config::NetworkConfig,
     receiver_account_id: &near_primitives::types::AccountId,
+    verbosity: crate::Verbosity,
 ) -> color_eyre::eyre::Result<bool> {
+    if let crate::Verbosity::Quiet = verbosity {
+        return Ok(true);
+    }
     if is_receiver_on_wrong_network(
         network_config.linkdrop_account_id.as_ref(),
         receiver_account_id,

--- a/src/common.rs
+++ b/src/common.rs
@@ -447,13 +447,19 @@ pub fn is_receiver_on_wrong_network(
     linkdrop_account_id: Option<&near_primitives::types::AccountId>,
     receiver_account_id: &near_primitives::types::AccountId,
 ) -> bool {
+    // Don't check for implicit accounts on the network,
+    // as they can be created on any network and we cannot be sure about the network based on the account ID.
+    if receiver_account_id.get_account_type().is_implicit() {
+        return false;
+    }
+
     let Some(linkdrop) = linkdrop_account_id else {
         return false;
     };
     let receiver_str = receiver_account_id.as_str();
     match linkdrop.as_str() {
         "near" => receiver_str.ends_with(".testnet"),
-        "testnet" => receiver_str.ends_with(".near") && !receiver_str.ends_with(".testnet"),
+        "testnet" => !receiver_str.ends_with(".testnet"),
         _ => false,
     }
 }
@@ -464,62 +470,58 @@ pub fn validate_receiver_account_id(
     network_config: &crate::config::NetworkConfig,
     receiver_account_id: &near_primitives::types::AccountId,
     verbosity: crate::Verbosity,
+    offline_mode: bool,
 ) -> color_eyre::eyre::Result<bool> {
     tracing::Span::current().pb_set_message(&format!(
         "<{receiver_account_id}> on network <{}> ...",
         network_config.network_name
     ));
     tracing::info!(target: "near_teach_me", "Validating the recipient account <{receiver_account_id}> on network <{}> ...", network_config.network_name);
+
     if let crate::Verbosity::Quiet = verbosity {
         return Ok(true);
     }
+
     if is_receiver_on_wrong_network(
         network_config.linkdrop_account_id.as_ref(),
         receiver_account_id,
     ) {
-        tracing::warn!(
-            "{}",
-            format!(
-                "<{}> looks like it belongs to a different network than <{}>.",
-                receiver_account_id, network_config.network_name
-            )
-            .red()
-        );
-        return suspend_tracing_indicatif::<_, color_eyre::eyre::Result<bool>>(|| {
-            ask_if_should_proceed()
-        });
+        return handle_validation_warning(format!(
+            "<{}> looks like it belongs to a different network than <{}>.",
+            receiver_account_id, network_config.network_name
+        ));
     }
 
-    let result = tokio::runtime::Runtime::new()
+    if offline_mode {
+        return handle_validation_warning(format!(
+            "Skipping account validation for <{}> on <{}> in offline mode.",
+            receiver_account_id, network_config.network_name
+        ));
+    }
+
+    match tokio::runtime::Runtime::new()
         .unwrap()
         .block_on(get_account_state(
             network_config,
             receiver_account_id,
             near_primitives::types::BlockReference::latest(),
-        ));
-
-    match result {
+        )) {
         Ok(_) => Ok(true),
         Err(near_jsonrpc_client::errors::JsonRpcError::ServerError(
             near_jsonrpc_client::errors::JsonRpcServerError::HandlerError(
                 near_jsonrpc_primitives::types::query::RpcQueryError::UnknownAccount { .. },
             ),
-        )) => {
-            tracing::warn!(
-                "{}",
-                format!(
-                    "<{}> does not exist on <{}>.",
-                    receiver_account_id, network_config.network_name
-                )
-                .red()
-            );
-            suspend_tracing_indicatif::<_, color_eyre::eyre::Result<bool>>(|| {
-                ask_if_should_proceed()
-            })
-        }
-        // Dont block the transaction if we can't reach the RPC
-        Err(_) => Ok(true),
+        )) => handle_validation_warning(format!(
+            "<{}> does not exist on <{}>.",
+            receiver_account_id, network_config.network_name
+        )),
+        Err(err) => Err(err.into()),
     }
+}
+
+fn handle_validation_warning(message: String) -> color_eyre::eyre::Result<bool> {
+    tracing::warn!("{}", message.red());
+    suspend_tracing_indicatif::<_, color_eyre::eyre::Result<bool>>(ask_if_should_proceed)
 }
 
 fn ask_if_should_proceed() -> color_eyre::eyre::Result<bool> {

--- a/src/common.rs
+++ b/src/common.rs
@@ -471,9 +471,13 @@ pub fn validate_receiver_account_id(
         network_config.linkdrop_account_id.as_ref(),
         receiver_account_id,
     ) {
-        eprintln!(
-            "\nWarning: <{}> looks like it belongs to a different network than <{}>.",
-            receiver_account_id, network_config.network_name
+        tracing::warn!(
+            "{}",
+            format!(
+                "<{}> looks like it belongs to a different network than <{}>.",
+                receiver_account_id, network_config.network_name
+            )
+            .red()
         );
         return ask_if_should_proceed();
     }
@@ -493,9 +497,13 @@ pub fn validate_receiver_account_id(
                 near_jsonrpc_primitives::types::query::RpcQueryError::UnknownAccount { .. },
             ),
         )) => {
-            eprintln!(
-                "\nWarning: <{}> does not exist on <{}>.",
-                receiver_account_id, network_config.network_name
+            tracing::warn!(
+                "{}",
+                format!(
+                    "<{}> does not exist on <{}>.",
+                    receiver_account_id, network_config.network_name
+                )
+                .red()
             );
             ask_if_should_proceed()
         }

--- a/src/common.rs
+++ b/src/common.rs
@@ -485,7 +485,9 @@ pub fn validate_receiver_account_id(
             )
             .red()
         );
-        return ask_if_should_proceed();
+        return suspend_tracing_indicatif::<_, color_eyre::eyre::Result<bool>>(|| {
+            ask_if_should_proceed()
+        });
     }
 
     let result = tokio::runtime::Runtime::new()

--- a/src/common.rs
+++ b/src/common.rs
@@ -443,6 +443,86 @@ pub fn find_network_where_account_exist(
     }
 }
 
+pub fn is_receiver_on_wrong_network(
+    linkdrop_account_id: Option<&near_primitives::types::AccountId>,
+    receiver_account_id: &near_primitives::types::AccountId,
+) -> bool {
+    let Some(linkdrop) = linkdrop_account_id else {
+        return false;
+    };
+    let receiver_str = receiver_account_id.as_str();
+    match linkdrop.as_str() {
+        "near" => receiver_str.ends_with(".testnet"),
+        "testnet" => receiver_str.ends_with(".near") && !receiver_str.ends_with(".testnet"),
+        _ => false,
+    }
+}
+
+/// Returns `Ok(true)` if the transaction should proceed, `Ok(false)` if the user cancelled.
+pub fn validate_receiver_account_id(
+    network_config: &crate::config::NetworkConfig,
+    receiver_account_id: &near_primitives::types::AccountId,
+) -> color_eyre::eyre::Result<bool> {
+    if is_receiver_on_wrong_network(
+        network_config.linkdrop_account_id.as_ref(),
+        receiver_account_id,
+    ) {
+        eprintln!(
+            "\nWarning: <{}> looks like it belongs to a different network than <{}>.",
+            receiver_account_id, network_config.network_name
+        );
+        return ask_if_should_proceed();
+    }
+
+    let result = tokio::runtime::Runtime::new()
+        .unwrap()
+        .block_on(get_account_state(
+            network_config,
+            receiver_account_id,
+            near_primitives::types::BlockReference::latest(),
+        ));
+
+    match result {
+        Ok(_) => Ok(true),
+        Err(near_jsonrpc_client::errors::JsonRpcError::ServerError(
+            near_jsonrpc_client::errors::JsonRpcServerError::HandlerError(
+                near_jsonrpc_primitives::types::query::RpcQueryError::UnknownAccount { .. },
+            ),
+        )) => {
+            eprintln!(
+                "\nWarning: <{}> does not exist on <{}>.",
+                receiver_account_id, network_config.network_name
+            );
+            ask_if_should_proceed()
+        }
+        // Dont block the transaction if we can't reach the RPC
+        Err(_) => Ok(true),
+    }
+}
+
+fn ask_if_should_proceed() -> color_eyre::eyre::Result<bool> {
+    #[derive(strum_macros::Display, PartialEq)]
+    enum ConfirmOptions {
+        #[strum(to_string = "Yes, I want to proceed with this receiver account ID.")]
+        Yes,
+        #[strum(to_string = "No, I want to cancel the transaction.")]
+        No,
+    }
+    match Select::new(
+        "Do you want to proceed?",
+        vec![ConfirmOptions::Yes, ConfirmOptions::No],
+    )
+    .prompt()
+    {
+        Ok(value) => Ok(value == ConfirmOptions::Yes),
+        Err(
+            inquire::error::InquireError::OperationCanceled
+            | inquire::error::InquireError::OperationInterrupted,
+        ) => Ok(false),
+        Err(err) => Err(err.into()),
+    }
+}
+
 pub fn ask_if_different_account_id_wanted() -> color_eyre::eyre::Result<bool> {
     #[derive(strum_macros::Display, PartialEq)]
     enum ConfirmOptions {

--- a/src/common.rs
+++ b/src/common.rs
@@ -459,11 +459,17 @@ pub fn is_receiver_on_wrong_network(
 }
 
 /// Returns `Ok(true)` if the transaction should proceed, `Ok(false)` if the user cancelled.
+#[tracing::instrument(name = "Validating the recipient account", skip_all)]
 pub fn validate_receiver_account_id(
     network_config: &crate::config::NetworkConfig,
     receiver_account_id: &near_primitives::types::AccountId,
     verbosity: crate::Verbosity,
 ) -> color_eyre::eyre::Result<bool> {
+    tracing::Span::current().pb_set_message(&format!(
+        "<{receiver_account_id}> on network <{}> ...",
+        network_config.network_name
+    ));
+    tracing::info!(target: "near_teach_me", "Validating the recipient account <{receiver_account_id}> on network <{}> ...", network_config.network_name);
     if let crate::Verbosity::Quiet = verbosity {
         return Ok(true);
     }
@@ -505,7 +511,9 @@ pub fn validate_receiver_account_id(
                 )
                 .red()
             );
-            ask_if_should_proceed()
+            suspend_tracing_indicatif::<_, color_eyre::eyre::Result<bool>>(|| {
+                ask_if_should_proceed()
+            })
         }
         // Dont block the transaction if we can't reach the RPC
         Err(_) => Ok(true),


### PR DESCRIPTION
Adds recipient validation to the tokens subcommand (send-near, send-ft,send-ft-call, send-nft), after network selection, two checks run: a network mismatch check that warns if the receiver looks like it belongs to a different network  and an rpc existence check that warns if the receiver account doesn't exist on the selected network. Both checks prompt the user for confirmation and never block, the user can always choose to proceed. If the rpc is unreachable,the existence check is skipped silently.

<img width="1379" height="510" alt="image" src="https://github.com/user-attachments/assets/0ce70bff-eab6-487f-bb72-3edce24b5acd" />

Fixes #581 
