### PR TITLE
chore: release v0.26.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.2](https://github.com/near/near-cli-rs/compare/v0.26.1...v0.26.2) - 2026-05-08
+
+### Added
+
+- validate receiver account before sending tokens ([#582](https://github.com/near/near-cli-rs/pull/582))
+
 ## [0.26.1](https://github.com/near/near-cli-rs/compare/v0.26.0...v0.26.1) - 2026-04-30
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2531,7 +2531,7 @@ dependencies = [
 
 [[package]]
 name = "near-cli-rs"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "bip39",
  "borsh",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-cli-rs"
-version = "0.26.1"
+version = "0.26.2"
 authors = ["FroVolod <frol_off@meta.ua>", "Near Inc <hello@nearprotocol.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2024"


### PR DESCRIPTION



## 🤖 New release

* `near-cli-rs`: 0.26.1 -> 0.26.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.26.2](https://github.com/near/near-cli-rs/compare/v0.26.1...v0.26.2) - 2026-05-08

### Added

- validate receiver account before sending tokens ([#582](https://github.com/near/near-cli-rs/pull/582))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).