### PR TITLE
refactor: Allow custom on_sending_delegate_action_callback handler for transactions and on_after_signing_callback for sign-message

### DIFF
--- a/src/commands/account/add_key/autogenerate_new_keypair/print_keypair_to_terminal/mod.rs
+++ b/src/commands/account/add_key/autogenerate_new_keypair/print_keypair_to_terminal/mod.rs
@@ -79,6 +79,7 @@ impl From<PrintKeypairToTerminalContext> for crate::commands::ActionContext {
                 move |_outcome_view, _network_config| Ok(()),
             ),
             sign_as_delegate_action: false,
+            on_sending_delegate_action_callback: None,
         }
     }
 }

--- a/src/commands/account/add_key/autogenerate_new_keypair/save_keypair_to_keychain/mod.rs
+++ b/src/commands/account/add_key/autogenerate_new_keypair/save_keypair_to_keychain/mod.rs
@@ -76,6 +76,7 @@ impl From<SaveKeypairToKeychainContext> for crate::commands::ActionContext {
                 |_outcome_view, _network_config| Ok(()),
             ),
             sign_as_delegate_action: false,
+            on_sending_delegate_action_callback: None,
         }
     }
 }

--- a/src/commands/account/add_key/autogenerate_new_keypair/save_keypair_to_legacy_keychain/mod.rs
+++ b/src/commands/account/add_key/autogenerate_new_keypair/save_keypair_to_legacy_keychain/mod.rs
@@ -98,6 +98,7 @@ impl From<SaveKeypairToLegacyKeychainContext> for crate::commands::ActionContext
                 |_outcome_view, _network_config| Ok(()),
             ),
             sign_as_delegate_action: false,
+            on_sending_delegate_action_callback: None,
         }
     }
 }

--- a/src/commands/account/add_key/use_ledger/mod.rs
+++ b/src/commands/account/add_key/use_ledger/mod.rs
@@ -137,6 +137,7 @@ impl From<UsbAddLedgerKeyContext> for crate::commands::ActionContext {
                 |_outcome_view, _network_config| Ok(()),
             ),
             sign_as_delegate_action: false,
+            on_sending_delegate_action_callback: None,
         }
     }
 }
@@ -220,6 +221,7 @@ impl From<BleAddLedgerKeyContext> for crate::commands::ActionContext {
                 |_outcome_view, _network_config| Ok(()),
             ),
             sign_as_delegate_action: false,
+            on_sending_delegate_action_callback: None,
         }
     }
 }

--- a/src/commands/account/add_key/use_manually_provided_seed_phrase/mod.rs
+++ b/src/commands/account/add_key/use_manually_provided_seed_phrase/mod.rs
@@ -75,6 +75,7 @@ impl From<AddAccessWithSeedPhraseActionContext> for crate::commands::ActionConte
                 |_outcome_view, _network_config| Ok(()),
             ),
             sign_as_delegate_action: false,
+            on_sending_delegate_action_callback: None,
         }
     }
 }

--- a/src/commands/account/add_key/use_mpc/mod.rs
+++ b/src/commands/account/add_key/use_mpc/mod.rs
@@ -240,6 +240,7 @@ impl From<MpcDeriveKeyToAddContext> for crate::commands::ActionContext {
                 |_outcome_view, _network_config| Ok(()),
             ),
             sign_as_delegate_action: false,
+            on_sending_delegate_action_callback: None,
         }
     }
 }

--- a/src/commands/account/add_key/use_public_key/mod.rs
+++ b/src/commands/account/add_key/use_public_key/mod.rs
@@ -68,6 +68,7 @@ impl From<AddAccessKeyActionContext> for crate::commands::ActionContext {
                 |_outcome_view, _network_config| Ok(()),
             ),
             sign_as_delegate_action: false,
+            on_sending_delegate_action_callback: None,
         }
     }
 }

--- a/src/commands/account/create_account/fund_myself_create_account/sign_as/mod.rs
+++ b/src/commands/account/create_account/fund_myself_create_account/sign_as/mod.rs
@@ -156,6 +156,7 @@ impl From<SignerAccountIdContext> for crate::commands::ActionContext {
             on_before_sending_transaction_callback: item.on_before_sending_transaction_callback,
             on_after_sending_transaction_callback,
             sign_as_delegate_action: false,
+            on_sending_delegate_action_callback: None,
         }
     }
 }

--- a/src/commands/account/delete_account/mod.rs
+++ b/src/commands/account/delete_account/mod.rs
@@ -107,6 +107,7 @@ impl From<BeneficiaryAccountContext> for crate::commands::ActionContext {
                 |_outcome_view, _network_config| Ok(()),
             ),
             sign_as_delegate_action: false,
+            on_sending_delegate_action_callback: None,
         }
     }
 }

--- a/src/commands/account/delete_key/public_keys_to_delete.rs
+++ b/src/commands/account/delete_key/public_keys_to_delete.rs
@@ -75,6 +75,7 @@ impl From<PublicKeyListContext> for crate::commands::ActionContext {
                 |_outcome_view, _network_config| Ok(()),
             ),
             sign_as_delegate_action: false,
+            on_sending_delegate_action_callback: None,
         }
     }
 }

--- a/src/commands/account/storage_management/storage_deposit.rs
+++ b/src/commands/account/storage_management/storage_deposit.rs
@@ -172,6 +172,7 @@ impl SignerAccountIdContext {
             ),
             on_after_sending_transaction_callback,
             sign_as_delegate_action: false,
+            on_sending_delegate_action_callback: None,
         }))
     }
 }

