### PR TITLE
chore: bump social-profile set call gas to 1 PGas

### DIFF
--- a/src/commands/account/update_social_profile/sign_as.rs
+++ b/src/commands/account/update_social_profile/sign_as.rs
@@ -202,7 +202,7 @@ fn get_prepopulated_transaction(
         Box::new(near_primitives::transaction::FunctionCallAction {
             method_name: "set".to_string(),
             args,
-            gas: near_primitives::gas::Gas::from_teragas(300),
+            gas: near_primitives::gas::Gas::from_teragas(1000),
             deposit,
         }),
     )];


### PR DESCRIPTION
## Summary
- Bumps the hardcoded `from_teragas(300)` in `update_social_profile/sign_as.rs` to `from_teragas(1000)` (1 PGas)
- Followup to the 2.11 gas limit increase ([devex#4](https://github.com/near/devex/issues/4)) — this was the last remaining 300 TGas hardcode in the CLI source

## Test plan
- [x] `cargo check` passes
- [ ] Manually verify `near account update-social-profile` still works against social.near