### PR TITLE
feat: post-quantum (ML-DSA-65) key generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -112,6 +112,11 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json
+      # near-crypto (post-quantum ML-DSA-65) pulls in aws-lc-sys, which needs
+      # NASM to assemble its x86_64 Windows code. Use aws-lc-sys's pregenerated
+      # NASM objects so the x86_64-pc-windows-msvc build doesn't require NASM on
+      # the runner. (aarch64 Windows / unix targets ignore this variable.)
+      AWS_LC_SYS_PREBUILT_NASM: "1"
     steps:
       - name: enable windows longpaths
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,6 +147,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+dependencies = [
+ "aws-lc-sys",
+ "untrusted 0.7.1",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -541,6 +564,15 @@ name = "clap_lex"
 version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "color-eyre"
@@ -1374,6 +1406,12 @@ dependencies = [
  "rustix",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "funty"
@@ -2506,9 +2544,8 @@ dependencies = [
 
 [[package]]
 name = "near-chain-configs"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ad19244d6390aa12020ed3f5971ea452fb54aa8b8f6435d4cf0cbbbc8fbd302"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
 dependencies = [
  "anyhow",
  "bytesize",
@@ -2600,9 +2637,8 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0238af1d79fd3841817e3a5861bb628ba825669f211ca379836ae716da67bb21"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -2612,10 +2648,10 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe9390bf0db47f0a34386ef6a30adc1270288874b7eac5cab7fa48d3f89fe03"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
 dependencies = [
+ "aws-lc-rs",
  "blake2",
  "borsh",
  "bs58 0.4.0",
@@ -2632,15 +2668,15 @@ dependencies = [
  "secp256k1",
  "serde",
  "serde_json",
+ "sha3",
  "subtle",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "near-fmt"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503fac5d4e533a6d5e2c642cd22bd2400d1159dd5b2db58072dfc183a288c273"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
 dependencies = [
  "near-primitives-core",
 ]
@@ -2659,8 +2695,7 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc-client"
 version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614359c17b9cbf5faf2d82ecfe10d7a79b588c51f5f04517f75eff09f1751cdb"
+source = "git+https://github.com/near/near-jsonrpc-client-rs?rev=5f5d150d47315745945fba7672bf8c90c5bf7f95#5f5d150d47315745945fba7672bf8c90c5bf7f95"
 dependencies = [
  "borsh",
  "lazy_static",
@@ -2677,9 +2712,8 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99fa313996117ffead7c6f8eb12bb2b83e6ad569c7c2fd58d406c0f53ed06e01"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
 dependencies = [
  "arbitrary",
  "near-chain-configs",
@@ -2716,9 +2750,8 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b89a9337ab742575d6dc9770ee7d4398de8cec8bbe5eaf25f00349f4e13d0173"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
 dependencies = [
  "borsh",
  "enum-map",
@@ -2735,9 +2768,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "381f54f821ecdddfaccba5815a8d72bb4bb7abacac79783ce86841518523c591"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -2778,9 +2810,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5660ac51d24534bc144e7cc04f702921c22a7e2553072663d4b43a56a8bb1ae7"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -2824,15 +2855,13 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-core"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ad456b1bd9876772d6c0b557d100d518d60dd13e359daca8e0293828e29a05"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
 
 [[package]]
 name = "near-schema-checker-lib"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebdeed0043b2309b306984e4d3eeff6777ba6c66a2f955d34f883fd4ce7f84f2"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
 dependencies = [
  "near-schema-checker-core",
  "near-schema-checker-macro",
@@ -2840,9 +2869,8 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-macro"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "731a7b9cc155e291f149f2f6f8f88f5cab512b772aaf301f9defb4e4bceb1629"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
 
 [[package]]
 name = "near-slip10"
@@ -2858,8 +2886,7 @@ dependencies = [
 [[package]]
 name = "near-socialdb-client"
 version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a7cd480aad6faff2ba872e3368cd17b96db3b4244621e59bb8b95df984607a8"
+source = "git+https://github.com/near/near-socialdb-client-rs?rev=2268c29c4e8ad095de2a511521f08411858a1811#2268c29c4e8ad095de2a511521f08411858a1811"
 dependencies = [
  "eyre",
  "near-crypto",
@@ -2874,15 +2901,13 @@ dependencies = [
 
 [[package]]
 name = "near-stdx"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f35191f9d7a78d5cdca9788e648dce89ebbb74faef4abfa6992ed7f1fb300369"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
 
 [[package]]
 name = "near-time"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ba02806ee8691aaf41717febbe09f8e8b60ff145f09f0fc23438c07a370b3b7"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
 dependencies = [
  "parking_lot",
  "serde",
@@ -3681,7 +3706,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.17",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -3798,7 +3823,7 @@ checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -5002,6 +5027,12 @@ name = "unsafe-libyaml"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -613,7 +613,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1129,7 +1129,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1278,7 +1278,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2119,7 +2119,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2544,8 +2544,9 @@ dependencies = [
 
 [[package]]
 name = "near-chain-configs"
-version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
+version = "0.37.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dd54ba00e601c21619a33d6e127cf0d604ee6c3080d8989492a0faf88cbc5b4"
 dependencies = [
  "anyhow",
  "bytesize",
@@ -2637,8 +2638,9 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
+version = "0.37.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdc29612694210b340ff04d94c539e0d65007c97fc4763075a1d6038e58778a1"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -2648,8 +2650,9 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
+version = "0.37.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48363b16b2cfb9776c93c9ca9c470ed6437a2adb997afa0212372b3130cd944a"
 dependencies = [
  "aws-lc-rs",
  "blake2",
@@ -2675,8 +2678,9 @@ dependencies = [
 
 [[package]]
 name = "near-fmt"
-version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
+version = "0.37.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d603b7171fdb5f5200b4d805c9361d54bb2568e5b0636b4f2a3b37e5e3b7549b"
 dependencies = [
  "near-primitives-core",
 ]
@@ -2695,7 +2699,7 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc-client"
 version = "0.21.1"
-source = "git+https://github.com/near/near-jsonrpc-client-rs?rev=5f5d150d47315745945fba7672bf8c90c5bf7f95#5f5d150d47315745945fba7672bf8c90c5bf7f95"
+source = "git+https://github.com/near/near-jsonrpc-client-rs?rev=b1ea63913de39768f4c40affaaf958e79704710d#b1ea63913de39768f4c40affaaf958e79704710d"
 dependencies = [
  "borsh",
  "lazy_static",
@@ -2712,8 +2716,9 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
+version = "0.37.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2422d73d08d6e3add41e1237443699a27e6150962cbe91aeef14dc2e937a7d26"
 dependencies = [
  "arbitrary",
  "near-chain-configs",
@@ -2750,8 +2755,9 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
+version = "0.37.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e376dc8810d6fa5bd295870c767a9418ef5f239e469ca0d7360bed3e89c703"
 dependencies = [
  "borsh",
  "enum-map",
@@ -2768,8 +2774,9 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
+version = "0.37.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ec7cdd531c3a0cd6c199f183ad6c74755d08344c13f4eab8edd1641fb74a18f"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -2810,8 +2817,9 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
+version = "0.37.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f69db87d9459f45873002def58c11b0ff9c55454ca3793ac9cec396aaa0e27d"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -2855,13 +2863,15 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-core"
-version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
+version = "0.37.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f9ab211568bffbc9b76fb87796a28fd4027cbaeccd4bd4743720d4de4fa48fd"
 
 [[package]]
 name = "near-schema-checker-lib"
-version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
+version = "0.37.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0170e3ee9be1a8f3d0fc5f3f21015fdc00aae2fc5fa9ab2b05e87a8f44e3b3f"
 dependencies = [
  "near-schema-checker-core",
  "near-schema-checker-macro",
@@ -2869,8 +2879,9 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-macro"
-version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
+version = "0.37.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e271c4d3f240580c96702ee0b40e9529174e651dcb8f1749a6ae7fe1c55751d"
 
 [[package]]
 name = "near-slip10"
@@ -2886,7 +2897,7 @@ dependencies = [
 [[package]]
 name = "near-socialdb-client"
 version = "0.15.1"
-source = "git+https://github.com/near/near-socialdb-client-rs?rev=2268c29c4e8ad095de2a511521f08411858a1811#2268c29c4e8ad095de2a511521f08411858a1811"
+source = "git+https://github.com/near/near-socialdb-client-rs?rev=c6c81d1a17bfd5275aa279b478b299721af108e8#c6c81d1a17bfd5275aa279b478b299721af108e8"
 dependencies = [
  "eyre",
  "near-crypto",
@@ -2901,13 +2912,15 @@ dependencies = [
 
 [[package]]
 name = "near-stdx"
-version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
+version = "0.37.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d49f8c17fb0087367b6dbc6bb76b134329c0929e82f099e4baf65312d55f84d"
 
 [[package]]
 name = "near-time"
-version = "0.0.0"
-source = "git+https://github.com/near/nearcore?rev=46483c8d45579dd89faa3bd47317d4c563bcde10#46483c8d45579dd89faa3bd47317d4c563bcde10"
+version = "0.37.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f410629742ba3e9103b274eb839bd89c7f6aaa3362b26495454d50efc917669"
 dependencies = [
  "parking_lot",
  "serde",
@@ -2975,7 +2988,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3461,7 +3474,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3787,7 +3800,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4514,7 +4527,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5354,7 +5367,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2544,9 +2544,9 @@ dependencies = [
 
 [[package]]
 name = "near-chain-configs"
-version = "0.37.0-rc.1"
+version = "0.37.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dd54ba00e601c21619a33d6e127cf0d604ee6c3080d8989492a0faf88cbc5b4"
+checksum = "139112ed78ed5f62ace80e88f4fe2de3edad1a94b90431263b18654d62473e9a"
 dependencies = [
  "anyhow",
  "bytesize",
@@ -2638,9 +2638,9 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "0.37.0-rc.1"
+version = "0.37.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdc29612694210b340ff04d94c539e0d65007c97fc4763075a1d6038e58778a1"
+checksum = "a4b30e07d9eb158f1084a36db8963262f75a353b0093a033aa0529faae9db108"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -2650,9 +2650,9 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "0.37.0-rc.1"
+version = "0.37.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48363b16b2cfb9776c93c9ca9c470ed6437a2adb997afa0212372b3130cd944a"
+checksum = "9ee338484a9348f3768f4d636a98875f746b9dfeb58f4d7761e70ff74f3ddbb5"
 dependencies = [
  "aws-lc-rs",
  "blake2",
@@ -2678,9 +2678,9 @@ dependencies = [
 
 [[package]]
 name = "near-fmt"
-version = "0.37.0-rc.1"
+version = "0.37.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d603b7171fdb5f5200b4d805c9361d54bb2568e5b0636b4f2a3b37e5e3b7549b"
+checksum = "1bf5e92ed9616818b0cbedcc582d2a582194334f9b622276580453624712380b"
 dependencies = [
  "near-primitives-core",
 ]
@@ -2699,7 +2699,7 @@ dependencies = [
 [[package]]
 name = "near-jsonrpc-client"
 version = "0.21.1"
-source = "git+https://github.com/near/near-jsonrpc-client-rs?rev=b1ea63913de39768f4c40affaaf958e79704710d#b1ea63913de39768f4c40affaaf958e79704710d"
+source = "git+https://github.com/near/near-jsonrpc-client-rs?rev=4196c34db5c5e6acfc563d62ab16c68b7c666d7e#4196c34db5c5e6acfc563d62ab16c68b7c666d7e"
 dependencies = [
  "borsh",
  "lazy_static",
@@ -2716,9 +2716,9 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "0.37.0-rc.1"
+version = "0.37.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2422d73d08d6e3add41e1237443699a27e6150962cbe91aeef14dc2e937a7d26"
+checksum = "79ada6f8e357a6eecba4947cb21e56abc58036fcab2136a438b358a4042b62a6"
 dependencies = [
  "arbitrary",
  "near-chain-configs",
@@ -2755,9 +2755,9 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "0.37.0-rc.1"
+version = "0.37.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e376dc8810d6fa5bd295870c767a9418ef5f239e469ca0d7360bed3e89c703"
+checksum = "c9a94eb0bc87f470537646ea6bc5b5b9272bcceb8a798a1bd47e938f8737454a"
 dependencies = [
  "borsh",
  "enum-map",
@@ -2774,9 +2774,9 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "0.37.0-rc.1"
+version = "0.37.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec7cdd531c3a0cd6c199f183ad6c74755d08344c13f4eab8edd1641fb74a18f"
+checksum = "b5704a32bee9023c61c725ed6403f6bfdd21226e4798d74312b427c5a0f7022c"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -2817,9 +2817,9 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "0.37.0-rc.1"
+version = "0.37.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f69db87d9459f45873002def58c11b0ff9c55454ca3793ac9cec396aaa0e27d"
+checksum = "f94564d97ca478c94b8a34fdcda0a0077b967fa83e7187c6b8267e9b6e441d47"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -2863,15 +2863,15 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-core"
-version = "0.37.0-rc.1"
+version = "0.37.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f9ab211568bffbc9b76fb87796a28fd4027cbaeccd4bd4743720d4de4fa48fd"
+checksum = "481ec75b745264fa2403643acde2402536ed4273fbf05ea8749a5d1813f683a0"
 
 [[package]]
 name = "near-schema-checker-lib"
-version = "0.37.0-rc.1"
+version = "0.37.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0170e3ee9be1a8f3d0fc5f3f21015fdc00aae2fc5fa9ab2b05e87a8f44e3b3f"
+checksum = "5eb4a7f0e4eb5aaa1032a396ef0b840f6b3cda399dfa74b9d5cfaf0c1b537260"
 dependencies = [
  "near-schema-checker-core",
  "near-schema-checker-macro",
@@ -2879,9 +2879,9 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-macro"
-version = "0.37.0-rc.1"
+version = "0.37.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e271c4d3f240580c96702ee0b40e9529174e651dcb8f1749a6ae7fe1c55751d"
+checksum = "24abafad706a94a56a687618ae7e13b296b0443f54c7b7d92477b3b3c82e336d"
 
 [[package]]
 name = "near-slip10"
@@ -2897,7 +2897,7 @@ dependencies = [
 [[package]]
 name = "near-socialdb-client"
 version = "0.15.1"
-source = "git+https://github.com/near/near-socialdb-client-rs?rev=c6c81d1a17bfd5275aa279b478b299721af108e8#c6c81d1a17bfd5275aa279b478b299721af108e8"
+source = "git+https://github.com/near/near-socialdb-client-rs?rev=66580af4ce6736056e3d6f15e6c93f0127b86aad#66580af4ce6736056e3d6f15e6c93f0127b86aad"
 dependencies = [
  "eyre",
  "near-crypto",
@@ -2912,15 +2912,15 @@ dependencies = [
 
 [[package]]
 name = "near-stdx"
-version = "0.37.0-rc.1"
+version = "0.37.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d49f8c17fb0087367b6dbc6bb76b134329c0929e82f099e4baf65312d55f84d"
+checksum = "f1e1cf6e256646ef9cabf86759582b2e7b06edfde846edaa68fc7d3e69d833f8"
 
 [[package]]
 name = "near-time"
-version = "0.37.0-rc.1"
+version = "0.37.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f410629742ba3e9103b274eb839bd89c7f6aaa3362b26495454d50efc917669"
+checksum = "3014c3edcc10d38313abd8401700b565ab555423eee090a1b1491c700ed711a2"
 dependencies = [
  "parking_lot",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,15 +79,15 @@ prettytable = "0.10.0"
 textwrap = "0.16.1"
 
 # TODO(post-quantum): nearcore 2.13 (post-quantum ML-DSA-65 access keys,
-# nearcore#15731). Published 2.13 RC 0.37.0-rc.1; bump to 0.37.0 (drop
+# nearcore#15731). Published 2.13 RC 0.37.0-rc.2; bump to 0.37.0 (drop
 # pre-release) once 2.13 ships stable. The jsonrpc/socialdb clients stay on
 # their matching 2.13 draft revs until they cut crates.io releases.
-near-crypto = "0.37.0-rc.1"
-near-primitives = "0.37.0-rc.1"
-near-jsonrpc-client = { git = "https://github.com/near/near-jsonrpc-client-rs", rev = "b1ea63913de39768f4c40affaaf958e79704710d", features = ["any"] }
-near-jsonrpc-primitives = "0.37.0-rc.1"
-near-parameters = "0.37.0-rc.1"
-near-socialdb-client = { git = "https://github.com/near/near-socialdb-client-rs", rev = "c6c81d1a17bfd5275aa279b478b299721af108e8" }
+near-crypto = "0.37.0-rc.2"
+near-primitives = "0.37.0-rc.2"
+near-jsonrpc-client = { git = "https://github.com/near/near-jsonrpc-client-rs", rev = "4196c34db5c5e6acfc563d62ab16c68b7c666d7e", features = ["any"] }
+near-jsonrpc-primitives = "0.37.0-rc.2"
+near-parameters = "0.37.0-rc.2"
+near-socialdb-client = { git = "https://github.com/near/near-socialdb-client-rs", rev = "66580af4ce6736056e3d6f15e6c93f0127b86aad" }
 
 near-ledger = { version = "0.9.4", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,18 +78,16 @@ bytesize = "1.1.0"
 prettytable = "0.10.0"
 textwrap = "0.16.1"
 
-# TODO(post-quantum): temporary git pins for nearcore 2.13 (post-quantum
-# ML-DSA-65 access keys, nearcore#15731). The 2.13 crates are not published to
-# crates.io yet, so we pin every crate that exchanges near-primitives/near-crypto
-# types to the same nearcore `2.13-release` rev (and the matching draft branches
-# of the jsonrpc/socialdb clients) so they resolve to a single version. Swap all
-# of these back to published crates.io versions once nearcore 2.13 ships.
-near-crypto = { git = "https://github.com/near/nearcore", rev = "46483c8d45579dd89faa3bd47317d4c563bcde10" }
-near-primitives = { git = "https://github.com/near/nearcore", rev = "46483c8d45579dd89faa3bd47317d4c563bcde10" }
-near-jsonrpc-client = { git = "https://github.com/near/near-jsonrpc-client-rs", rev = "5f5d150d47315745945fba7672bf8c90c5bf7f95", features = ["any"] }
-near-jsonrpc-primitives = { git = "https://github.com/near/nearcore", rev = "46483c8d45579dd89faa3bd47317d4c563bcde10" }
-near-parameters = { git = "https://github.com/near/nearcore", rev = "46483c8d45579dd89faa3bd47317d4c563bcde10" }
-near-socialdb-client = { git = "https://github.com/near/near-socialdb-client-rs", rev = "2268c29c4e8ad095de2a511521f08411858a1811" }
+# TODO(post-quantum): nearcore 2.13 (post-quantum ML-DSA-65 access keys,
+# nearcore#15731). Published 2.13 RC 0.37.0-rc.1; bump to 0.37.0 (drop
+# pre-release) once 2.13 ships stable. The jsonrpc/socialdb clients stay on
+# their matching 2.13 draft revs until they cut crates.io releases.
+near-crypto = "0.37.0-rc.1"
+near-primitives = "0.37.0-rc.1"
+near-jsonrpc-client = { git = "https://github.com/near/near-jsonrpc-client-rs", rev = "b1ea63913de39768f4c40affaaf958e79704710d", features = ["any"] }
+near-jsonrpc-primitives = "0.37.0-rc.1"
+near-parameters = "0.37.0-rc.1"
+near-socialdb-client = { git = "https://github.com/near/near-socialdb-client-rs", rev = "c6c81d1a17bfd5275aa279b478b299721af108e8" }
 
 near-ledger = { version = "0.9.4", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,12 +78,18 @@ bytesize = "1.1.0"
 prettytable = "0.10.0"
 textwrap = "0.16.1"
 
-near-crypto = "0.36.0"
-near-primitives = "0.36.0"
-near-jsonrpc-client = { version = "0.21", features = ["any"] }
-near-jsonrpc-primitives = "0.36.0"
-near-parameters = "0.36.0"
-near-socialdb-client = "0.15"
+# TODO(post-quantum): temporary git pins for nearcore 2.13 (post-quantum
+# ML-DSA-65 access keys, nearcore#15731). The 2.13 crates are not published to
+# crates.io yet, so we pin every crate that exchanges near-primitives/near-crypto
+# types to the same nearcore `2.13-release` rev (and the matching draft branches
+# of the jsonrpc/socialdb clients) so they resolve to a single version. Swap all
+# of these back to published crates.io versions once nearcore 2.13 ships.
+near-crypto = { git = "https://github.com/near/nearcore", rev = "46483c8d45579dd89faa3bd47317d4c563bcde10" }
+near-primitives = { git = "https://github.com/near/nearcore", rev = "46483c8d45579dd89faa3bd47317d4c563bcde10" }
+near-jsonrpc-client = { git = "https://github.com/near/near-jsonrpc-client-rs", rev = "5f5d150d47315745945fba7672bf8c90c5bf7f95", features = ["any"] }
+near-jsonrpc-primitives = { git = "https://github.com/near/nearcore", rev = "46483c8d45579dd89faa3bd47317d4c563bcde10" }
+near-parameters = { git = "https://github.com/near/nearcore", rev = "46483c8d45579dd89faa3bd47317d4c563bcde10" }
+near-socialdb-client = { git = "https://github.com/near/near-socialdb-client-rs", rev = "2268c29c4e8ad095de2a511521f08411858a1811" }
 
 near-ledger = { version = "0.9.4", optional = true }
 

--- a/src/commands/account/add_key/autogenerate_new_keypair/mod.rs
+++ b/src/commands/account/add_key/autogenerate_new_keypair/mod.rs
@@ -1,4 +1,3 @@
-use std::str::FromStr;
 use strum::{EnumDiscriminants, EnumIter, EnumMessage};
 
 mod print_keypair_to_terminal;
@@ -9,6 +8,10 @@ mod save_keypair_to_legacy_keychain;
 #[interactive_clap(input_context = super::access_key_type::AccessTypeContext)]
 #[interactive_clap(output_context = GenerateKeypairContext)]
 pub struct GenerateKeypair {
+    #[interactive_clap(long)]
+    #[interactive_clap(skip_default_input_arg)]
+    /// Which signature scheme should the new key pair use?
+    signature_scheme: crate::common::SignatureScheme,
     #[interactive_clap(subcommand)]
     save_mode: SaveMode,
 }
@@ -18,25 +21,33 @@ pub struct GenerateKeypairContext {
     global_context: crate::GlobalContext,
     signer_account_id: near_primitives::types::AccountId,
     permission: near_primitives::account::AccessKeyPermission,
-    key_pair_properties: crate::common::KeyPairProperties,
+    generated_key_pair: crate::common::GeneratedKeyPair,
     public_key: near_crypto::PublicKey,
 }
 
 impl GenerateKeypairContext {
     pub fn from_previous_context(
         previous_context: super::access_key_type::AccessTypeContext,
-        _scope: &<GenerateKeypair as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+        scope: &<GenerateKeypair as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
     ) -> color_eyre::eyre::Result<Self> {
-        let key_pair_properties: crate::common::KeyPairProperties =
-            crate::common::generate_keypair()?;
-        let public_key = near_crypto::PublicKey::from_str(&key_pair_properties.public_key_str)?;
+        let generated_key_pair =
+            crate::common::GeneratedKeyPair::generate(&scope.signature_scheme)?;
+        let public_key = generated_key_pair.public_key()?;
         Ok(Self {
             global_context: previous_context.global_context,
             signer_account_id: previous_context.signer_account_id,
             permission: previous_context.permission,
-            key_pair_properties,
+            generated_key_pair,
             public_key,
         })
+    }
+}
+
+impl GenerateKeypair {
+    fn input_signature_scheme(
+        _context: &super::access_key_type::AccessTypeContext,
+    ) -> color_eyre::eyre::Result<Option<crate::common::SignatureScheme>> {
+        crate::common::input_signature_scheme()
     }
 }
 

--- a/src/commands/account/add_key/autogenerate_new_keypair/print_keypair_to_terminal/mod.rs
+++ b/src/commands/account/add_key/autogenerate_new_keypair/print_keypair_to_terminal/mod.rs
@@ -12,7 +12,7 @@ pub struct PrintKeypairToTerminalContext {
     global_context: crate::GlobalContext,
     signer_account_id: near_primitives::types::AccountId,
     permission: near_primitives::account::AccessKeyPermission,
-    key_pair_properties: crate::common::KeyPairProperties,
+    generated_key_pair: crate::common::GeneratedKeyPair,
     public_key: near_crypto::PublicKey,
 }
 
@@ -25,7 +25,7 @@ impl PrintKeypairToTerminalContext {
             global_context: previous_context.global_context,
             signer_account_id: previous_context.signer_account_id,
             permission: previous_context.permission,
-            key_pair_properties: previous_context.key_pair_properties,
+            generated_key_pair: previous_context.generated_key_pair,
             public_key: previous_context.public_key,
         })
     }
@@ -62,18 +62,7 @@ impl From<PrintKeypairToTerminalContext> for crate::commands::ActionContext {
                 |_prepopulated_unsigned_transaction, _network_config| Ok(()),
             ),
             on_before_sending_transaction_callback: std::sync::Arc::new(
-                move |_transaction, _network_config| {
-                    Ok(format!(
-                        "\n--------------------  Access key info ------------------
-                        \nMaster Seed Phrase: {}\nSeed Phrase HD Path: {}\nImplicit Account ID: {}\nPublic Key: {}\nSECRET KEYPAIR: {}
-                        \n--------------------------------------------------------",
-                        item.key_pair_properties.master_seed_phrase,
-                        item.key_pair_properties.seed_phrase_hd_path,
-                        item.key_pair_properties.implicit_account_id,
-                        item.key_pair_properties.public_key_str,
-                        item.key_pair_properties.secret_keypair_str,
-                    ))
-                },
+                move |_transaction, _network_config| Ok(item.generated_key_pair.terminal_info()),
             ),
             on_after_sending_transaction_callback: std::sync::Arc::new(
                 move |_outcome_view, _network_config| Ok(()),

--- a/src/commands/account/add_key/autogenerate_new_keypair/save_keypair_to_keychain/mod.rs
+++ b/src/commands/account/add_key/autogenerate_new_keypair/save_keypair_to_keychain/mod.rs
@@ -57,8 +57,8 @@ impl From<SaveKeypairToKeychainContext> for crate::commands::ActionContext {
                     crate::common::save_access_key_to_keychain_or_save_to_legacy_keychain(
                         network_config.clone(),
                         credentials_home_dir.clone(),
-                        &serde_json::to_string(&item.0.key_pair_properties)?,
-                        &item.0.key_pair_properties.public_key_str,
+                        &item.0.generated_key_pair.keychain_json()?,
+                        item.0.generated_key_pair.public_key_str(),
                         account_id.as_ref(),
                     )
                 }

--- a/src/commands/account/add_key/autogenerate_new_keypair/save_keypair_to_legacy_keychain/mod.rs
+++ b/src/commands/account/add_key/autogenerate_new_keypair/save_keypair_to_legacy_keychain/mod.rs
@@ -14,7 +14,7 @@ pub struct SaveKeypairToLegacyKeychainContext {
     global_context: crate::GlobalContext,
     signer_account_id: near_primitives::types::AccountId,
     permission: near_primitives::account::AccessKeyPermission,
-    key_pair_properties: crate::common::KeyPairProperties,
+    generated_key_pair: crate::common::GeneratedKeyPair,
     public_key: near_crypto::PublicKey,
 }
 
@@ -27,7 +27,7 @@ impl SaveKeypairToLegacyKeychainContext {
             global_context: previous_context.global_context,
             signer_account_id: previous_context.signer_account_id,
             permission: previous_context.permission,
-            key_pair_properties: previous_context.key_pair_properties,
+            generated_key_pair: previous_context.generated_key_pair,
             public_key: previous_context.public_key,
         })
     }
@@ -69,18 +69,18 @@ impl From<SaveKeypairToLegacyKeychainContext> for crate::commands::ActionContext
                             signed_delegate_action,
                         ) => signed_delegate_action.delegate_action.sender_id.clone()
                     };
-                    let key_pair_properties_buf = serde_json::to_string(&item.key_pair_properties)?;
+                    let key_pair_properties_buf = item.generated_key_pair.keychain_json()?;
                     crate::common::save_access_key_to_legacy_keychain(
                         network_config.clone(),
                         credentials_home_dir.clone(),
                         &key_pair_properties_buf,
-                        &item.key_pair_properties.public_key_str,
+                        item.generated_key_pair.public_key_str(),
                         account_id.as_ref(),
                     )
                     .wrap_err_with(|| {
                         format!(
                             "Failed to save a file with access key: {}",
-                            &item.key_pair_properties.public_key_str
+                            item.generated_key_pair.public_key_str()
                         )
                     })
                 }

--- a/src/commands/account/create_account/fund_myself_create_account/add_key/autogenerate_new_keypair/mod.rs
+++ b/src/commands/account/create_account/fund_myself_create_account/add_key/autogenerate_new_keypair/mod.rs
@@ -1,11 +1,13 @@
-use std::str::FromStr;
-
 use strum::{EnumDiscriminants, EnumIter, EnumMessage};
 
 #[derive(Debug, Clone, interactive_clap_derive::InteractiveClap)]
 #[interactive_clap(input_context = super::super::NewAccountContext)]
 #[interactive_clap(output_context = GenerateKeypairContext)]
 pub struct GenerateKeypair {
+    #[interactive_clap(long)]
+    #[interactive_clap(skip_default_input_arg)]
+    /// Which signature scheme should the new key pair use?
+    signature_scheme: crate::common::SignatureScheme,
     #[interactive_clap(subcommand)]
     save_mode: SaveMode,
 }
@@ -14,17 +16,17 @@ pub struct GenerateKeypair {
 pub struct GenerateKeypairContext {
     global_context: crate::GlobalContext,
     account_properties: super::super::AccountProperties,
-    key_pair_properties: crate::common::KeyPairProperties,
+    generated_key_pair: crate::common::GeneratedKeyPair,
 }
 
 impl GenerateKeypairContext {
     pub fn from_previous_context(
         previous_context: super::super::NewAccountContext,
-        _scope: &<GenerateKeypair as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+        scope: &<GenerateKeypair as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
     ) -> color_eyre::eyre::Result<Self> {
-        let key_pair_properties: crate::common::KeyPairProperties =
-            crate::common::generate_keypair()?;
-        let public_key = near_crypto::PublicKey::from_str(&key_pair_properties.public_key_str)?;
+        let generated_key_pair =
+            crate::common::GeneratedKeyPair::generate(&scope.signature_scheme)?;
+        let public_key = generated_key_pair.public_key()?;
         let account_properties = super::super::AccountProperties {
             new_account_id: previous_context.new_account_id,
             initial_balance: previous_context.initial_balance,
@@ -34,8 +36,16 @@ impl GenerateKeypairContext {
         Ok(Self {
             global_context: previous_context.global_context,
             account_properties,
-            key_pair_properties,
+            generated_key_pair,
         })
+    }
+}
+
+impl GenerateKeypair {
+    fn input_signature_scheme(
+        _context: &super::super::NewAccountContext,
+    ) -> color_eyre::eyre::Result<Option<crate::common::SignatureScheme>> {
+        crate::common::input_signature_scheme()
     }
 }
 
@@ -87,44 +97,31 @@ impl SaveModeContext {
         let on_before_sending_transaction_callback: crate::transaction_signature_options::OnBeforeSendingTransactionCallback =
             std::sync::Arc::new({
                 let new_account_id = previous_context.account_properties.new_account_id.clone();
-                let key_pair_properties = previous_context.key_pair_properties.clone();
+                let generated_key_pair = previous_context.generated_key_pair.clone();
                 let credentials_home_dir = previous_context.global_context.config.credentials_home_dir.clone();
 
                 move |_transaction, network_config| {
                     match scope {
                         SaveModeDiscriminants::SaveToKeychain => {
-                            let key_pair_properties_buf =
-                                serde_json::to_string(&key_pair_properties)?;
-                                crate::common::save_access_key_to_keychain_or_save_to_legacy_keychain(
-                                    network_config.clone(),
-                                    credentials_home_dir.clone(),
-                                    &key_pair_properties_buf,
-                                    &key_pair_properties.public_key_str,
-                                    new_account_id.as_ref(),
-                                )
-                            }
+                            crate::common::save_access_key_to_keychain_or_save_to_legacy_keychain(
+                                network_config.clone(),
+                                credentials_home_dir.clone(),
+                                &generated_key_pair.keychain_json()?,
+                                generated_key_pair.public_key_str(),
+                                new_account_id.as_ref(),
+                            )
+                        }
                         SaveModeDiscriminants::SaveToLegacyKeychain => {
-                            let key_pair_properties_buf =
-                                serde_json::to_string(&key_pair_properties)?;
                             crate::common::save_access_key_to_legacy_keychain(
                                 network_config.clone(),
                                 credentials_home_dir.clone(),
-                                &key_pair_properties_buf,
-                                &key_pair_properties.public_key_str,
+                                &generated_key_pair.keychain_json()?,
+                                generated_key_pair.public_key_str(),
                                 new_account_id.as_ref(),
                             )
                         }
                         SaveModeDiscriminants::PrintToTerminal => {
-                            Ok(format!(
-                                "\n--------------------  Access key info ------------------
-                                \nMaster Seed Phrase: {}\nSeed Phrase HD Path: {}\nImplicit Account ID: {}\nPublic Key: {}\nSECRET KEYPAIR: {}
-                                \n--------------------------------------------------------",
-                                key_pair_properties.master_seed_phrase,
-                                key_pair_properties.seed_phrase_hd_path,
-                                key_pair_properties.implicit_account_id,
-                                key_pair_properties.public_key_str,
-                                key_pair_properties.secret_keypair_str,
-                            ))
+                            Ok(generated_key_pair.terminal_info())
                         }
                     }
                 }

--- a/src/commands/account/create_account/sponsor_by_faucet_service/add_key/autogenerate_new_keypair/mod.rs
+++ b/src/commands/account/create_account/sponsor_by_faucet_service/add_key/autogenerate_new_keypair/mod.rs
@@ -1,11 +1,13 @@
-use std::str::FromStr;
-
 use strum::{EnumDiscriminants, EnumIter, EnumMessage};
 
 #[derive(Debug, Clone, interactive_clap_derive::InteractiveClap)]
 #[interactive_clap(input_context = super::super::NewAccountContext)]
 #[interactive_clap(output_context = GenerateKeypairContext)]
 pub struct GenerateKeypair {
+    #[interactive_clap(long)]
+    #[interactive_clap(skip_default_input_arg)]
+    /// Which signature scheme should the new key pair use?
+    signature_scheme: crate::common::SignatureScheme,
     #[interactive_clap(subcommand)]
     save_mode: SaveMode,
 }
@@ -15,27 +17,35 @@ pub struct GenerateKeypairContext {
     config: crate::config::Config,
     new_account_id: crate::types::account_id::AccountId,
     public_key: near_crypto::PublicKey,
-    key_pair_properties: crate::common::KeyPairProperties,
+    generated_key_pair: crate::common::GeneratedKeyPair,
     on_before_creating_account_callback: super::super::network::OnBeforeCreatingAccountCallback,
 }
 
 impl GenerateKeypairContext {
     pub fn from_previous_context(
         previous_context: super::super::NewAccountContext,
-        _scope: &<GenerateKeypair as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+        scope: &<GenerateKeypair as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
     ) -> color_eyre::eyre::Result<Self> {
-        let key_pair_properties: crate::common::KeyPairProperties =
-            crate::common::generate_keypair()?;
-        let public_key = near_crypto::PublicKey::from_str(&key_pair_properties.public_key_str)?;
+        let generated_key_pair =
+            crate::common::GeneratedKeyPair::generate(&scope.signature_scheme)?;
+        let public_key = generated_key_pair.public_key()?;
 
         Ok(Self {
             config: previous_context.config,
             new_account_id: previous_context.new_account_id,
             public_key,
-            key_pair_properties,
+            generated_key_pair,
             on_before_creating_account_callback: previous_context
                 .on_before_creating_account_callback,
         })
+    }
+}
+
+impl GenerateKeypair {
+    fn input_signature_scheme(
+        _context: &super::super::NewAccountContext,
+    ) -> color_eyre::eyre::Result<Option<crate::common::SignatureScheme>> {
+        crate::common::input_signature_scheme()
     }
 }
 
@@ -75,44 +85,31 @@ impl SaveModeContext {
         let on_after_getting_network_callback: super::super::network::OnAfterGettingNetworkCallback =
             std::sync::Arc::new({
                 let new_account_id_str = previous_context.new_account_id.to_string();
-                let key_pair_properties = previous_context.key_pair_properties.clone();
+                let generated_key_pair = previous_context.generated_key_pair.clone();
                 let credentials_home_dir = previous_context.config.credentials_home_dir.clone();
 
                 move |network_config| {
                     match scope {
                         SaveModeDiscriminants::SaveToKeychain => {
-                            let key_pair_properties_buf =
-                                serde_json::to_string(&key_pair_properties)?;
                             crate::common::save_access_key_to_keychain_or_save_to_legacy_keychain(
                                 network_config.clone(),
                                 credentials_home_dir.clone(),
-                                &key_pair_properties_buf,
-                                &key_pair_properties.public_key_str,
+                                &generated_key_pair.keychain_json()?,
+                                generated_key_pair.public_key_str(),
                                 &new_account_id_str,
                             )
                         }
                         SaveModeDiscriminants::SaveToLegacyKeychain => {
-                            let key_pair_properties_buf =
-                                serde_json::to_string(&key_pair_properties)?;
                             crate::common::save_access_key_to_legacy_keychain(
                                 network_config.clone(),
                                 credentials_home_dir.clone(),
-                                &key_pair_properties_buf,
-                                &key_pair_properties.public_key_str,
+                                &generated_key_pair.keychain_json()?,
+                                generated_key_pair.public_key_str(),
                                 &new_account_id_str,
                             )
                         }
                         SaveModeDiscriminants::PrintToTerminal => {
-                            Ok(format!(
-                                "\n--------------------  Access key info ------------------
-                                \nMaster Seed Phrase: {}\nSeed Phrase HD Path: {}\nImplicit Account ID: {}\nPublic Key: {}\nSECRET KEYPAIR: {}
-                                \n--------------------------------------------------------",
-                                key_pair_properties.master_seed_phrase,
-                                key_pair_properties.seed_phrase_hd_path,
-                                key_pair_properties.implicit_account_id,
-                                key_pair_properties.public_key_str,
-                                key_pair_properties.secret_keypair_str,
-                            ))
+                            Ok(generated_key_pair.terminal_info())
                         }
                     }
                 }

--- a/src/commands/account/delete_key/public_keys_to_delete.rs
+++ b/src/commands/account/delete_key/public_keys_to_delete.rs
@@ -110,11 +110,21 @@ impl PublicKeyList {
                 ) {
                 Ok(rpc_query_response) => {
                     let access_key_list_for_network = rpc_query_response.access_key_list_view()?;
-                    access_key_list.extend(access_key_list_for_network.keys.iter().map(
-                        |access_key_info_view| AccessKeyInfo {
-                            public_key: access_key_info_view.public_key.clone(),
-                            permission: access_key_info_view.access_key.permission.clone(),
-                            network_name: network_config.network_name.clone(),
+                    access_key_list.extend(access_key_list_for_network.keys.iter().filter_map(
+                        |access_key_info_view| {
+                            // In 2.13 the access-key list returns a `PublicKeyHandle`.
+                            // ML-DSA-65 keys are stored on-chain only as a hash, so the
+                            // full public key needed to build a DeleteKey action can't be
+                            // recovered here; `full_pubkey()` returns `None` for them and
+                            // they are skipped from the interactive picker.
+                            access_key_info_view
+                                .public_key
+                                .full_pubkey()
+                                .map(|public_key| AccessKeyInfo {
+                                    public_key,
+                                    permission: access_key_info_view.access_key.permission.clone(),
+                                    network_name: network_config.network_name.clone(),
+                                })
                         },
                     ));
                     processed_network.push(network_config.network_name.to_string());

--- a/src/commands/contract/view_storage/output_format/mod.rs
+++ b/src/commands/contract/view_storage/output_format/mod.rs
@@ -37,6 +37,8 @@ pub fn get_contract_state(
                 account_id: contract_account_id.clone(),
                 prefix,
                 include_proof: false,
+                after_key: None,
+                limit: None,
             },
         })
         .wrap_err_with(|| {

--- a/src/commands/generate_keypair/mod.rs
+++ b/src/commands/generate_keypair/mod.rs
@@ -1,0 +1,304 @@
+use color_eyre::eyre::Context;
+use inquire::{CustomType, Select};
+use strum::{EnumDiscriminants, EnumIter, EnumMessage, IntoEnumIterator};
+
+/// Generate a fresh key pair offline, without touching any account or the
+/// network. Supports the classic Ed25519 keys as well as the post-quantum
+/// ML-DSA-65 signature scheme (FIPS 204).
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(input_context = crate::GlobalContext)]
+#[interactive_clap(output_context = GenerateKeypairContext)]
+pub struct GenerateKeypairCommand {
+    #[interactive_clap(value_enum)]
+    #[interactive_clap(skip_default_input_arg)]
+    /// Which signature scheme should the new key pair use?
+    signature_scheme: SignatureScheme,
+    #[interactive_clap(subcommand)]
+    output_mode: OutputMode,
+}
+
+#[derive(Debug, Clone)]
+pub struct GenerateKeypairContext {
+    key_pair: GeneratedKeyPair,
+}
+
+impl GenerateKeypairContext {
+    pub fn from_previous_context(
+        _previous_context: crate::GlobalContext,
+        scope: &<GenerateKeypairCommand as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+    ) -> color_eyre::eyre::Result<Self> {
+        let key_pair = GeneratedKeyPair::generate(&scope.signature_scheme)?;
+        Ok(Self { key_pair })
+    }
+}
+
+impl GenerateKeypairCommand {
+    fn input_signature_scheme(
+        _context: &crate::GlobalContext,
+    ) -> color_eyre::eyre::Result<Option<SignatureScheme>> {
+        let variants = SignatureSchemeDiscriminants::iter().collect::<Vec<_>>();
+        let selected = Select::new(
+            "Which signature scheme should the new key pair use?",
+            variants,
+        )
+        .prompt()?;
+        Ok(Some(match selected {
+            SignatureSchemeDiscriminants::Ed25519 => SignatureScheme::Ed25519,
+            SignatureSchemeDiscriminants::MlDsa65 => SignatureScheme::MlDsa65,
+        }))
+    }
+}
+
+#[derive(Debug, Clone, EnumDiscriminants, clap::ValueEnum)]
+#[strum_discriminants(derive(EnumMessage, EnumIter))]
+/// Which signature scheme should the new key pair use?
+pub enum SignatureScheme {
+    /// Ed25519 (classic, default NEAR key type)
+    #[value(name = "ed25519")]
+    Ed25519,
+    /// ML-DSA-65 post-quantum signature scheme (FIPS 204)
+    #[value(name = "ml-dsa-65")]
+    MlDsa65,
+}
+
+impl interactive_clap::ToCli for SignatureScheme {
+    type CliVariant = SignatureScheme;
+}
+
+impl std::fmt::Display for SignatureScheme {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Self::Ed25519 => write!(f, "ed25519"),
+            Self::MlDsa65 => write!(f, "ml-dsa-65"),
+        }
+    }
+}
+
+impl std::str::FromStr for SignatureScheme {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ed25519" => Ok(Self::Ed25519),
+            "ml-dsa-65" => Ok(Self::MlDsa65),
+            _ => Err(format!("SignatureScheme: invalid value `{s}`")),
+        }
+    }
+}
+
+impl std::fmt::Display for SignatureSchemeDiscriminants {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Self::Ed25519 => write!(f, "ed25519    - Ed25519 (classic, default NEAR key type)"),
+            Self::MlDsa65 => write!(
+                f,
+                "ml-dsa-65  - ML-DSA-65 post-quantum signature scheme (FIPS 204)"
+            ),
+        }
+    }
+}
+
+#[derive(Debug, Clone, EnumDiscriminants, interactive_clap::InteractiveClap)]
+#[interactive_clap(context = GenerateKeypairContext)]
+#[strum_discriminants(derive(EnumMessage, EnumIter))]
+/// How do you want to output the generated key pair?
+pub enum OutputMode {
+    #[strum_discriminants(strum(
+        message = "print-to-terminal  - Print the generated key pair to the terminal"
+    ))]
+    /// Print the generated key pair to the terminal
+    PrintToTerminal(PrintToTerminal),
+    #[strum_discriminants(strum(
+        message = "save-to-file       - Save the generated key pair to a JSON file"
+    ))]
+    /// Save the generated key pair to a JSON file
+    SaveToFile(SaveToFile),
+}
+
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(input_context = GenerateKeypairContext)]
+#[interactive_clap(output_context = PrintToTerminalContext)]
+pub struct PrintToTerminal;
+
+#[derive(Debug, Clone)]
+pub struct PrintToTerminalContext;
+
+impl PrintToTerminalContext {
+    pub fn from_previous_context(
+        previous_context: GenerateKeypairContext,
+        _scope: &<PrintToTerminal as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+    ) -> color_eyre::eyre::Result<Self> {
+        previous_context.key_pair.print_to_terminal();
+        Ok(Self)
+    }
+}
+
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(input_context = GenerateKeypairContext)]
+#[interactive_clap(output_context = SaveToFileContext)]
+pub struct SaveToFile {
+    #[interactive_clap(skip_default_input_arg)]
+    /// What is the path to the JSON file where the key pair should be saved (e.g. ./my-key.json)?
+    file_path: crate::types::path_buf::PathBuf,
+}
+
+#[derive(Debug, Clone)]
+pub struct SaveToFileContext;
+
+impl SaveToFileContext {
+    pub fn from_previous_context(
+        previous_context: GenerateKeypairContext,
+        scope: &<SaveToFile as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+    ) -> color_eyre::eyre::Result<Self> {
+        let file_path: std::path::PathBuf = scope.file_path.clone().into();
+        previous_context.key_pair.save_to_file(&file_path)?;
+        Ok(Self)
+    }
+}
+
+impl SaveToFile {
+    fn input_file_path(
+        _context: &GenerateKeypairContext,
+    ) -> color_eyre::eyre::Result<Option<crate::types::path_buf::PathBuf>> {
+        Ok(Some(
+            CustomType::new(
+                "What is the path to the JSON file where the key pair should be saved?",
+            )
+            .with_starting_input("key.json")
+            .prompt()?,
+        ))
+    }
+}
+
+/// A freshly generated key pair, holding everything we want to display or
+/// persist for the chosen signature scheme.
+#[derive(Debug, Clone)]
+enum GeneratedKeyPair {
+    Ed25519(crate::common::KeyPairProperties),
+    /// ML-DSA-65 keys are random (no seed phrase / HD derivation) and have no
+    /// implicit-account-id form defined yet, so we only keep the key strings.
+    MlDsa65 {
+        public_key: String,
+        private_key: String,
+    },
+}
+
+impl GeneratedKeyPair {
+    fn generate(signature_scheme: &SignatureScheme) -> color_eyre::eyre::Result<Self> {
+        match signature_scheme {
+            SignatureScheme::Ed25519 => Ok(Self::Ed25519(crate::common::generate_keypair()?)),
+            SignatureScheme::MlDsa65 => {
+                let private_key =
+                    near_crypto::SecretKey::from_random(near_crypto::KeyType::MLDSA65);
+                let public_key = private_key.public_key();
+                Ok(Self::MlDsa65 {
+                    public_key: public_key.to_string(),
+                    private_key: private_key.to_string(),
+                })
+            }
+        }
+    }
+
+    fn print_to_terminal(&self) {
+        match self {
+            Self::Ed25519(properties) => {
+                eprintln!(
+                    "\nSignature scheme: Ed25519\
+                     \nMaster Seed Phrase: {}\
+                     \nSeed Phrase HD Path: {}\
+                     \nImplicit Account ID: {}\
+                     \nPublic Key: {}\
+                     \nSECRET KEYPAIR: {}",
+                    properties.master_seed_phrase,
+                    properties.seed_phrase_hd_path,
+                    properties.implicit_account_id,
+                    properties.public_key_str,
+                    properties.secret_keypair_str,
+                );
+            }
+            Self::MlDsa65 {
+                public_key,
+                private_key,
+            } => {
+                eprintln!(
+                    "\nSignature scheme: ML-DSA-65 (post-quantum, FIPS 204)\
+                     \nPublic Key: {public_key}\
+                     \nSECRET KEYPAIR: {private_key}"
+                );
+            }
+        }
+    }
+
+    fn save_to_file(&self, file_path: &std::path::Path) -> color_eyre::eyre::Result<()> {
+        if let Some(parent) = file_path.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            std::fs::create_dir_all(parent)
+                .wrap_err_with(|| format!("Failed to create parent directory for {file_path:?}"))?;
+        }
+        let json = match self {
+            Self::Ed25519(properties) => serde_json::to_string_pretty(properties)?,
+            Self::MlDsa65 {
+                public_key,
+                private_key,
+            } => serde_json::to_string_pretty(&serde_json::json!({
+                "public_key": public_key,
+                "private_key": private_key,
+            }))?,
+        };
+        std::fs::write(file_path, json)
+            .wrap_err_with(|| format!("Failed to write the key pair to {file_path:?}"))?;
+        eprintln!("\nThe key pair was saved to {file_path:?}");
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    #[test]
+    fn ml_dsa_65_keypair_roundtrips() {
+        let key_pair = GeneratedKeyPair::generate(&SignatureScheme::MlDsa65).unwrap();
+        let GeneratedKeyPair::MlDsa65 {
+            public_key,
+            private_key,
+        } = &key_pair
+        else {
+            panic!("expected an ML-DSA-65 key pair");
+        };
+        assert!(public_key.starts_with("ml-dsa-65:"), "{public_key}");
+        assert!(private_key.starts_with("ml-dsa-65:"), "{private_key}");
+
+        // The printed strings must parse back into near_crypto types of the
+        // post-quantum key type, and the secret key must derive the public key.
+        let parsed_public = near_crypto::PublicKey::from_str(public_key).unwrap();
+        let parsed_secret = near_crypto::SecretKey::from_str(private_key).unwrap();
+        // `KeyType` intentionally does not implement `PartialEq` in 2.13, so we
+        // match on the variant instead of comparing with `assert_eq!`.
+        assert!(matches!(
+            parsed_public.key_type(),
+            near_crypto::KeyType::MLDSA65
+        ));
+        assert!(matches!(
+            parsed_secret.key_type(),
+            near_crypto::KeyType::MLDSA65
+        ));
+        assert_eq!(parsed_secret.public_key(), parsed_public);
+
+        // A signature produced by the secret key must verify under the public key.
+        let message = b"post-quantum near-cli-rs";
+        let signature = parsed_secret.sign(message);
+        assert!(signature.verify(message, &parsed_public));
+    }
+
+    #[test]
+    fn ed25519_remains_the_classic_default() {
+        let key_pair = GeneratedKeyPair::generate(&SignatureScheme::Ed25519).unwrap();
+        let GeneratedKeyPair::Ed25519(properties) = &key_pair else {
+            panic!("expected an Ed25519 key pair");
+        };
+        assert!(properties.public_key_str.starts_with("ed25519:"));
+        assert!(near_crypto::PublicKey::from_str(&properties.public_key_str).is_ok());
+    }
+}

--- a/src/commands/generate_keypair/mod.rs
+++ b/src/commands/generate_keypair/mod.rs
@@ -1,6 +1,6 @@
 use color_eyre::eyre::Context;
-use inquire::{CustomType, Select};
-use strum::{EnumDiscriminants, EnumIter, EnumMessage, IntoEnumIterator};
+use inquire::CustomType;
+use strum::{EnumDiscriminants, EnumIter, EnumMessage};
 
 /// Generate a fresh key pair offline, without touching any account or the
 /// network. Supports the classic Ed25519 keys as well as the post-quantum
@@ -9,17 +9,17 @@ use strum::{EnumDiscriminants, EnumIter, EnumMessage, IntoEnumIterator};
 #[interactive_clap(input_context = crate::GlobalContext)]
 #[interactive_clap(output_context = GenerateKeypairContext)]
 pub struct GenerateKeypairCommand {
-    #[interactive_clap(value_enum)]
+    #[interactive_clap(long)]
     #[interactive_clap(skip_default_input_arg)]
     /// Which signature scheme should the new key pair use?
-    signature_scheme: SignatureScheme,
+    signature_scheme: crate::common::SignatureScheme,
     #[interactive_clap(subcommand)]
     output_mode: OutputMode,
 }
 
 #[derive(Debug, Clone)]
 pub struct GenerateKeypairContext {
-    key_pair: GeneratedKeyPair,
+    key_pair: crate::common::GeneratedKeyPair,
 }
 
 impl GenerateKeypairContext {
@@ -27,73 +27,17 @@ impl GenerateKeypairContext {
         _previous_context: crate::GlobalContext,
         scope: &<GenerateKeypairCommand as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
     ) -> color_eyre::eyre::Result<Self> {
-        let key_pair = GeneratedKeyPair::generate(&scope.signature_scheme)?;
-        Ok(Self { key_pair })
+        Ok(Self {
+            key_pair: crate::common::GeneratedKeyPair::generate(&scope.signature_scheme)?,
+        })
     }
 }
 
 impl GenerateKeypairCommand {
     fn input_signature_scheme(
         _context: &crate::GlobalContext,
-    ) -> color_eyre::eyre::Result<Option<SignatureScheme>> {
-        let variants = SignatureSchemeDiscriminants::iter().collect::<Vec<_>>();
-        let selected = Select::new(
-            "Which signature scheme should the new key pair use?",
-            variants,
-        )
-        .prompt()?;
-        Ok(Some(match selected {
-            SignatureSchemeDiscriminants::Ed25519 => SignatureScheme::Ed25519,
-            SignatureSchemeDiscriminants::MlDsa65 => SignatureScheme::MlDsa65,
-        }))
-    }
-}
-
-#[derive(Debug, Clone, EnumDiscriminants, clap::ValueEnum)]
-#[strum_discriminants(derive(EnumMessage, EnumIter))]
-/// Which signature scheme should the new key pair use?
-pub enum SignatureScheme {
-    /// Ed25519 (classic, default NEAR key type)
-    #[value(name = "ed25519")]
-    Ed25519,
-    /// ML-DSA-65 post-quantum signature scheme (FIPS 204)
-    #[value(name = "ml-dsa-65")]
-    MlDsa65,
-}
-
-impl interactive_clap::ToCli for SignatureScheme {
-    type CliVariant = SignatureScheme;
-}
-
-impl std::fmt::Display for SignatureScheme {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match self {
-            Self::Ed25519 => write!(f, "ed25519"),
-            Self::MlDsa65 => write!(f, "ml-dsa-65"),
-        }
-    }
-}
-
-impl std::str::FromStr for SignatureScheme {
-    type Err = String;
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "ed25519" => Ok(Self::Ed25519),
-            "ml-dsa-65" => Ok(Self::MlDsa65),
-            _ => Err(format!("SignatureScheme: invalid value `{s}`")),
-        }
-    }
-}
-
-impl std::fmt::Display for SignatureSchemeDiscriminants {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match self {
-            Self::Ed25519 => write!(f, "ed25519    - Ed25519 (classic, default NEAR key type)"),
-            Self::MlDsa65 => write!(
-                f,
-                "ml-dsa-65  - ML-DSA-65 post-quantum signature scheme (FIPS 204)"
-            ),
-        }
+    ) -> color_eyre::eyre::Result<Option<crate::common::SignatureScheme>> {
+        crate::common::input_signature_scheme()
     }
 }
 
@@ -127,7 +71,7 @@ impl PrintToTerminalContext {
         previous_context: GenerateKeypairContext,
         _scope: &<PrintToTerminal as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
     ) -> color_eyre::eyre::Result<Self> {
-        previous_context.key_pair.print_to_terminal();
+        eprintln!("{}", previous_context.key_pair.terminal_info());
         Ok(Self)
     }
 }
@@ -150,7 +94,15 @@ impl SaveToFileContext {
         scope: &<SaveToFile as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
     ) -> color_eyre::eyre::Result<Self> {
         let file_path: std::path::PathBuf = scope.file_path.clone().into();
-        previous_context.key_pair.save_to_file(&file_path)?;
+        if let Some(parent) = file_path.parent()
+            && !parent.as_os_str().is_empty()
+        {
+            std::fs::create_dir_all(parent)
+                .wrap_err_with(|| format!("Failed to create parent directory for {file_path:?}"))?;
+        }
+        std::fs::write(&file_path, previous_context.key_pair.keychain_json()?)
+            .wrap_err_with(|| format!("Failed to write the key pair to {file_path:?}"))?;
+        eprintln!("\nThe key pair was saved to {file_path:?}");
         Ok(Self)
     }
 }
@@ -169,92 +121,9 @@ impl SaveToFile {
     }
 }
 
-/// A freshly generated key pair, holding everything we want to display or
-/// persist for the chosen signature scheme.
-#[derive(Debug, Clone)]
-enum GeneratedKeyPair {
-    Ed25519(crate::common::KeyPairProperties),
-    /// ML-DSA-65 keys are random (no seed phrase / HD derivation) and have no
-    /// implicit-account-id form defined yet, so we only keep the key strings.
-    MlDsa65 {
-        public_key: String,
-        private_key: String,
-    },
-}
-
-impl GeneratedKeyPair {
-    fn generate(signature_scheme: &SignatureScheme) -> color_eyre::eyre::Result<Self> {
-        match signature_scheme {
-            SignatureScheme::Ed25519 => Ok(Self::Ed25519(crate::common::generate_keypair()?)),
-            SignatureScheme::MlDsa65 => {
-                let private_key =
-                    near_crypto::SecretKey::from_random(near_crypto::KeyType::MLDSA65);
-                let public_key = private_key.public_key();
-                Ok(Self::MlDsa65 {
-                    public_key: public_key.to_string(),
-                    private_key: private_key.to_string(),
-                })
-            }
-        }
-    }
-
-    fn print_to_terminal(&self) {
-        match self {
-            Self::Ed25519(properties) => {
-                eprintln!(
-                    "\nSignature scheme: Ed25519\
-                     \nMaster Seed Phrase: {}\
-                     \nSeed Phrase HD Path: {}\
-                     \nImplicit Account ID: {}\
-                     \nPublic Key: {}\
-                     \nSECRET KEYPAIR: {}",
-                    properties.master_seed_phrase,
-                    properties.seed_phrase_hd_path,
-                    properties.implicit_account_id,
-                    properties.public_key_str,
-                    properties.secret_keypair_str,
-                );
-            }
-            Self::MlDsa65 {
-                public_key,
-                private_key,
-            } => {
-                eprintln!(
-                    "\nSignature scheme: ML-DSA-65 (post-quantum, FIPS 204)\
-                     \nPublic Key: {public_key}\
-                     \nSECRET KEYPAIR: {private_key}"
-                );
-            }
-        }
-    }
-
-    fn save_to_file(&self, file_path: &std::path::Path) -> color_eyre::eyre::Result<()> {
-        if let Some(parent) = file_path.parent()
-            && !parent.as_os_str().is_empty()
-        {
-            std::fs::create_dir_all(parent)
-                .wrap_err_with(|| format!("Failed to create parent directory for {file_path:?}"))?;
-        }
-        let json = match self {
-            Self::Ed25519(properties) => serde_json::to_string_pretty(properties)?,
-            Self::MlDsa65 {
-                public_key,
-                private_key,
-            } => serde_json::to_string_pretty(&serde_json::json!({
-                "public_key": public_key,
-                "private_key": private_key,
-            }))?,
-        };
-        std::fs::write(file_path, json)
-            .wrap_err_with(|| format!("Failed to write the key pair to {file_path:?}"))?;
-        eprintln!("\nThe key pair was saved to {file_path:?}");
-        Ok(())
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::common::{GeneratedKeyPair, SignatureScheme};
     use std::str::FromStr;
 
     #[test]

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -4,6 +4,7 @@ use strum::{EnumDiscriminants, EnumIter, EnumMessage};
 pub mod account;
 mod config;
 pub mod contract;
+pub mod generate_keypair;
 pub mod message;
 mod staking;
 mod tokens;
@@ -48,6 +49,11 @@ pub enum TopLevelCommand {
     ))]
     /// Use this to manage connections in a configuration file (config.toml).
     Config(self::config::ConfigCommands),
+    #[strum_discriminants(strum(
+        message = "generate-keypair - Generate a new key pair offline (Ed25519 or post-quantum ML-DSA-65)"
+    ))]
+    /// Generate a new key pair offline (Ed25519 or post-quantum ML-DSA-65)
+    GenerateKeypair(self::generate_keypair::GenerateKeypairCommand),
     #[cfg(feature = "self-update")]
     #[strum_discriminants(strum(message = "extension   - Manage near CLI and extensions"))]
     /// Use this to manage near CLI and extensions

--- a/src/commands/transaction/reconstruct_transaction/mod.rs
+++ b/src/commands/transaction/reconstruct_transaction/mod.rs
@@ -265,6 +265,9 @@ fn action_transformation(
         Action::Delegate(_) => {
             panic!("Internal error: Delegate action should have been handled before calling action_transformation.");
         }
+        Action::DelegateV2(_) => Err(color_eyre::eyre::eyre!(
+            "Reconstructing DelegateV2 (meta) transactions is not supported."
+        )),
         Action::DeployGlobalContract(action) => {
             let file_path = CustomType::<crate::types::path_buf::PathBuf>::new("Enter the file path where to save the contract:")
                 .with_starting_input("reconstruct-transaction-deploy-code.wasm")

--- a/src/common.rs
+++ b/src/common.rs
@@ -836,6 +836,158 @@ pub fn generate_keypair() -> color_eyre::eyre::Result<KeyPairProperties> {
     Ok(key_pair_properties)
 }
 
+/// Signature scheme to use when autogenerating a new key pair: the classic
+/// Ed25519, or the post-quantum ML-DSA-65 (FIPS 204) scheme that protocol 2.13
+/// adds as a third access-key type.
+#[derive(Debug, Clone, strum::EnumDiscriminants, clap::ValueEnum)]
+#[strum_discriminants(derive(strum::EnumMessage, strum::EnumIter))]
+pub enum SignatureScheme {
+    /// Ed25519 (classic, default NEAR key type)
+    #[value(name = "ed25519")]
+    Ed25519,
+    /// ML-DSA-65 post-quantum signature scheme (FIPS 204)
+    #[value(name = "ml-dsa-65")]
+    MlDsa65,
+}
+
+impl interactive_clap::ToCli for SignatureScheme {
+    type CliVariant = SignatureScheme;
+}
+
+impl std::fmt::Display for SignatureScheme {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Self::Ed25519 => write!(f, "ed25519"),
+            Self::MlDsa65 => write!(f, "ml-dsa-65"),
+        }
+    }
+}
+
+impl std::str::FromStr for SignatureScheme {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ed25519" => Ok(Self::Ed25519),
+            "ml-dsa-65" => Ok(Self::MlDsa65),
+            _ => Err(format!("SignatureScheme: invalid value `{s}`")),
+        }
+    }
+}
+
+impl std::fmt::Display for SignatureSchemeDiscriminants {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Self::Ed25519 => write!(f, "ed25519    - Ed25519 (classic, default NEAR key type)"),
+            Self::MlDsa65 => write!(
+                f,
+                "ml-dsa-65  - ML-DSA-65 post-quantum signature scheme (FIPS 204)"
+            ),
+        }
+    }
+}
+
+/// Shared resolver for the `--signature-scheme` argument of every command that
+/// autogenerates a key pair. When the flag is omitted we default to Ed25519
+/// (so existing non-interactive invocations keep their behaviour) but, in an
+/// interactive terminal, prompt the user to pick instead.
+pub fn input_signature_scheme() -> color_eyre::eyre::Result<Option<SignatureScheme>> {
+    use std::io::IsTerminal;
+    if !std::io::stdin().is_terminal() {
+        return Ok(Some(SignatureScheme::Ed25519));
+    }
+    let variants = SignatureSchemeDiscriminants::iter().collect::<Vec<_>>();
+    let selected = Select::new(
+        "Which signature scheme should the new key pair use?",
+        variants,
+    )
+    .prompt()?;
+    Ok(Some(match selected {
+        SignatureSchemeDiscriminants::Ed25519 => SignatureScheme::Ed25519,
+        SignatureSchemeDiscriminants::MlDsa65 => SignatureScheme::MlDsa65,
+    }))
+}
+
+/// A freshly generated key pair for either supported signature scheme. The
+/// Ed25519 variant keeps the full [`KeyPairProperties`] (seed phrase, HD path,
+/// implicit account id); ML-DSA-65 keys are random and carry only the key
+/// strings (there is no seed phrase or implicit-account form for them yet).
+#[derive(Debug, Clone)]
+pub enum GeneratedKeyPair {
+    Ed25519(KeyPairProperties),
+    MlDsa65 {
+        public_key: String,
+        private_key: String,
+    },
+}
+
+impl GeneratedKeyPair {
+    pub fn generate(signature_scheme: &SignatureScheme) -> color_eyre::eyre::Result<Self> {
+        match signature_scheme {
+            SignatureScheme::Ed25519 => Ok(Self::Ed25519(generate_keypair()?)),
+            SignatureScheme::MlDsa65 => {
+                let private_key =
+                    near_crypto::SecretKey::from_random(near_crypto::KeyType::MLDSA65);
+                Ok(Self::MlDsa65 {
+                    public_key: private_key.public_key().to_string(),
+                    private_key: private_key.to_string(),
+                })
+            }
+        }
+    }
+
+    pub fn public_key_str(&self) -> &str {
+        match self {
+            Self::Ed25519(properties) => &properties.public_key_str,
+            Self::MlDsa65 { public_key, .. } => public_key,
+        }
+    }
+
+    pub fn public_key(&self) -> color_eyre::eyre::Result<near_crypto::PublicKey> {
+        Ok(near_crypto::PublicKey::from_str(self.public_key_str())?)
+    }
+
+    /// JSON written to the keychain / legacy keychain credentials file. Ed25519
+    /// preserves the historical full `KeyPairProperties` layout; ML-DSA-65 uses
+    /// the minimal `{ public_key, private_key }` credentials format (which the
+    /// keychain reader already understands).
+    pub fn keychain_json(&self) -> color_eyre::eyre::Result<String> {
+        Ok(match self {
+            Self::Ed25519(properties) => serde_json::to_string(properties)?,
+            Self::MlDsa65 {
+                public_key,
+                private_key,
+            } => serde_json::to_string(&serde_json::json!({
+                "public_key": public_key,
+                "private_key": private_key,
+            }))?,
+        })
+    }
+
+    /// Human-readable "access key info" block printed to the terminal.
+    pub fn terminal_info(&self) -> String {
+        match self {
+            Self::Ed25519(properties) => format!(
+                "\n--------------------  Access key info ------------------\
+                 \nMaster Seed Phrase: {}\nSeed Phrase HD Path: {}\nImplicit Account ID: {}\nPublic Key: {}\nSECRET KEYPAIR: {}\
+                 \n--------------------------------------------------------",
+                properties.master_seed_phrase,
+                properties.seed_phrase_hd_path,
+                properties.implicit_account_id,
+                properties.public_key_str,
+                properties.secret_keypair_str,
+            ),
+            Self::MlDsa65 {
+                public_key,
+                private_key,
+            } => format!(
+                "\n--------------------  Access key info ------------------\
+                 \nSignature scheme: ML-DSA-65 (post-quantum, FIPS 204)\nPublic Key: {public_key}\nSECRET KEYPAIR: {private_key}\
+                 \n--------------------------------------------------------",
+            ),
+        }
+    }
+}
+
 pub fn print_full_signed_transaction(
     transaction: near_primitives::transaction::SignedTransaction,
 ) -> String {

--- a/src/common.rs
+++ b/src/common.rs
@@ -1016,6 +1016,26 @@ pub fn print_unsigned_transaction(
                 };
                 info_str.push_str(&print_unsigned_transaction(&prepopulated_transaction));
             }
+            near_primitives::transaction::Action::DelegateV2(versioned_signed_delegate_action) => {
+                let actions = versioned_signed_delegate_action
+                    .delegate_action
+                    .get_actions();
+                let (signer_id, receiver_id) =
+                    match &versioned_signed_delegate_action.delegate_action {
+                        near_primitives::action::delegate::VersionedDelegateActionPayload::V2(
+                            delegate_action,
+                        ) => (
+                            delegate_action.sender_id.clone(),
+                            delegate_action.receiver_id.clone(),
+                        ),
+                    };
+                let prepopulated_transaction = crate::commands::PrepopulatedTransaction {
+                    signer_id,
+                    receiver_id,
+                    actions,
+                };
+                info_str.push_str(&print_unsigned_transaction(&prepopulated_transaction));
+            }
             near_primitives::transaction::Action::DeployGlobalContract(deploy) => {
                 let code_hash = CryptoHash::hash_bytes(&deploy.code);
                 let identifier = match deploy.deploy_mode {
@@ -1183,6 +1203,19 @@ fn print_value_successful_transaction(
                 info_str.push_str(&format!(
                     "Actions delegated for <{}> completed successfully.",
                     delegate_action.sender_id,
+                ));
+            }
+            near_primitives::views::ActionView::DelegateV2 {
+                delegate_action,
+                signature: _,
+            } => {
+                let sender_id = match delegate_action {
+                    near_primitives::action::delegate::VersionedDelegateActionPayload::V2(
+                        delegate_action,
+                    ) => delegate_action.sender_id,
+                };
+                info_str.push_str(&format!(
+                    "Actions delegated for <{sender_id}> completed successfully.",
                 ));
             }
             near_primitives::views::ActionView::DeployGlobalContract { code: _ }
@@ -1491,6 +1524,14 @@ pub fn convert_action_error_to_cli_result(
                 account_id
             ))
         }
+        near_primitives::errors::ActionErrorKind::DelegateActionInvalidNonceIndex {
+            nonce_index,
+            num_nonces,
+        } => color_eyre::eyre::Result::Err(color_eyre::eyre::eyre!(
+            "Error: Delegate action used gas-key nonce index {} but the key only has {} nonce(s).",
+            nonce_index,
+            num_nonces
+        )),
     }
 }
 
@@ -1522,6 +1563,12 @@ pub fn convert_invalid_tx_error_to_cli_result(
                 },
                 near_primitives::errors::InvalidAccessKeyError::DepositWithFunctionCall => {
                     color_eyre::eyre::Result::Err(color_eyre::eyre::eyre!("Error: Having a deposit with a function call action is not allowed with a function call access key."))
+                }
+                near_primitives::errors::InvalidAccessKeyError::DelegateActionRequiresNonGasKey => {
+                    color_eyre::eyre::Result::Err(color_eyre::eyre::eyre!("Error: A delegate action signed with a plain access-key nonce must not be signed by a gas key."))
+                }
+                near_primitives::errors::InvalidAccessKeyError::DelegateActionRequiresGasKey => {
+                    color_eyre::eyre::Result::Err(color_eyre::eyre::eyre!("Error: A delegate action signed with a gas-key nonce must be signed by a gas key."))
                 }
             }
         },
@@ -2273,6 +2320,8 @@ pub fn fetch_currently_active_staking_pools(
                 account_id: staking_pools_factory_account_id.clone(),
                 prefix: near_primitives::types::StoreKey::from(b"se".to_vec()),
                 include_proof: false,
+                after_key: None,
+                limit: None,
             },
         })
         .map_err(color_eyre::Report::msg)?;

--- a/src/transaction_signature_options/sign_with_mpc/mod.rs
+++ b/src/transaction_signature_options/sign_with_mpc/mod.rs
@@ -424,6 +424,11 @@ impl DepositContext {
                 near_crypto::KeyType::SECP256K1 => {
                     mpc_sign_request::MpcSignPayload::Ecdsa(hashed_payload)
                 }
+                near_crypto::KeyType::MLDSA65 => {
+                    return Err(color_eyre::eyre::eyre!(
+                        "MPC signing does not support post-quantum ML-DSA-65 keys."
+                    ));
+                }
             };
 
         let mpc_sign_request = mpc_sign_request::MpcSignRequest {
@@ -636,6 +641,11 @@ pub fn near_key_type_to_mpc_domain_id(key_type: near_crypto::KeyType) -> u64 {
     match key_type {
         near_crypto::KeyType::SECP256K1 => 0u64,
         near_crypto::KeyType::ED25519 => 1u64,
+        // MPC only derives ecdsa/eddsa keys; callers reject ML-DSA-65 before
+        // reaching this point (see the payload match above).
+        near_crypto::KeyType::MLDSA65 => {
+            unreachable!("MPC does not support post-quantum ML-DSA-65 keys")
+        }
     }
 }
 


### PR DESCRIPTION
## What

Adds full CLI support for the post-quantum **ML-DSA-65** (FIPS 204) signature scheme that NEAR protocol 2.13 introduces as a third access-key type, alongside the classic **Ed25519**.

**1. A new offline `near generate-keypair` command** — create a key pair for either scheme and print it or save it to a JSON file (no account, no network):

```
near generate-keypair --signature-scheme ml-dsa-65 print-to-terminal
near generate-keypair --signature-scheme ml-dsa-65 save-to-file ./pq-key.json
```

**2. A `--signature-scheme` option on the on-chain autogenerate flows** — `account add-key`, `account create-account fund-myself`, and `account create-account sponsor-by-faucet-service` can now autogenerate and submit an ML-DSA-65 access key:

```
near account add-key alice.testnet grant-full-access \
  autogenerate-new-keypair --signature-scheme ml-dsa-65 save-to-keychain network-config testnet ...
```

The flag **defaults to `ed25519` when omitted** (and only prompts in an interactive terminal), so every existing non-interactive invocation behaves exactly as before. ML-DSA-65 keys are also emitted in the standard `ml-dsa-65:<base58>` string form, so an externally generated key can be added via the existing `account add-key … use-manually-provided-public-key` flow too.

## Why

NEAR protocol **2.13** introduces post-quantum ML-DSA-65 access keys (see near/nearcore#15731). This lands the CLI side: generating PQ key pairs. Related ecosystem work: near/docs#3061, near/near-sdk-rs#1557.

## 2.13 API adaptations

Bumping to 2.13 required adapting to a few `near-primitives` / `near-crypto` changes (unrelated to keygen, but needed to compile):

- New `Action::DelegateV2` / `ActionView::DelegateV2` (v2 meta-transactions) — handled in the transaction display paths.
- New `ActionErrorKind::DelegateActionInvalidNonceIndex` and `InvalidAccessKeyError::DelegateActionRequiresNonGasKey` / `DelegateActionRequiresGasKey` (gas keys) — mapped to CLI error messages.
- `QueryRequest::ViewState` gained `after_key` / `limit` fields.
- The access-key list now returns `PublicKeyHandle`; the delete-key picker uses `full_pubkey()` and skips ML-DSA-65 entries (which are stored on-chain only as a hash, so the full key isn't recoverable for a `DeleteKey` action).
- `KeyType` no longer derives `PartialEq` — comparisons switched to pattern matching.

## Scope / limitations

- ML-DSA-65 keys are generated **randomly** (no seed-phrase / HD recovery — there is no NEAR standard for that yet) and have no implicit-account-id form (deferred to a later protocol milestone), so `create-account` *named*-account flows support them but the `ed25519`-only implicit-account paths are unchanged.
- On-chain use of PQ keys is enabled by the `PostQuantumSignatures` protocol feature, **stabilized at protocol version 85** (the 2.13 stable version) — so the `AddKey` transactions these flows build become valid on a network once it upgrades to protocol 85 with the 2.13 rollout (it is *not* nightly-gated).

## Testing

- New unit tests generate an ML-DSA-65 key pair, parse it back through `near-crypto`, and verify a signature round-trips.
- Full suite green locally: `cargo test --all-features`, `cargo clippy --all-features --all-targets -- -D warnings`, `cargo fmt --check`, and the `--no-default-features` (+`ledger`) checks.