--- a/src/commands/account/storage_management/storage_withdraw.rs
+++ b/src/commands/account/storage_management/storage_withdraw.rs
@@ -105,6 +105,7 @@ impl SignerAccountIdContext {
             ),
             on_after_sending_transaction_callback,
             sign_as_delegate_action: false,
+            on_sending_delegate_action_callback: None,
         }))
     }
 }

--- a/src/commands/account/update_social_profile/sign_as.rs
+++ b/src/commands/account/update_social_profile/sign_as.rs
@@ -106,6 +106,7 @@ impl From<SignerContext> for crate::commands::ActionContext {
             ),
             on_after_sending_transaction_callback,
             sign_as_delegate_action: false,
+            on_sending_delegate_action_callback: None,
         }
     }
 }

--- a/src/commands/contract/call_function/as_transaction/mod.rs
+++ b/src/commands/contract/call_function/as_transaction/mod.rs
@@ -286,6 +286,7 @@ impl From<SignerAccountIdContext> for crate::commands::ActionContext {
                 |_outcome_view, _network_config| Ok(()),
             ),
             sign_as_delegate_action: false,
+            on_sending_delegate_action_callback: None,
         }
     }
 }

--- a/src/commands/contract/deploy/initialize_mode/call_function_type/mod.rs
+++ b/src/commands/contract/deploy/initialize_mode/call_function_type/mod.rs
@@ -186,6 +186,7 @@ impl DepositContext {
                 |_outcome_view, _network_config| Ok(()),
             ),
             sign_as_delegate_action: false,
+            on_sending_delegate_action_callback: None,
         }))
     }
 }

--- a/src/commands/contract/deploy/initialize_mode/mod.rs
+++ b/src/commands/contract/deploy/initialize_mode/mod.rs
@@ -74,6 +74,7 @@ impl From<NoInitializeContext> for crate::commands::ActionContext {
                 |_outcome_view, _network_config| Ok(()),
             ),
             sign_as_delegate_action: false,
+            on_sending_delegate_action_callback: None,
         }
     }
 }

--- a/src/commands/contract/deploy_global/mod.rs
+++ b/src/commands/contract/deploy_global/mod.rs
@@ -172,6 +172,7 @@ impl From<DeployGlobalResultContext> for crate::commands::ActionContext {
                 |_outcome_view, _network_config| Ok(()),
             ),
             sign_as_delegate_action: false,
+            on_sending_delegate_action_callback: None,
         }
     }
 }

--- a/src/commands/contract/state_init/mod.rs
+++ b/src/commands/contract/state_init/mod.rs
@@ -698,6 +698,7 @@ impl From<SignerAccountIdContext> for crate::commands::ActionContext {
             on_after_sending_transaction_callback: std::sync::Arc::new(
                 |_outcome_view, _network_config| Ok(()),
             ),
+            on_sending_delegate_action_callback: None,
             sign_as_delegate_action: false,
         }
     }

--- a/src/commands/message/sign_nep413/mod.rs
+++ b/src/commands/message/sign_nep413/mod.rs
@@ -74,9 +74,28 @@ impl SignNep413Context {
     }
 }
 
-#[derive(Debug, Clone)]
+pub type OnAfterSigningNep413Callback =
+    std::sync::Arc<dyn Fn(SignedMessage) -> color_eyre::eyre::Result<()>>;
+
+fn default_on_after_signing_nep413_callback() -> OnAfterSigningNep413Callback {
+    std::sync::Arc::new(|signed_message| {
+        println!("{}", serde_json::to_string_pretty(&signed_message)?);
+        Ok(())
+    })
+}
+
+#[derive(Clone)]
 pub struct FinalSignNep413Context {
     pub global_context: crate::GlobalContext,
     pub payload: NEP413Payload,
     pub signer_id: near_primitives::types::AccountId,
+    pub on_after_signing_callback: OnAfterSigningNep413Callback,
+}
+
+impl std::fmt::Debug for FinalSignNep413Context {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("FinalSignNep413Context")
+            .field("signer_id", &self.signer_id)
+            .finish()
+    }
 }

--- a/src/commands/message/sign_nep413/signature_options/sign_with_access_key_file.rs
+++ b/src/commands/message/sign_nep413/signature_options/sign_with_access_key_file.rs
@@ -33,7 +33,7 @@ impl SignAccessKeyFileContext {
             public_key: account_json.public_key.to_string(),
             signature: signature.to_string(),
         };
-        println!("{}", serde_json::to_string_pretty(&signed_message)?);
+        (previous_context.on_after_signing_callback)(signed_message)?;
         Ok(Self)
     }
 }

--- a/src/commands/message/sign_nep413/signature_options/sign_with_keychain.rs
+++ b/src/commands/message/sign_nep413/signature_options/sign_with_keychain.rs
@@ -18,6 +18,7 @@ impl SignKeychainContext {
             std::sync::Arc::new({
                 let signer_id = previous_context.signer_id.clone();
                 let payload = previous_context.payload.clone();
+                let on_after_signing = previous_context.on_after_signing_callback.clone();
                 move |network_config| {
                     let key_pair = crate::commands::account::export_account::get_account_key_pair_from_keychain(network_config, &signer_id)?;
                     let signature =
@@ -28,7 +29,7 @@ impl SignKeychainContext {
                         public_key: key_pair.public_key.to_string(),
                         signature: signature.to_string(),
                     };
-                    println!("{}", serde_json::to_string_pretty(&signed_message)?);
+                    on_after_signing(signed_message)?;
                     Ok(())
                 }
             });

--- a/src/commands/message/sign_nep413/signature_options/sign_with_ledger.rs
+++ b/src/commands/message/sign_nep413/signature_options/sign_with_ledger.rs
@@ -93,7 +93,7 @@ impl UsbSignNep413Context {
             public_key: public_key.to_string(),
             signature: signature.to_string(),
         };
-        println!("{}", serde_json::to_string_pretty(&signed_message)?);
+        (previous_context.final_context.on_after_signing_callback)(signed_message)?;
 
         Ok(Self)
     }
