### PR TITLE
chore: release v0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.0](https://github.com/near/near-cli-rs/compare/v0.25.1...v0.26.0) - 2026-04-16
+
+### Added
+
+- state-init command ([#560](https://github.com/near/near-cli-rs/pull/560))
+
+### Other
+
+- Allow custom on_sending_delegate_action_callback handler for transactions and on_after_signing_callback for sign-message ([#583](https://github.com/near/near-cli-rs/pull/583))
+
 ## [0.25.1](https://github.com/near/near-cli-rs/compare/v0.25.0...v0.25.1) - 2026-04-15
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2531,7 +2531,7 @@ dependencies = [
 
 [[package]]
 name = "near-cli-rs"
-version = "0.25.1"
+version = "0.26.0"
 dependencies = [
  "bip39",
  "borsh",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-cli-rs"
-version = "0.25.1"
+version = "0.26.0"
 authors = ["FroVolod <frol_off@meta.ua>", "Near Inc <hello@nearprotocol.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2024"


### PR DESCRIPTION



## 🤖 New release

* `near-cli-rs`: 0.25.1 -> 0.26.0 (⚠ API breaking changes)

### ⚠ `near-cli-rs` breaking changes

```text
--- failure auto_trait_impl_removed: auto trait no longer implemented ---

Description:
A public type has stopped implementing one or more auto traits. This can break downstream code that depends on the traits being implemented.
        ref: https://doc.rust-lang.org/reference/special-types-and-traits.html#auto-traits
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/auto_trait_impl_removed.ron

Failed in:
  type SignAsWrapperContext is no longer Send, in /tmp/.tmp3byBRY/near-cli-rs/src/commands/message/sign_nep413/signer/mod.rs:20
  type SignAsWrapperContext is no longer Sync, in /tmp/.tmp3byBRY/near-cli-rs/src/commands/message/sign_nep413/signer/mod.rs:20
  type SignAsWrapperContext is no longer UnwindSafe, in /tmp/.tmp3byBRY/near-cli-rs/src/commands/message/sign_nep413/signer/mod.rs:20
  type SignAsWrapperContext is no longer RefUnwindSafe, in /tmp/.tmp3byBRY/near-cli-rs/src/commands/message/sign_nep413/signer/mod.rs:20
  type DepositContext is no longer Send, in /tmp/.tmp3byBRY/near-cli-rs/src/transaction_signature_options/sign_with_mpc/mod.rs:374
  type DepositContext is no longer Sync, in /tmp/.tmp3byBRY/near-cli-rs/src/transaction_signature_options/sign_with_mpc/mod.rs:374
  type DepositContext is no longer UnwindSafe, in /tmp/.tmp3byBRY/near-cli-rs/src/transaction_signature_options/sign_with_mpc/mod.rs:374
  type DepositContext is no longer RefUnwindSafe, in /tmp/.tmp3byBRY/near-cli-rs/src/transaction_signature_options/sign_with_mpc/mod.rs:374
  type FinalSignNep413Context is no longer Send, in /tmp/.tmp3byBRY/near-cli-rs/src/commands/message/sign_nep413/mod.rs:88
  type FinalSignNep413Context is no longer Sync, in /tmp/.tmp3byBRY/near-cli-rs/src/commands/message/sign_nep413/mod.rs:88
  type FinalSignNep413Context is no longer UnwindSafe, in /tmp/.tmp3byBRY/near-cli-rs/src/commands/message/sign_nep413/mod.rs:88
  type FinalSignNep413Context is no longer RefUnwindSafe, in /tmp/.tmp3byBRY/near-cli-rs/src/commands/message/sign_nep413/mod.rs:88
  type SignLedgerContext is no longer Send, in /tmp/.tmp3byBRY/near-cli-rs/src/commands/message/sign_nep413/signature_options/sign_with_ledger.rs:17
  type SignLedgerContext is no longer Sync, in /tmp/.tmp3byBRY/near-cli-rs/src/commands/message/sign_nep413/signature_options/sign_with_ledger.rs:17
  type SignLedgerContext is no longer UnwindSafe, in /tmp/.tmp3byBRY/near-cli-rs/src/commands/message/sign_nep413/signature_options/sign_with_ledger.rs:17
  type SignLedgerContext is no longer RefUnwindSafe, in /tmp/.tmp3byBRY/near-cli-rs/src/commands/message/sign_nep413/signature_options/sign_with_ledger.rs:17

--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ConstructTransaction.receiver in /tmp/.tmp3byBRY/near-cli-rs/src/commands/transaction/construct_transaction/mod.rs:18
  field ActionContext.on_sending_delegate_action_callback in /tmp/.tmp3byBRY/near-cli-rs/src/commands/mod.rs:113
  field FinalSignNep413Context.on_after_signing_callback in /tmp/.tmp3byBRY/near-cli-rs/src/commands/message/sign_nep413/mod.rs:92
  field TransactionContext.on_sending_delegate_action_callback in /tmp/.tmp3byBRY/near-cli-rs/src/commands/mod.rs:129
  field CliConstructTransaction.receiver in /tmp/.tmp3byBRY/near-cli-rs/src/commands/transaction/construct_transaction/mod.rs:10
  field SubmitContext.on_sending_delegate_action_callback in /tmp/.tmp3byBRY/near-cli-rs/src/transaction_signature_options/mod.rs:129

--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant ContractActionsDiscriminants::Inspect 3 -> 4 in /tmp/.tmp3byBRY/near-cli-rs/src/commands/contract/mod.rs:58
  variant ContractActionsDiscriminants::Verify 4 -> 5 in /tmp/.tmp3byBRY/near-cli-rs/src/commands/contract/mod.rs:64
  variant ContractActionsDiscriminants::DownloadAbi 5 -> 6 in /tmp/.tmp3byBRY/near-cli-rs/src/commands/contract/mod.rs:67
  variant ContractActionsDiscriminants::DownloadWasm 6 -> 7 in /tmp/.tmp3byBRY/near-cli-rs/src/commands/contract/mod.rs:70
  variant ContractActionsDiscriminants::ViewStorage 7 -> 8 in /tmp/.tmp3byBRY/near-cli-rs/src/commands/contract/mod.rs:73
  variant ContractActionsDiscriminants::Inspect 3 -> 4 in /tmp/.tmp3byBRY/near-cli-rs/src/commands/contract/mod.rs:58
  variant ContractActionsDiscriminants::Verify 4 -> 5 in /tmp/.tmp3byBRY/near-cli-rs/src/commands/contract/mod.rs:64
  variant ContractActionsDiscriminants::DownloadAbi 5 -> 6 in /tmp/.tmp3byBRY/near-cli-rs/src/commands/contract/mod.rs:67
  variant ContractActionsDiscriminants::DownloadWasm 6 -> 7 in /tmp/.tmp3byBRY/near-cli-rs/src/commands/contract/mod.rs:70
  variant ContractActionsDiscriminants::ViewStorage 7 -> 8 in /tmp/.tmp3byBRY/near-cli-rs/src/commands/contract/mod.rs:73

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant ContractActionsDiscriminants:StateInit in /tmp/.tmp3byBRY/near-cli-rs/src/commands/contract/mod.rs:52
  variant ContractActionsDiscriminants:StateInit in /tmp/.tmp3byBRY/near-cli-rs/src/commands/contract/mod.rs:52
  variant CliContractActions:StateInit in /tmp/.tmp3byBRY/near-cli-rs/src/commands/contract/mod.rs:27

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/inherent_method_missing.ron

Failed in:
  ConstructTransaction::input_receiver_account_id, previously in file /tmp/.tmpRPtiGg/near-cli-rs/src/commands/transaction/construct_transaction/mod.rs:55

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field receiver_account_id of struct ConstructTransaction, previously in file /tmp/.tmpRPtiGg/near-cli-rs/src/commands/transaction/construct_transaction/mod.rs:16
  field next_actions of struct ConstructTransaction, previously in file /tmp/.tmpRPtiGg/near-cli-rs/src/commands/transaction/construct_transaction/mod.rs:18
  field receiver_account_id of struct InteractiveClapContextScopeForConstructTransaction, previously in file /tmp/.tmpRPtiGg/near-cli-rs/src/commands/transaction/construct_transaction/mod.rs:7
  field receiver_account_id of struct CliConstructTransaction, previously in file /tmp/.tmpRPtiGg/near-cli-rs/src/commands/transaction/construct_transaction/mod.rs:7
  field next_actions of struct CliConstructTransaction, previously in file /tmp/.tmpRPtiGg/near-cli-rs/src/commands/transaction/construct_transaction/mod.rs:7
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.26.0](https://github.com/near/near-cli-rs/compare/v0.25.1...v0.26.0) - 2026-04-16

### Added

- state-init command ([#560](https://github.com/near/near-cli-rs/pull/560))

### Other

- Allow custom on_sending_delegate_action_callback handler for transactions and on_after_signing_callback for sign-message ([#583](https://github.com/near/near-cli-rs/pull/583))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).