### PR TITLE
chore(deps): replace `slipped10` with `near-slip10`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2564,6 +2564,7 @@ dependencies = [
  "near-parameters",
  "near-primitives",
  "near-sandbox",
+ "near-slip10",
  "near-socialdb-client",
  "near-token",
  "near-verify-rs",
@@ -2580,7 +2581,6 @@ dependencies = [
  "serde_with",
  "shell-words",
  "shellexpand",
- "slipped10",
  "smart-default",
  "strum",
  "strum_macros",
@@ -2843,6 +2843,17 @@ name = "near-schema-checker-macro"
 version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b61eccf333a27e5dc076290f9eb59b18fc848188377bf3e99e0fe0a93627e18"
+
+[[package]]
+name = "near-slip10"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f476bc5f8bcb36242d25ef252ce43edb22d4dfb8dcdd1b61812c7c9a7594400f"
+dependencies = [
+ "ed25519-dalek",
+ "hmac",
+ "sha2 0.9.9",
+]
 
 [[package]]
 name = "near-socialdb-client"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2695,9 +2695,9 @@ dependencies = [
 
 [[package]]
 name = "near-ledger"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc04735bd42debf28c620d52897f7b2ea81dc3d1477db8536563a6a519872c6"
+checksum = "424f7235bf804ced014da18a6732bfd37f82f01b750d2e7532d79b55026f56ff"
 dependencies = [
  "borsh",
  "btleplug",
@@ -2709,7 +2709,7 @@ dependencies = [
  "ledger-transport",
  "ledger-transport-hid",
  "log",
- "slipped10",
+ "near-slip10",
  "tokio",
  "uuid",
 ]
@@ -4288,17 +4288,6 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
-
-[[package]]
-name = "slipped10"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a45443e66aa5d96db5e02d17db056e1ca970232a4fe73e1f9bc1816d68f4e98"
-dependencies = [
- "ed25519-dalek",
- "hmac",
- "sha2 0.9.9",
-]
 
 [[package]]
 name = "smallvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ serde_with = "3.12.0"
 toml = "0.8"
 dirs = "6"
 shellexpand = "3"
-slipped10 = { version = "0.4.6" }
+near-slip10 = { version = "0.4.7" }
 url = { version = "2", features = ["serde"] }
 open = "5"
 shell-words = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ near-jsonrpc-primitives = "0.35"
 near-parameters = "0.35"
 near-socialdb-client = "0.15"
 
-near-ledger = { version = "0.9.2", optional = true }
+near-ledger = { version = "0.9.3", optional = true }
 
 near-gas = { version = "0.3", features = [
     "serde",
@@ -128,7 +128,13 @@ insta = "1.40"
 regex = "1.10"
 
 [features]
-default = ["ledger", "ledger-ble", "self-update", "inspect_contract", "verify_contract"]
+default = [
+    "ledger",
+    "ledger-ble",
+    "self-update",
+    "inspect_contract",
+    "verify_contract",
+]
 ledger = ["near-ledger"]
 ledger-ble = ["near-ledger/ble", "ledger"]
 self-update = ["self_update", "semver"]

--- a/src/commands/account/add_key/use_manually_provided_seed_phrase/mod.rs
+++ b/src/commands/account/add_key/use_manually_provided_seed_phrase/mod.rs
@@ -24,7 +24,8 @@ impl AddAccessWithSeedPhraseActionContext {
         previous_context: super::access_key_type::AccessTypeContext,
         scope: &<AddAccessWithSeedPhraseAction as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
     ) -> color_eyre::eyre::Result<Self> {
-        let seed_phrase_hd_path_default = slipped10::BIP32Path::from_str("m/44'/397'/0'").unwrap();
+        let seed_phrase_hd_path_default =
+            near_slip10::BIP32Path::from_str("m/44'/397'/0'").unwrap();
         let public_key = crate::common::get_public_key_from_seed_phrase(
             seed_phrase_hd_path_default,
             &scope.master_seed_phrase,

--- a/src/commands/account/create_account/fund_myself_create_account/add_key/use_manually_provided_seed_phrase/mod.rs
+++ b/src/commands/account/create_account/fund_myself_create_account/add_key/use_manually_provided_seed_phrase/mod.rs
@@ -21,7 +21,7 @@ impl AddAccessWithSeedPhraseActionContext {
     ) -> color_eyre::eyre::Result<Self> {
         // This is the HD path that is used in NEAR Wallet for plaintext seed phrase generation and, subsequently, for account recovery by a seed phrase.
         let near_wallet_seed_phrase_hd_path_default =
-            slipped10::BIP32Path::from_str("m/44'/397'/0'").unwrap();
+            near_slip10::BIP32Path::from_str("m/44'/397'/0'").unwrap();
         let public_key = crate::common::get_public_key_from_seed_phrase(
             near_wallet_seed_phrase_hd_path_default,
             &scope.master_seed_phrase,

--- a/src/commands/account/create_account/sponsor_by_faucet_service/add_key/use_manually_provided_seed_phrase/mod.rs
+++ b/src/commands/account/create_account/sponsor_by_faucet_service/add_key/use_manually_provided_seed_phrase/mod.rs
@@ -21,7 +21,7 @@ impl AddAccessWithSeedPhraseActionContext {
     ) -> color_eyre::eyre::Result<Self> {
         // This is the HD path that is used in NEAR Wallet for plaintext seed phrase generation and, subsequently, for account recovery by a seed phrase.
         let near_wallet_seed_phrase_hd_path_default =
-            slipped10::BIP32Path::from_str("m/44'/397'/0'").unwrap();
+            near_slip10::BIP32Path::from_str("m/44'/397'/0'").unwrap();
         let public_key = crate::common::get_public_key_from_seed_phrase(
             near_wallet_seed_phrase_hd_path_default,
             &scope.master_seed_phrase,

--- a/src/commands/transaction/construct_transaction/add_action_1/add_action/add_key/use_manually_provided_seed_phrase/mod.rs
+++ b/src/commands/transaction/construct_transaction/add_action_1/add_action/add_key/use_manually_provided_seed_phrase/mod.rs
@@ -20,7 +20,8 @@ impl AddAccessWithSeedPhraseActionContext {
         previous_context: super::access_key_type::AccessKeyPermissionContext,
         scope: &<AddAccessWithSeedPhraseAction as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
     ) -> color_eyre::eyre::Result<Self> {
-        let seed_phrase_hd_path_default = slipped10::BIP32Path::from_str("m/44'/397'/0'").unwrap();
+        let seed_phrase_hd_path_default =
+            near_slip10::BIP32Path::from_str("m/44'/397'/0'").unwrap();
         let public_key = crate::common::get_public_key_from_seed_phrase(
             seed_phrase_hd_path_default,
             &scope.master_seed_phrase,

--- a/src/commands/transaction/construct_transaction/add_action_2/add_action/add_key/use_manually_provided_seed_phrase/mod.rs
+++ b/src/commands/transaction/construct_transaction/add_action_2/add_action/add_key/use_manually_provided_seed_phrase/mod.rs
@@ -20,7 +20,8 @@ impl AddAccessWithSeedPhraseActionContext {
         previous_context: super::access_key_type::AccessKeyPermissionContext,
         scope: &<AddAccessWithSeedPhraseAction as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
     ) -> color_eyre::eyre::Result<Self> {
-        let seed_phrase_hd_path_default = slipped10::BIP32Path::from_str("m/44'/397'/0'").unwrap();
+        let seed_phrase_hd_path_default =
+            near_slip10::BIP32Path::from_str("m/44'/397'/0'").unwrap();
         let public_key = crate::common::get_public_key_from_seed_phrase(
             seed_phrase_hd_path_default,
             &scope.master_seed_phrase,

--- a/src/commands/transaction/construct_transaction/add_action_3/add_action/add_key/use_manually_provided_seed_phrase/mod.rs
+++ b/src/commands/transaction/construct_transaction/add_action_3/add_action/add_key/use_manually_provided_seed_phrase/mod.rs
@@ -20,7 +20,8 @@ impl AddAccessWithSeedPhraseActionContext {
         previous_context: super::access_key_type::AccessKeyPermissionContext,
         scope: &<AddAccessWithSeedPhraseAction as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
     ) -> color_eyre::eyre::Result<Self> {
-        let seed_phrase_hd_path_default = slipped10::BIP32Path::from_str("m/44'/397'/0'").unwrap();
+        let seed_phrase_hd_path_default =
+            near_slip10::BIP32Path::from_str("m/44'/397'/0'").unwrap();
         let public_key = crate::common::get_public_key_from_seed_phrase(
             seed_phrase_hd_path_default,
             &scope.master_seed_phrase,

--- a/src/common.rs
+++ b/src/common.rs
@@ -638,9 +638,9 @@ pub fn get_key_pair_properties_from_seed_phrase(
     master_seed_phrase: String,
 ) -> color_eyre::eyre::Result<KeyPairProperties> {
     let master_seed = bip39::Mnemonic::parse(&master_seed_phrase)?.to_seed("");
-    let derived_private_key = slipped10::derive_key_from_path(
+    let derived_private_key = near_slip10::derive_key_from_path(
         &master_seed,
-        slipped10::Curve::Ed25519,
+        near_slip10::Curve::Ed25519,
         &seed_phrase_hd_path.clone().into(),
     )
     .map_err(|err| {
@@ -667,13 +667,13 @@ pub fn get_key_pair_properties_from_seed_phrase(
 }
 
 pub fn get_public_key_from_seed_phrase(
-    seed_phrase_hd_path: slipped10::BIP32Path,
+    seed_phrase_hd_path: near_slip10::BIP32Path,
     master_seed_phrase: &str,
 ) -> color_eyre::eyre::Result<near_crypto::PublicKey> {
     let master_seed = bip39::Mnemonic::parse(master_seed_phrase)?.to_seed("");
-    let derived_private_key = slipped10::derive_key_from_path(
+    let derived_private_key = near_slip10::derive_key_from_path(
         &master_seed,
-        slipped10::Curve::Ed25519,
+        near_slip10::Curve::Ed25519,
         &seed_phrase_hd_path,
     )
     .map_err(|err| {
@@ -703,9 +703,9 @@ pub fn generate_keypair() -> color_eyre::eyre::Result<KeyPairProperties> {
             (master_seed_phrase, mnemonic.to_seed(""))
         };
 
-    let derived_private_key = slipped10::derive_key_from_path(
+    let derived_private_key = near_slip10::derive_key_from_path(
         &master_seed,
-        slipped10::Curve::Ed25519,
+        near_slip10::Curve::Ed25519,
         &generate_keypair.seed_phrase_hd_path.clone().into(),
     )
     .map_err(|err| {

--- a/src/transaction_signature_options/sign_with_ledger/ble_helpers.rs
+++ b/src/transaction_signature_options/sign_with_ledger/ble_helpers.rs
@@ -6,7 +6,7 @@
 const BLE_SCAN_MAX_RETRIES: usize = 3;
 
 pub fn ble_connect_and_get_public_key(
-    seed_phrase_hd_path: slipped10::BIP32Path,
+    seed_phrase_hd_path: near_slip10::BIP32Path,
 ) -> color_eyre::eyre::Result<ed25519_dalek::VerifyingKey> {
     let rt = new_ble_runtime()?;
 
@@ -18,7 +18,7 @@ pub fn ble_connect_and_get_public_key(
 }
 
 pub fn ble_get_public_key_and_sign_nep413(
-    seed_phrase_hd_path: slipped10::BIP32Path,
+    seed_phrase_hd_path: near_slip10::BIP32Path,
     payload: near_ledger::NEP413Payload,
 ) -> color_eyre::eyre::Result<(ed25519_dalek::VerifyingKey, near_ledger::SignatureBytes)> {
     let rt = new_ble_runtime()?;
@@ -51,7 +51,7 @@ pub struct BleSession {
 
 impl BleSession {
     pub fn connect_open_and_get_public_key(
-        seed_phrase_hd_path: slipped10::BIP32Path,
+        seed_phrase_hd_path: near_slip10::BIP32Path,
     ) -> color_eyre::eyre::Result<(Self, ed25519_dalek::VerifyingKey)> {
         let rt = new_ble_runtime()?;
 
@@ -68,7 +68,7 @@ impl BleSession {
     pub fn sign_transaction(
         &self,
         unsigned_tx: &[u8],
-        seed_phrase_hd_path: slipped10::BIP32Path,
+        seed_phrase_hd_path: near_slip10::BIP32Path,
     ) -> Result<near_ledger::SignatureBytes, near_ledger::NEARLedgerError> {
         self.rt.block_on(async {
             near_ledger::sign_transaction_ble(&self.transport, unsigned_tx, seed_phrase_hd_path)
@@ -79,7 +79,7 @@ impl BleSession {
     pub fn sign_message_nep366_delegate_action(
         &self,
         payload: &[u8],
-        seed_phrase_hd_path: slipped10::BIP32Path,
+        seed_phrase_hd_path: near_slip10::BIP32Path,
     ) -> Result<near_ledger::SignatureBytes, near_ledger::NEARLedgerError> {
         self.rt.block_on(async {
             near_ledger::sign_message_nep366_delegate_action_ble(
@@ -150,7 +150,7 @@ async fn open_near_app(transport: &near_ledger::TransportBle) -> color_eyre::eyr
 )]
 async fn get_public_key(
     transport: &near_ledger::TransportBle,
-    seed_phrase_hd_path: slipped10::BIP32Path,
+    seed_phrase_hd_path: near_slip10::BIP32Path,
 ) -> color_eyre::eyre::Result<ed25519_dalek::VerifyingKey> {
     near_ledger::get_public_key_ble(transport, seed_phrase_hd_path)
         .await

--- a/src/transaction_signature_options/sign_with_ledger/mod.rs
+++ b/src/transaction_signature_options/sign_with_ledger/mod.rs
@@ -210,7 +210,7 @@ fn sign_transaction_with_usb(
     tracing::info!(target: "near_teach_me", "Signing the transaction with Ledger device via USB. Follow the instructions on the ledger ...");
 
     let network_config = previous_context.network_config.clone();
-    let seed_phrase_hd_path_raw: slipped10::BIP32Path = seed_phrase_hd_path.clone().into();
+    let seed_phrase_hd_path_raw: near_slip10::BIP32Path = seed_phrase_hd_path.clone().into();
     let public_key: near_crypto::PublicKey = signer_public_key.clone().into();
 
     let (nonce, block_hash, block_height) = if previous_context.global_context.offline {
@@ -473,7 +473,7 @@ fn sign_transaction_with_ble(
     tracing::info!(target: "near_teach_me", "Signing the transaction with Ledger device via Bluetooth. Follow the instructions on the ledger ...");
 
     let network_config = previous_context.network_config.clone();
-    let seed_phrase_hd_path_raw: slipped10::BIP32Path = seed_phrase_hd_path.clone().into();
+    let seed_phrase_hd_path_raw: near_slip10::BIP32Path = seed_phrase_hd_path.clone().into();
     let public_key: near_crypto::PublicKey = signer_public_key.clone().into();
 
     let (nonce, block_hash, block_height) = if previous_context.global_context.offline {

--- a/src/types/slip10.rs
+++ b/src/types/slip10.rs
@@ -1,5 +1,5 @@
 #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
-pub struct BIP32Path(pub slipped10::BIP32Path);
+pub struct BIP32Path(pub near_slip10::BIP32Path);
 
 impl std::fmt::Display for BIP32Path {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
@@ -11,19 +11,19 @@ impl std::str::FromStr for BIP32Path {
     type Err = color_eyre::eyre::Report;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let bip32path = slipped10::BIP32Path::from_str(s).map_err(Self::Err::msg)?;
+        let bip32path = near_slip10::BIP32Path::from_str(s).map_err(Self::Err::msg)?;
         Ok(Self(bip32path))
     }
 }
 
-impl From<BIP32Path> for slipped10::BIP32Path {
+impl From<BIP32Path> for near_slip10::BIP32Path {
     fn from(item: BIP32Path) -> Self {
         item.0
     }
 }
 
-impl From<slipped10::BIP32Path> for BIP32Path {
-    fn from(item: slipped10::BIP32Path) -> Self {
+impl From<near_slip10::BIP32Path> for BIP32Path {
+    fn from(item: near_slip10::BIP32Path) -> Self {
         Self(item)
     }
 }


### PR DESCRIPTION
Replaces the unmaintained `slipped10` crate with the `near-slip10` fork (v0.4.7) due to possible supply chain attack. Updates imports and usage.

Related links:
original slack discussion/report: https://nearone.slack.com/archives/C0A64SAMDNG/p1776266170753839

Should be merged after https://github.com/near/near-ledger-rs/pull/32