@@ -135,7 +135,7 @@ impl BleSignNep413Context {
             public_key: public_key.to_string(),
             signature: signature.to_string(),
         };
-        println!("{}", serde_json::to_string_pretty(&signed_message)?);
+        (previous_context.final_context.on_after_signing_callback)(signed_message)?;
 
         Ok(Self)
     }

--- a/src/commands/message/sign_nep413/signature_options/sign_with_legacy_keychain.rs
+++ b/src/commands/message/sign_nep413/signature_options/sign_with_legacy_keychain.rs
@@ -23,6 +23,7 @@ impl SignLegacyKeychainContext {
                     .config
                     .credentials_home_dir
                     .clone();
+                let on_after_signing = previous_context.on_after_signing_callback.clone();
                 move |network_config| {
                     let key_pair = crate::commands::account::export_account::get_account_key_pair_from_legacy_keychain(
                         network_config,
@@ -37,7 +38,7 @@ impl SignLegacyKeychainContext {
                         public_key: key_pair.public_key.to_string(),
                         signature: signature.to_string(),
                     };
-                    println!("{}", serde_json::to_string_pretty(&signed_message)?);
+                    on_after_signing(signed_message)?;
                     Ok(())
                 }
             });

--- a/src/commands/message/sign_nep413/signature_options/sign_with_private_key.rs
+++ b/src/commands/message/sign_nep413/signature_options/sign_with_private_key.rs
@@ -23,7 +23,7 @@ impl SignPrivateKeyContext {
             public_key: public_key.to_string(),
             signature: signature.to_string(),
         };
-        println!("{}", serde_json::to_string_pretty(&signed_message)?);
+        (previous_context.on_after_signing_callback)(signed_message)?;
         Ok(Self)
     }
 }

--- a/src/commands/message/sign_nep413/signature_options/sign_with_seed_phrase.rs
+++ b/src/commands/message/sign_nep413/signature_options/sign_with_seed_phrase.rs
@@ -31,7 +31,7 @@ impl SignSeedPhraseContext {
             public_key: key_pair_properties.public_key_str,
             signature: signature.to_string(),
         };
-        println!("{}", serde_json::to_string_pretty(&signed_message)?);
+        (previous_context.on_after_signing_callback)(signed_message)?;
         Ok(Self)
     }
 }

--- a/src/commands/message/sign_nep413/signer/mod.rs
+++ b/src/commands/message/sign_nep413/signer/mod.rs
@@ -35,6 +35,7 @@ impl SignAsWrapperContext {
             global_context: previous_context.global_context,
             payload,
             signer_id: scope.signer_account_id.clone().into(),
+            on_after_signing_callback: super::default_on_after_signing_nep413_callback(),
         }))
     }
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -110,6 +110,8 @@ pub struct ActionContext {
         crate::transaction_signature_options::OnBeforeSendingTransactionCallback,
     pub on_after_sending_transaction_callback:
         crate::transaction_signature_options::OnAfterSendingTransactionCallback,
+    pub on_sending_delegate_action_callback:
+        Option<crate::transaction_signature_options::OnSendingDelegateActionCallback>,
     pub sign_as_delegate_action: bool,
 }
 
@@ -124,5 +126,7 @@ pub struct TransactionContext {
         crate::transaction_signature_options::OnBeforeSendingTransactionCallback,
     pub on_after_sending_transaction_callback:
         crate::transaction_signature_options::OnAfterSendingTransactionCallback,
+    pub on_sending_delegate_action_callback:
+        Option<crate::transaction_signature_options::OnSendingDelegateActionCallback>,
     pub sign_as_delegate_action: bool,
 }

--- a/src/commands/staking/delegate/deposit_and_stake.rs
+++ b/src/commands/staking/delegate/deposit_and_stake.rs
@@ -75,6 +75,7 @@ impl DepositAndStakeContext {
             ),
             on_after_sending_transaction_callback,
             sign_as_delegate_action: false,
+            on_sending_delegate_action_callback: None,
         }))
     }
 }

--- a/src/commands/staking/delegate/stake.rs
+++ b/src/commands/staking/delegate/stake.rs
@@ -77,6 +77,7 @@ impl StakeContext {
             ),
             on_after_sending_transaction_callback,
             sign_as_delegate_action: false,
+            on_sending_delegate_action_callback: None,
         }))
     }
 }

--- a/src/commands/staking/delegate/stake_all.rs
+++ b/src/commands/staking/delegate/stake_all.rs
@@ -71,6 +71,7 @@ impl StakeAllContext {
             ),
             on_after_sending_transaction_callback,
             sign_as_delegate_action: false,
+            on_sending_delegate_action_callback: None,
         }))
     }
 }

--- a/src/commands/staking/delegate/unstake.rs
+++ b/src/commands/staking/delegate/unstake.rs
@@ -77,6 +77,7 @@ impl UnstakeContext {
             ),
             on_after_sending_transaction_callback,
             sign_as_delegate_action: false,
