### PR TITLE
ci: use npm trusted publishing (OIDC) instead of NPM_TOKEN

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -283,6 +283,10 @@ jobs:
       - plan
       - host
     runs-on: "ubuntu-22.04"
+    # OIDC trusted publishing (replaces NPM_TOKEN); id-token mints the short-lived token.
+    permissions:
+      contents: read
+      id-token: write
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       PLAN: ${{ needs.plan.outputs.val }}
@@ -296,15 +300,16 @@ jobs:
           merge-multiple: true
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'
+      # Trusted publishing needs npm >= 11.5.1.
+      - name: Upgrade npm for trusted publishing support
+        run: npm install -g npm@latest
       - run: |
           for release in $(echo "$PLAN" | jq --compact-output '.releases[] | select([.artifacts[] | endswith("-npm-package.tar.gz")] | any)'); do
             pkg=$(echo "$release" | jq '.artifacts[] | select(endswith("-npm-package.tar.gz"))' --raw-output)
             npm publish --access public "./npm/${pkg}"
           done
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   announce:
     needs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -304,7 +304,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       # Trusted publishing needs npm >= 11.5.1.
       - name: Upgrade npm for trusted publishing support
-        run: npm install -g npm@latest
+        run: npm install -g npm@^11.5.1
       - run: |
           for release in $(echo "$PLAN" | jq --compact-output '.releases[] | select([.artifacts[] | endswith("-npm-package.tar.gz")] | any)'); do
             pkg=$(echo "$release" | jq '.artifacts[] | select(endswith("-npm-package.tar.gz"))' --raw-output)


### PR DESCRIPTION
npm publishing started failing after trusted publishing was enabled for the package on npmjs.com. This switches the `publish-npm` job to OIDC trusted publishing, mirroring the setup in cargo-near:

- Add `id-token: write` permission to the job
- Drop `NODE_AUTH_TOKEN` / `NPM_TOKEN`
- Upgrade npm on the runner (trusted publishing needs npm >= 11.5.1)