### PR TITLE
fix: Fixed a bug in the command line parsing of the "send-ft" command.

### DIFF
--- a/src/commands/tokens/send_ft/amount_ft.rs
+++ b/src/commands/tokens/send_ft/amount_ft.rs
@@ -1,9 +1,12 @@
 use inquire::CustomType;
 
 #[derive(Debug, Clone, interactive_clap::InteractiveClap)]
-#[interactive_clap(input_context = super::SendFtCommandContext)]
+#[interactive_clap(input_context = super::FtContractContext)]
 #[interactive_clap(output_context = AmountFtContext)]
 pub struct AmountFt {
+    #[interactive_clap(skip_default_input_arg)]
+    /// What is the receiver account ID?
+    receiver_account_id: crate::types::account_id::AccountId,
     #[interactive_clap(skip_default_input_arg)]
     /// Enter an amount FT to transfer:
     ft_transfer_amount: crate::types::ft_properties::FungibleTokenTransferAmount,
@@ -23,7 +26,7 @@ pub struct AmountFtContext {
 
 impl AmountFtContext {
     pub fn from_previous_context(
-        previous_context: super::SendFtCommandContext,
+        previous_context: super::FtContractContext,
         scope: &<AmountFt as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
     ) -> color_eyre::eyre::Result<Self> {
         let ft_transfer_amount =
@@ -40,7 +43,7 @@ impl AmountFtContext {
         Ok(Self {
             global_context: previous_context.global_context,
             signer_account_id: previous_context.signer_account_id,
-            receiver_account_id: previous_context.receiver_account_id,
+            receiver_account_id: scope.receiver_account_id.clone().into(),
             ft_contract: previous_context.ft_contract,
             ft_transfer_amount,
         })
@@ -48,8 +51,17 @@ impl AmountFtContext {
 }
 
 impl AmountFt {
+    pub fn input_receiver_account_id(
+        context: &super::FtContractContext,
+    ) -> color_eyre::eyre::Result<Option<crate::types::account_id::AccountId>> {
+        crate::common::input_non_signer_account_id_from_used_account_list(
+            &context.global_context.config.credentials_home_dir,
+            "What is the receiver account ID?",
+        )
+    }
+
     fn input_ft_transfer_amount(
-        context: &super::SendFtCommandContext,
+        context: &super::FtContractContext,
     ) -> color_eyre::eyre::Result<Option<crate::types::ft_properties::FungibleTokenTransferAmount>>
     {
         let ft_metadata = context.ft_contract.ft_metadata.clone();

--- a/src/commands/tokens/send_ft/mod.rs
+++ b/src/commands/tokens/send_ft/mod.rs
@@ -17,9 +17,9 @@ pub struct FtContract {
     #[interactive_clap(skip_default_input_arg)]
     /// What is the ft-contract account ID?
     ft_contract_account_id: crate::types::account_id::AccountId,
-    #[interactive_clap(named_arg)]
+    #[interactive_clap(subargs)]
     /// Specify sending FT command parameters:
-    send_ft_command: SendFtCommand,
+    amount_ft: self::amount_ft::AmountFt,
 }
 
 #[derive(Debug, Clone)]
@@ -127,51 +127,6 @@ pub fn input_ft_contract_account_id(
     let account_id = crate::types::account_id::AccountId::from_str(&account_id_str)?;
 
     Ok(Some(account_id))
-}
-
-#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
-#[interactive_clap(input_context = FtContractContext)]
-#[interactive_clap(output_context = SendFtCommandContext)]
-pub struct SendFtCommand {
-    #[interactive_clap(skip_default_input_arg)]
-    /// What is the receiver account ID?
-    receiver_account_id: crate::types::account_id::AccountId,
-    #[interactive_clap(subargs)]
-    /// Specify amount FT
-    amount_ft: self::amount_ft::AmountFt,
-}
-
-#[derive(Debug, Clone)]
-pub struct SendFtCommandContext {
-    global_context: crate::GlobalContext,
-    signer_account_id: near_primitives::types::AccountId,
-    ft_contract: crate::types::ft_properties::FtContract,
-    receiver_account_id: near_primitives::types::AccountId,
-}
-
-impl SendFtCommandContext {
-    pub fn from_previous_context(
-        previous_context: FtContractContext,
-        scope: &<SendFtCommand as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
-    ) -> color_eyre::eyre::Result<Self> {
-        Ok(Self {
-            global_context: previous_context.global_context,
-            signer_account_id: previous_context.signer_account_id,
-            ft_contract: previous_context.ft_contract,
-            receiver_account_id: scope.receiver_account_id.clone().into(),
-        })
-    }
-}
-
-impl SendFtCommand {
-    pub fn input_receiver_account_id(
-        context: &FtContractContext,
-    ) -> color_eyre::eyre::Result<Option<crate::types::account_id::AccountId>> {
-        crate::common::input_non_signer_account_id_from_used_account_list(
-            &context.global_context.config.credentials_home_dir,
-            "What is the receiver account ID?",
-        )
-    }
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/src/commands/tokens/send_ft_call/amount_ft.rs
+++ b/src/commands/tokens/send_ft_call/amount_ft.rs
@@ -3,9 +3,12 @@ use inquire::CustomType;
 use strum::{EnumDiscriminants, EnumIter, EnumMessage};
 
 #[derive(Debug, Clone, interactive_clap::InteractiveClap)]
-#[interactive_clap(input_context = super::SendFtCallCommandContext)]
+#[interactive_clap(input_context = super::FtContractContext)]
 #[interactive_clap(output_context = AmountFtContext)]
 pub struct AmountFt {
+    #[interactive_clap(skip_default_input_arg)]
+    /// What is the receiver account ID?
+    receiver_account_id: crate::types::account_id::AccountId,
     #[interactive_clap(skip_default_input_arg)]
     /// Enter an amount FT to transfer:
     ft_transfer_amount: crate::types::ft_properties::FungibleTokenTransferAmount,
@@ -25,7 +28,7 @@ pub struct AmountFtContext {
 
 impl AmountFtContext {
     pub fn from_previous_context(
-        previous_context: super::SendFtCallCommandContext,
+        previous_context: super::FtContractContext,
         scope: &<AmountFt as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
     ) -> color_eyre::eyre::Result<Self> {
         let ft_transfer_amount =
@@ -42,7 +45,7 @@ impl AmountFtContext {
         Ok(Self {
             global_context: previous_context.global_context,
             signer_account_id: previous_context.signer_account_id,
-            receiver_account_id: previous_context.receiver_account_id,
+            receiver_account_id: scope.receiver_account_id.clone().into(),
             ft_contract: previous_context.ft_contract,
             ft_transfer_amount,
         })
@@ -50,8 +53,17 @@ impl AmountFtContext {
 }
 
 impl AmountFt {
+    pub fn input_receiver_account_id(
+        context: &super::FtContractContext,
+    ) -> color_eyre::eyre::Result<Option<crate::types::account_id::AccountId>> {
+        crate::common::input_non_signer_account_id_from_used_account_list(
+            &context.global_context.config.credentials_home_dir,
+            "What is the receiver account ID?",
+        )
+    }
+
     fn input_ft_transfer_amount(
-        context: &super::SendFtCallCommandContext,
+        context: &super::FtContractContext,
     ) -> color_eyre::eyre::Result<Option<crate::types::ft_properties::FungibleTokenTransferAmount>>
     {
         let ft_metadata = context.ft_contract.ft_metadata.clone();

--- a/src/commands/tokens/send_ft_call/mod.rs
+++ b/src/commands/tokens/send_ft_call/mod.rs
@@ -15,9 +15,9 @@ pub struct FtContract {
     #[interactive_clap(skip_default_input_arg)]
     /// What is the ft-contract account ID?
     ft_contract_account_id: crate::types::account_id::AccountId,
-    #[interactive_clap(named_arg)]
+    #[interactive_clap(subargs)]
     /// Specify sending FTCall command parameters:
-    send_ft_call_command: SendFtCallCommand,
+    amount_ft: self::amount_ft::AmountFt,
 }
 
 #[derive(Debug, Clone)]
@@ -77,51 +77,6 @@ impl FtContract {
         context: &super::TokensCommandsContext,
     ) -> color_eyre::eyre::Result<Option<crate::types::account_id::AccountId>> {
         input_ft_contract_account_id(&context.global_context.config.credentials_home_dir)
-    }
-}
-
-#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
-#[interactive_clap(input_context = FtContractContext)]
-#[interactive_clap(output_context = SendFtCallCommandContext)]
-pub struct SendFtCallCommand {
-    #[interactive_clap(skip_default_input_arg)]
-    /// What is the receiver account ID?
-    receiver_account_id: crate::types::account_id::AccountId,
-    #[interactive_clap(subargs)]
-    /// Specify amount FT
-    amount_ft: self::amount_ft::AmountFt,
-}
-
-#[derive(Debug, Clone)]
-pub struct SendFtCallCommandContext {
-    global_context: crate::GlobalContext,
-    signer_account_id: near_primitives::types::AccountId,
-    ft_contract: crate::types::ft_properties::FtContract,
-    receiver_account_id: near_primitives::types::AccountId,
-}
-
-impl SendFtCallCommandContext {
-    pub fn from_previous_context(
-        previous_context: FtContractContext,
-        scope: &<SendFtCallCommand as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
-    ) -> color_eyre::eyre::Result<Self> {
-        Ok(Self {
-            global_context: previous_context.global_context,
-            signer_account_id: previous_context.signer_account_id,
-            ft_contract: previous_context.ft_contract,
-            receiver_account_id: scope.receiver_account_id.clone().into(),
-        })
-    }
-}
-
-impl SendFtCallCommand {
-    pub fn input_receiver_account_id(
-        context: &FtContractContext,
-    ) -> color_eyre::eyre::Result<Option<crate::types::account_id::AccountId>> {
-        crate::common::input_non_signer_account_id_from_used_account_list(
-            &context.global_context.config.credentials_home_dir,
-            "What is the receiver account ID?",
-        )
     }
 }
 


### PR DESCRIPTION
This command had an invalid parameter (`send-at-command`)
```
near tokens fro_volod.testnet send-ft usdn.testnet send-ft-command volodymyr.testnet '10 usn' memo '' network-config testnet-fastnear
```

The cli command is now fixed.
```
near tokens fro_volod.testnet send-ft usdn.testnet volodymyr.testnet '10 usn' memo '' network-config testnet-fastnear 
```