+            on_sending_delegate_action_callback: None,
         }))
     }
 }

--- a/src/commands/staking/delegate/unstake_all.rs
+++ b/src/commands/staking/delegate/unstake_all.rs
@@ -71,6 +71,7 @@ impl UnstakeAllContext {
             ),
             on_after_sending_transaction_callback,
             sign_as_delegate_action: false,
+            on_sending_delegate_action_callback: None,
         }))
     }
 }

--- a/src/commands/staking/delegate/withdraw.rs
+++ b/src/commands/staking/delegate/withdraw.rs
@@ -77,6 +77,7 @@ impl WithdrawContext {
             ),
             on_after_sending_transaction_callback,
             sign_as_delegate_action: false,
+            on_sending_delegate_action_callback: None,
         }))
     }
 }

--- a/src/commands/staking/delegate/withdraw_all.rs
+++ b/src/commands/staking/delegate/withdraw_all.rs
@@ -71,6 +71,7 @@ impl WithdrawAllContext {
             ),
             on_after_sending_transaction_callback,
             sign_as_delegate_action: false,
+            on_sending_delegate_action_callback: None,
         }))
     }
 }

--- a/src/commands/tokens/send_ft/amount_ft.rs
+++ b/src/commands/tokens/send_ft/amount_ft.rs
@@ -189,6 +189,7 @@ impl FtTransferParamsContext {
             ),
             on_after_sending_transaction_callback,
             sign_as_delegate_action: false,
+            on_sending_delegate_action_callback: None,
         }))
     }
 }

--- a/src/commands/tokens/send_ft_call/amount_ft.rs
+++ b/src/commands/tokens/send_ft_call/amount_ft.rs
@@ -300,5 +300,6 @@ fn build_action_context(
         ),
         on_after_sending_transaction_callback,
         sign_as_delegate_action: false,
+        on_sending_delegate_action_callback: None,
     })
 }

--- a/src/commands/tokens/send_near/mod.rs
+++ b/src/commands/tokens/send_near/mod.rs
@@ -68,6 +68,7 @@ impl From<SendNearCommandContext> for crate::commands::ActionContext {
                 |_outcome_view, _network_config| Ok(()),
             ),
             sign_as_delegate_action: false,
+            on_sending_delegate_action_callback: None,
         }
     }
 }

--- a/src/commands/tokens/send_nft/mod.rs
+++ b/src/commands/tokens/send_nft/mod.rs
@@ -115,6 +115,7 @@ impl From<SendNftCommandContext> for crate::commands::ActionContext {
             ),
             on_after_sending_transaction_callback,
             sign_as_delegate_action: false,
+            on_sending_delegate_action_callback: None,
         }
     }
 }

--- a/src/commands/transaction/construct_transaction/skip_action/mod.rs
+++ b/src/commands/transaction/construct_transaction/skip_action/mod.rs
@@ -51,6 +51,7 @@ impl From<SkipActionContext> for crate::commands::ActionContext {
             on_after_sending_transaction_callback: std::sync::Arc::new(
                 |_outcome_view, _network_config| Ok(()),
             ),
+            on_sending_delegate_action_callback: None,
             sign_as_delegate_action: item.0.sign_as_delegate_action,
         }
     }

--- a/src/commands/transaction/send_meta_transaction/sign_as/mod.rs
+++ b/src/commands/transaction/send_meta_transaction/sign_as/mod.rs
@@ -61,6 +61,7 @@ impl RelayerAccountIdContext {
                 |_outcome, _network_config| Ok(()),
             ),
             sign_as_delegate_action: false,
+            on_sending_delegate_action_callback: None,
         }))
     }
 }

--- a/src/commands/transaction/sign_transaction/mod.rs
+++ b/src/commands/transaction/sign_transaction/mod.rs
@@ -46,6 +46,7 @@ impl SignTransactionContext {
                 |_outcome_view, _network_config| Ok(()),
             ),
             sign_as_delegate_action: false,
+            on_sending_delegate_action_callback: None,
         }))
     }
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -2089,7 +2089,7 @@ pub fn get_validator_list(
             .buffer_unordered(concurrency)
             .try_collect::<Vec<_>>(),
     )?;
-    validator_list.sort_by(|a, b| b.stake.cmp(&a.stake));
+    validator_list.sort_by_key(|b| std::cmp::Reverse(b.stake));
     Ok(validator_list)
 }
 

--- a/src/network_for_transaction/mod.rs
+++ b/src/network_for_transaction/mod.rs
@@ -22,6 +22,8 @@ pub struct NetworkForTransactionArgsContext {
         crate::transaction_signature_options::OnBeforeSendingTransactionCallback,
     on_after_sending_transaction_callback:
         crate::transaction_signature_options::OnAfterSendingTransactionCallback,
+    on_sending_delegate_action_callback:
+        Option<crate::transaction_signature_options::OnSendingDelegateActionCallback>,
     sign_as_delegate_action: bool,
 }
 
@@ -54,6 +56,8 @@ impl NetworkForTransactionArgsContext {
                 .on_before_sending_transaction_callback,
             on_after_sending_transaction_callback: previous_context
                 .on_after_sending_transaction_callback,
+            on_sending_delegate_action_callback: previous_context
+                .on_sending_delegate_action_callback,
             sign_as_delegate_action,
         })
     }
@@ -71,6 +75,7 @@ impl From<NetworkForTransactionArgsContext> for crate::commands::TransactionCont
             ),
             on_before_sending_transaction_callback: item.on_before_sending_transaction_callback,
             on_after_sending_transaction_callback: item.on_after_sending_transaction_callback,
