### PR TITLE
chore: release v0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.0](https://github.com/near/near-cli-rs/compare/v0.26.2...v0.27.0) - 2026-06-03
+
+### Added
+
+- Added the ability to select multiple keys to remove from the account ([#597](https://github.com/near/near-cli-rs/pull/597))
+
+### Fixed
+
+- Fixed offline mode ([#593](https://github.com/near/near-cli-rs/pull/593))
+- Fixed a bug in the command line parsing of the "send-ft" command. ([#592](https://github.com/near/near-cli-rs/pull/592))
+
+### Other
+
+- bump nearcore crates to 0.36 (2.12 / protocol 84) ([#599](https://github.com/near/near-cli-rs/pull/599))
+
 ## [0.26.2](https://github.com/near/near-cli-rs/compare/v0.26.1...v0.26.2) - 2026-05-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2531,7 +2531,7 @@ dependencies = [
 
 [[package]]
 name = "near-cli-rs"
-version = "0.26.2"
+version = "0.27.0"
 dependencies = [
  "bip39",
  "borsh",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-cli-rs"
-version = "0.26.2"
+version = "0.27.0"
 authors = ["FroVolod <frol_off@meta.ua>", "Near Inc <hello@nearprotocol.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2024"


### PR DESCRIPTION



## 🤖 New release

* `near-cli-rs`: 0.26.2 -> 0.27.0 (⚠ API breaking changes)

### ⚠ `near-cli-rs` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field InteractiveClapContextScopeForDeleteKeyAction.public_keys in /tmp/.tmpeDjOJC/near-cli-rs/src/commands/transaction/construct_transaction/add_action_1/add_action/delete_key/mod.rs:1
  field CliDeleteKeyAction.public_keys in /tmp/.tmpeDjOJC/near-cli-rs/src/commands/transaction/construct_transaction/add_action_1/add_action/delete_key/mod.rs:1

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.47.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field public_key of struct CliDeleteKeyAction, previously in file /tmp/.tmpStMj1t/near-cli-rs/src/commands/transaction/construct_transaction/add_action_1/add_action/delete_key/mod.rs:1
  field public_key of struct InteractiveClapContextScopeForDeleteKeyAction, previously in file /tmp/.tmpStMj1t/near-cli-rs/src/commands/transaction/construct_transaction/add_action_1/add_action/delete_key/mod.rs:1
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.27.0](https://github.com/near/near-cli-rs/compare/v0.26.2...v0.27.0) - 2026-06-03

### Added

- Added the ability to select multiple keys to remove from the account ([#597](https://github.com/near/near-cli-rs/pull/597))

### Fixed

- Fixed offline mode ([#593](https://github.com/near/near-cli-rs/pull/593))
- Fixed a bug in the command line parsing of the "send-ft" command. ([#592](https://github.com/near/near-cli-rs/pull/592))

### Other

- bump nearcore crates to 0.36 (2.12 / protocol 84) ([#599](https://github.com/near/near-cli-rs/pull/599))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).