+            on_sending_delegate_action_callback: item.on_sending_delegate_action_callback,
             sign_as_delegate_action: item.sign_as_delegate_action,
         }
     }

--- a/src/transaction_signature_options/mod.rs
+++ b/src/transaction_signature_options/mod.rs
@@ -116,7 +116,7 @@ pub type OnSendingDelegateActionCallback = std::sync::Arc<
     dyn Fn(
         near_primitives::action::delegate::SignedDelegateAction,
         &crate::config::NetworkConfig,
-    ) -> color_eyre::eyre::Result<()>,
+    ) -> crate::CliResult,
 >;
 
 #[derive(Clone)]

--- a/src/transaction_signature_options/mod.rs
+++ b/src/transaction_signature_options/mod.rs
@@ -112,6 +112,13 @@ pub type OnAfterSendingTransactionCallback = std::sync::Arc<
     ) -> crate::CliResult,
 >;
 
+pub type OnSendingDelegateActionCallback = std::sync::Arc<
+    dyn Fn(
+        near_primitives::action::delegate::SignedDelegateAction,
+        &crate::config::NetworkConfig,
+    ) -> color_eyre::eyre::Result<()>,
+>;
+
 #[derive(Clone)]
 pub struct SubmitContext {
     pub network_config: crate::config::NetworkConfig,
@@ -119,6 +126,7 @@ pub struct SubmitContext {
     pub signed_transaction_or_signed_delegate_action: SignedTransactionOrSignedDelegateAction,
     pub on_before_sending_transaction_callback: OnBeforeSendingTransactionCallback,
     pub on_after_sending_transaction_callback: OnAfterSendingTransactionCallback,
+    pub on_sending_delegate_action_callback: Option<OnSendingDelegateActionCallback>,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]

--- a/src/transaction_signature_options/send/mod.rs
+++ b/src/transaction_signature_options/send/mod.rs
@@ -73,6 +73,17 @@ impl SendContext {
             super::SignedTransactionOrSignedDelegateAction::SignedDelegateAction(
                 signed_delegate_action,
             ) if previous_context
+                .on_sending_delegate_action_callback
+                .is_some() =>
+            {
+                let callback = previous_context
+                    .on_sending_delegate_action_callback
+                    .unwrap();
+                callback(signed_delegate_action, &previous_context.network_config)?;
+            }
+            super::SignedTransactionOrSignedDelegateAction::SignedDelegateAction(
+                signed_delegate_action,
+            ) if previous_context
                 .network_config
                 .meta_transaction_relayer_url
                 .is_some() =>

--- a/src/transaction_signature_options/sign_with_access_key_file/mod.rs
+++ b/src/transaction_signature_options/sign_with_access_key_file/mod.rs
@@ -37,6 +37,8 @@ pub struct SignAccessKeyFileContext {
         crate::transaction_signature_options::OnBeforeSendingTransactionCallback,
     on_after_sending_transaction_callback:
         crate::transaction_signature_options::OnAfterSendingTransactionCallback,
+    on_sending_delegate_action_callback:
+        Option<crate::transaction_signature_options::OnSendingDelegateActionCallback>,
 }
 
 impl SignAccessKeyFileContext {
@@ -131,6 +133,8 @@ impl SignAccessKeyFileContext {
                     .on_before_sending_transaction_callback,
                 on_after_sending_transaction_callback: previous_context
                     .on_after_sending_transaction_callback,
+                on_sending_delegate_action_callback: previous_context
+                    .on_sending_delegate_action_callback,
             });
         }
 
@@ -162,6 +166,8 @@ impl SignAccessKeyFileContext {
                 .on_before_sending_transaction_callback,
             on_after_sending_transaction_callback: previous_context
                 .on_after_sending_transaction_callback,
+            on_sending_delegate_action_callback: previous_context
+                .on_sending_delegate_action_callback,
         })
     }
 }
@@ -175,6 +181,7 @@ impl From<SignAccessKeyFileContext> for super::SubmitContext {
                 .signed_transaction_or_signed_delegate_action,
             on_before_sending_transaction_callback: item.on_before_sending_transaction_callback,
             on_after_sending_transaction_callback: item.on_after_sending_transaction_callback,
+            on_sending_delegate_action_callback: item.on_sending_delegate_action_callback,
         }
     }
 }

--- a/src/transaction_signature_options/sign_with_keychain/mod.rs
+++ b/src/transaction_signature_options/sign_with_keychain/mod.rs
@@ -39,6 +39,8 @@ pub struct SignKeychainContext {
         crate::transaction_signature_options::OnBeforeSendingTransactionCallback,
     on_after_sending_transaction_callback:
         crate::transaction_signature_options::OnAfterSendingTransactionCallback,
+    on_sending_delegate_action_callback:
+        Option<crate::transaction_signature_options::OnSendingDelegateActionCallback>,
 }
 
 impl From<super::sign_with_legacy_keychain::SignLegacyKeychainContext> for SignKeychainContext {
@@ -50,6 +52,7 @@ impl From<super::sign_with_legacy_keychain::SignLegacyKeychainContext> for SignK
                 .signed_transaction_or_signed_delegate_action,
             on_before_sending_transaction_callback: value.on_before_sending_transaction_callback,
             on_after_sending_transaction_callback: value.on_after_sending_transaction_callback,
+            on_sending_delegate_action_callback: value.on_sending_delegate_action_callback,
         }
     }
 }
@@ -222,6 +225,8 @@ impl SignKeychainContext {
                     .on_before_sending_transaction_callback,
                 on_after_sending_transaction_callback: previous_context
                     .on_after_sending_transaction_callback,
+                on_sending_delegate_action_callback: previous_context
+                    .on_sending_delegate_action_callback,
             });
         }
 
@@ -253,6 +258,8 @@ impl SignKeychainContext {
                 .on_before_sending_transaction_callback,
             on_after_sending_transaction_callback: previous_context
                 .on_after_sending_transaction_callback,
+            on_sending_delegate_action_callback: previous_context
+                .on_sending_delegate_action_callback,
         })
     }
 }
@@ -297,6 +304,7 @@ impl From<SignKeychainContext> for super::SubmitContext {
                 .signed_transaction_or_signed_delegate_action,
             on_before_sending_transaction_callback: item.on_before_sending_transaction_callback,
             on_after_sending_transaction_callback: item.on_after_sending_transaction_callback,
+            on_sending_delegate_action_callback: item.on_sending_delegate_action_callback,
         }
     }
 }

--- a/src/transaction_signature_options/sign_with_ledger/mod.rs
+++ b/src/transaction_signature_options/sign_with_ledger/mod.rs
@@ -314,6 +314,9 @@ fn sign_transaction_with_usb(
             on_after_sending_transaction_callback: previous_context
                 .on_after_sending_transaction_callback
                 .clone(),
+            on_sending_delegate_action_callback: previous_context
+                .on_sending_delegate_action_callback
+                .clone(),
         }));
     }
 
@@ -365,6 +368,9 @@ fn sign_transaction_with_usb(
             .clone(),
         on_after_sending_transaction_callback: previous_context
             .on_after_sending_transaction_callback
+            .clone(),
+        on_sending_delegate_action_callback: previous_context
+            .on_sending_delegate_action_callback
             .clone(),
     }))
 }
@@ -577,6 +583,9 @@ fn sign_transaction_with_ble(
             on_after_sending_transaction_callback: previous_context
                 .on_after_sending_transaction_callback
                 .clone(),
+            on_sending_delegate_action_callback: previous_context
+                .on_sending_delegate_action_callback
+                .clone(),
         }));
     }
 
@@ -628,6 +637,9 @@ fn sign_transaction_with_ble(
             .clone(),
         on_after_sending_transaction_callback: previous_context
             .on_after_sending_transaction_callback
+            .clone(),
+        on_sending_delegate_action_callback: previous_context
+            .on_sending_delegate_action_callback
             .clone(),
     }))
 }

--- a/src/transaction_signature_options/sign_with_legacy_keychain/mod.rs
+++ b/src/transaction_signature_options/sign_with_legacy_keychain/mod.rs
@@ -43,6 +43,8 @@ pub struct SignLegacyKeychainContext {
         crate::transaction_signature_options::OnBeforeSendingTransactionCallback,
     pub(crate) on_after_sending_transaction_callback:
         crate::transaction_signature_options::OnAfterSendingTransactionCallback,
+    pub(crate) on_sending_delegate_action_callback:
+        Option<crate::transaction_signature_options::OnSendingDelegateActionCallback>,
 }
 
 impl SignLegacyKeychainContext {
@@ -211,6 +213,8 @@ impl SignLegacyKeychainContext {
                     .on_before_sending_transaction_callback,
                 on_after_sending_transaction_callback: previous_context
                     .on_after_sending_transaction_callback,
+                on_sending_delegate_action_callback: previous_context
+                    .on_sending_delegate_action_callback,
             });
         }
 
@@ -246,6 +250,8 @@ impl SignLegacyKeychainContext {
                 .on_before_sending_transaction_callback,
             on_after_sending_transaction_callback: previous_context
                 .on_after_sending_transaction_callback,
+            on_sending_delegate_action_callback: previous_context
+                .on_sending_delegate_action_callback,
         })
     }
 }
@@ -259,6 +265,7 @@ impl From<SignLegacyKeychainContext> for super::SubmitContext {
                 .signed_transaction_or_signed_delegate_action,
             on_before_sending_transaction_callback: item.on_before_sending_transaction_callback,
             on_after_sending_transaction_callback: item.on_after_sending_transaction_callback,
+            on_sending_delegate_action_callback: item.on_sending_delegate_action_callback,
         }
     }
 }

--- a/src/transaction_signature_options/sign_with_mpc/mod.rs
+++ b/src/transaction_signature_options/sign_with_mpc/mod.rs
@@ -620,6 +620,7 @@ impl From<DepositContext> for crate::commands::TransactionContext {
                 |_signed_transaction, _network_config| Ok(String::new()),
             ),
             on_after_sending_transaction_callback,
+            on_sending_delegate_action_callback: None,
             sign_as_delegate_action,
         }
     }
@@ -701,6 +702,7 @@ pub fn dao_sign_with_mpc_after_send_flow(
             std::sync::Arc::new(
                 |_outcome_view, _network_config| Ok(()),
         ),
+        on_sending_delegate_action_callback: None,
     };
 
     prompt_and_submit(submit_context)

--- a/src/transaction_signature_options/sign_with_mpc/mod.rs
+++ b/src/transaction_signature_options/sign_with_mpc/mod.rs
@@ -381,6 +381,9 @@ pub struct DepositContext {
     mpc_sign_request_serialized: Vec<u8>,
     global_context: crate::GlobalContext,
     network_config: crate::config::NetworkConfig,
+    on_sending_delegate_action_callback:
+        Option<crate::transaction_signature_options::OnSendingDelegateActionCallback>,
+    sign_as_delegate_action: bool,
 }
 
 impl DepositContext {
@@ -448,6 +451,10 @@ impl DepositContext {
             mpc_sign_request_serialized,
             global_context: previous_context.tx_context.global_context,
             network_config: previous_context.tx_context.network_config,
+            on_sending_delegate_action_callback: previous_context
+                .tx_context
+                .on_sending_delegate_action_callback,
+            sign_as_delegate_action: previous_context.tx_context.sign_as_delegate_action,
         })
     }
 }
@@ -480,7 +487,6 @@ impl Deposit {
 
 impl From<DepositContext> for crate::commands::TransactionContext {
     fn from(item: DepositContext) -> Self {
-        let sign_as_delegate_action = item.network_config.meta_transaction_relayer_url.is_some();
         let mpc_sign_transaction = crate::commands::PrepopulatedTransaction {
             signer_id: item.admin_account_id.clone(),
             receiver_id: item.mpc_contract_address.clone(),
@@ -620,8 +626,8 @@ impl From<DepositContext> for crate::commands::TransactionContext {
                 |_signed_transaction, _network_config| Ok(String::new()),
             ),
             on_after_sending_transaction_callback,
-            on_sending_delegate_action_callback: None,
-            sign_as_delegate_action,
+            on_sending_delegate_action_callback: item.on_sending_delegate_action_callback,
+            sign_as_delegate_action: item.sign_as_delegate_action,
         }
     }
 }

--- a/src/transaction_signature_options/sign_with_private_key/mod.rs
+++ b/src/transaction_signature_options/sign_with_private_key/mod.rs
@@ -37,6 +37,8 @@ pub struct SignPrivateKeyContext {
         crate::transaction_signature_options::OnBeforeSendingTransactionCallback,
     on_after_sending_transaction_callback:
         crate::transaction_signature_options::OnAfterSendingTransactionCallback,
+    on_sending_delegate_action_callback:
+        Option<crate::transaction_signature_options::OnSendingDelegateActionCallback>,
 }
 
 impl SignPrivateKeyContext {
@@ -125,6 +127,8 @@ impl SignPrivateKeyContext {
                     .on_before_sending_transaction_callback,
                 on_after_sending_transaction_callback: previous_context
                     .on_after_sending_transaction_callback,
+                on_sending_delegate_action_callback: previous_context
+                    .on_sending_delegate_action_callback,
             });
         }
 
@@ -154,6 +158,8 @@ impl SignPrivateKeyContext {
                 .on_before_sending_transaction_callback,
             on_after_sending_transaction_callback: previous_context
                 .on_after_sending_transaction_callback,
+            on_sending_delegate_action_callback: previous_context
+                .on_sending_delegate_action_callback,
         })
     }
 }
@@ -167,6 +173,7 @@ impl From<SignPrivateKeyContext> for super::SubmitContext {
                 .signed_transaction_or_signed_delegate_action,
             on_before_sending_transaction_callback: item.on_before_sending_transaction_callback,
             on_after_sending_transaction_callback: item.on_after_sending_transaction_callback,
+            on_sending_delegate_action_callback: item.on_sending_delegate_action_callback,
         }
     }
 }

--- a/src/transaction_signature_options/sign_with_seed_phrase/mod.rs
+++ b/src/transaction_signature_options/sign_with_seed_phrase/mod.rs
@@ -42,6 +42,8 @@ pub struct SignSeedPhraseContext {
         crate::transaction_signature_options::OnBeforeSendingTransactionCallback,
     on_after_sending_transaction_callback:
         crate::transaction_signature_options::OnAfterSendingTransactionCallback,
+    on_sending_delegate_action_callback:
+        Option<crate::transaction_signature_options::OnSendingDelegateActionCallback>,
 }
 
 impl SignSeedPhraseContext {
@@ -135,6 +137,8 @@ impl SignSeedPhraseContext {
                     .on_before_sending_transaction_callback,
                 on_after_sending_transaction_callback: previous_context
                     .on_after_sending_transaction_callback,
+                on_sending_delegate_action_callback: previous_context
+                    .on_sending_delegate_action_callback,
             });
         }
 
@@ -164,6 +168,8 @@ impl SignSeedPhraseContext {
                 .on_before_sending_transaction_callback,
             on_after_sending_transaction_callback: previous_context
                 .on_after_sending_transaction_callback,
+            on_sending_delegate_action_callback: previous_context
+                .on_sending_delegate_action_callback,
         })
     }
 }
@@ -177,6 +183,7 @@ impl From<SignSeedPhraseContext> for super::SubmitContext {
                 .signed_transaction_or_signed_delegate_action,
             on_before_sending_transaction_callback: item.on_before_sending_transaction_callback,
             on_after_sending_transaction_callback: item.on_after_sending_transaction_callback,
+            on_sending_delegate_action_callback: item.on_sending_delegate_action_callback,
         }
     }
 }

--- a/src/transaction_signature_options/submit_dao_proposal/mod.rs
+++ b/src/transaction_signature_options/submit_dao_proposal/mod.rs
@@ -287,6 +287,7 @@ impl From<DepositContext> for crate::commands::TransactionContext {
                 |_signed_transaction, _network_config| Ok(String::new()),
             ),
             on_after_sending_transaction_callback: item.on_after_sending_transaction_callback,
+            on_sending_delegate_action_callback: None,
             sign_as_delegate_action,
         }
     }

--- a/src/transaction_signature_options/submit_dao_proposal/mod.rs
+++ b/src/transaction_signature_options/submit_dao_proposal/mod.rs
@@ -22,6 +22,9 @@ pub struct DaoProposalContext {
     network_config: crate::config::NetworkConfig,
     on_after_sending_transaction_callback:
         crate::transaction_signature_options::OnAfterSendingTransactionCallback,
+    on_sending_delegate_action_callback:
+        Option<crate::transaction_signature_options::OnSendingDelegateActionCallback>,
+    sign_as_delegate_action: bool,
     dao_account_id: near_primitives::types::AccountId,
     receiver_id: near_primitives::types::AccountId,
     proposal_kind: dao_kind_arguments::ProposalKind,
@@ -52,6 +55,9 @@ impl DaoProposalContext {
             global_context: previous_context.global_context,
             network_config: previous_context.network_config,
             on_after_sending_transaction_callback,
+            on_sending_delegate_action_callback: previous_context
+                .on_sending_delegate_action_callback,
+            sign_as_delegate_action: previous_context.sign_as_delegate_action,
             dao_account_id: scope.dao_account_id.clone().into(),
             receiver_id: previous_context.prepopulated_transaction.signer_id.clone(),
             proposal_kind,
@@ -88,6 +94,9 @@ pub struct DaoProposalArgumentsContext {
     network_config: crate::config::NetworkConfig,
     on_after_sending_transaction_callback:
         crate::transaction_signature_options::OnAfterSendingTransactionCallback,
+    on_sending_delegate_action_callback:
+        Option<crate::transaction_signature_options::OnSendingDelegateActionCallback>,
+    sign_as_delegate_action: bool,
     dao_account_id: near_primitives::types::AccountId,
     receiver_id: near_primitives::types::AccountId,
     proposal_args: Vec<u8>,
@@ -110,6 +119,9 @@ impl DaoProposalArgumentsContext {
             network_config: previous_context.network_config,
             on_after_sending_transaction_callback: previous_context
                 .on_after_sending_transaction_callback,
+            on_sending_delegate_action_callback: previous_context
+                .on_sending_delegate_action_callback,
+            sign_as_delegate_action: previous_context.sign_as_delegate_action,
             dao_account_id: previous_context.dao_account_id,
             receiver_id: previous_context.receiver_id,
             proposal_args,
@@ -145,6 +157,9 @@ pub struct PrepaidGasContext {
     network_config: crate::config::NetworkConfig,
     on_after_sending_transaction_callback:
         crate::transaction_signature_options::OnAfterSendingTransactionCallback,
+    on_sending_delegate_action_callback:
+        Option<crate::transaction_signature_options::OnSendingDelegateActionCallback>,
+    sign_as_delegate_action: bool,
     dao_account_id: near_primitives::types::AccountId,
     receiver_id: near_primitives::types::AccountId,
     proposal_args: Vec<u8>,
@@ -161,6 +176,9 @@ impl PrepaidGasContext {
             network_config: previous_context.network_config,
             on_after_sending_transaction_callback: previous_context
                 .on_after_sending_transaction_callback,
+            on_sending_delegate_action_callback: previous_context
+                .on_sending_delegate_action_callback,
+            sign_as_delegate_action: previous_context.sign_as_delegate_action,
             dao_account_id: previous_context.dao_account_id,
             receiver_id: previous_context.receiver_id,
             proposal_args: previous_context.proposal_args,
@@ -211,6 +229,9 @@ pub struct DepositContext {
     network_config: crate::config::NetworkConfig,
     on_after_sending_transaction_callback:
         crate::transaction_signature_options::OnAfterSendingTransactionCallback,
+    on_sending_delegate_action_callback:
+        Option<crate::transaction_signature_options::OnSendingDelegateActionCallback>,
+    sign_as_delegate_action: bool,
     dao_account_id: near_primitives::types::AccountId,
     receiver_id: near_primitives::types::AccountId,
     proposal_args: Vec<u8>,
@@ -228,6 +249,9 @@ impl DepositContext {
             network_config: previous_context.network_config,
             on_after_sending_transaction_callback: previous_context
                 .on_after_sending_transaction_callback,
+            on_sending_delegate_action_callback: previous_context
+                .on_sending_delegate_action_callback,
+            sign_as_delegate_action: previous_context.sign_as_delegate_action,
             dao_account_id: previous_context.dao_account_id,
             receiver_id: previous_context.receiver_id,
             proposal_args: previous_context.proposal_args,
@@ -251,7 +275,6 @@ impl Deposit {
 
 impl From<DepositContext> for crate::commands::TransactionContext {
     fn from(item: DepositContext) -> Self {
-        let sign_as_delegate_action = item.network_config.meta_transaction_relayer_url.is_some();
         let new_prepopulated_transaction = crate::commands::PrepopulatedTransaction {
             signer_id: item.dao_account_id,
             receiver_id: item.receiver_id,
@@ -287,8 +310,8 @@ impl From<DepositContext> for crate::commands::TransactionContext {
                 |_signed_transaction, _network_config| Ok(String::new()),
             ),
             on_after_sending_transaction_callback: item.on_after_sending_transaction_callback,
-            on_sending_delegate_action_callback: None,
-            sign_as_delegate_action,
+            on_sending_delegate_action_callback: item.on_sending_delegate_action_callback,
+            sign_as_delegate_action: item.sign_as_delegate_action,
         }
     }
 }


### PR DESCRIPTION
I need it for trezu CLI, which leverages a custom meta-transaction relayer backend that requires auth, so it is better to just enable customization here and let trezu CLI to reuse parts of near-cli-rs nicely