### PR TITLE
feat: gas-key support (nearcore 2.13)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2698,8 +2698,9 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-client"
-version = "0.21.1"
-source = "git+https://github.com/near/near-jsonrpc-client-rs?rev=4196c34db5c5e6acfc563d62ab16c68b7c666d7e#4196c34db5c5e6acfc563d62ab16c68b7c666d7e"
+version = "0.22.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "249aacedbd175416a3635a83752581225b08a80e34bcba7ff65959c8954cf8e7"
 dependencies = [
  "borsh",
  "lazy_static",
@@ -2896,8 +2897,9 @@ dependencies = [
 
 [[package]]
 name = "near-socialdb-client"
-version = "0.15.1"
-source = "git+https://github.com/near/near-socialdb-client-rs?rev=66580af4ce6736056e3d6f15e6c93f0127b86aad#66580af4ce6736056e3d6f15e6c93f0127b86aad"
+version = "0.16.0-rc.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbf155a85c6b9bd805beff5f7d0cfae6bcd113a952d13d21733d6bc3b9090a89"
 dependencies = [
  "eyre",
  "near-crypto",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,15 +79,14 @@ prettytable = "0.10.0"
 textwrap = "0.16.1"
 
 # TODO(post-quantum): nearcore 2.13 (post-quantum ML-DSA-65 access keys,
-# nearcore#15731). Published 2.13 RC 0.37.0-rc.2; bump to 0.37.0 (drop
-# pre-release) once 2.13 ships stable. The jsonrpc/socialdb clients stay on
-# their matching 2.13 draft revs until they cut crates.io releases.
-near-crypto = "0.37.0-rc.2"
-near-primitives = "0.37.0-rc.2"
-near-jsonrpc-client = { git = "https://github.com/near/near-jsonrpc-client-rs", rev = "4196c34db5c5e6acfc563d62ab16c68b7c666d7e", features = ["any"] }
-near-jsonrpc-primitives = "0.37.0-rc.2"
-near-parameters = "0.37.0-rc.2"
-near-socialdb-client = { git = "https://github.com/near/near-socialdb-client-rs", rev = "66580af4ce6736056e3d6f15e6c93f0127b86aad" }
+# nearcore#15731). Pinned to the published 2.13 RCs; drop the exact `=` and
+# bump to 0.37.0 / stable jsonrpc + socialdb once 2.13 ships stable.
+near-crypto = "=0.37.0-rc.2"
+near-primitives = "=0.37.0-rc.2"
+near-jsonrpc-client = { version = "=0.22.0-rc.1", features = ["any"] }
+near-jsonrpc-primitives = "=0.37.0-rc.2"
+near-parameters = "=0.37.0-rc.2"
+near-socialdb-client = "=0.16.0-rc.1"
 
 near-ledger = { version = "0.9.4", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,8 +79,9 @@ prettytable = "0.10.0"
 textwrap = "0.16.1"
 
 # TODO(post-quantum): nearcore 2.13 (post-quantum ML-DSA-65 access keys,
-# nearcore#15731). Pinned to the published 2.13 RCs; drop the exact `=` and
-# bump to 0.37.0 / stable jsonrpc + socialdb once 2.13 ships stable.
+# nearcore#15731) has no stable crates.io release yet, so every near-* crate
+# below is pinned to an exact `=` 2.13 pre-release (no git deps). Relax these
+# to `0.37` / stable jsonrpc + socialdb once 2.13 ships to mainnet.
 near-crypto = "=0.37.0-rc.2"
 near-primitives = "=0.37.0-rc.2"
 near-jsonrpc-client = { version = "=0.22.0-rc.1", features = ["any"] }

--- a/src/commands/account/add_key/access_key_type/mod.rs
+++ b/src/commands/account/add_key/access_key_type/mod.rs
@@ -179,22 +179,10 @@ fn validate_num_nonces(
     Ok(num_nonces as near_primitives::types::NonceIndex)
 }
 
-/// Prompt for the initial NEAR balance funded into the gas key.
-fn input_gas_key_balance() -> color_eyre::eyre::Result<crate::types::near_token::NearToken> {
-    let balance: crate::types::near_token::NearToken = CustomType::new(
-        "How much NEAR do you want to deposit into the gas key balance (example: 1 NEAR or 0.5 NEAR or 10000 yoctonear)?",
-    )
-    .prompt()?;
-    Ok(balance)
-}
-
 #[derive(Debug, Clone, interactive_clap::InteractiveClap)]
 #[interactive_clap(input_context = super::AddKeyCommandContext)]
 #[interactive_clap(output_context = GasKeyFullAccessTypeContext)]
 pub struct GasKeyFullAccessType {
-    #[interactive_clap(long)]
-    #[interactive_clap(skip_default_input_arg)]
-    balance: crate::types::near_token::NearToken,
     #[interactive_clap(long)]
     #[interactive_clap(skip_default_input_arg)]
     num_nonces: u64,
@@ -217,9 +205,11 @@ impl GasKeyFullAccessTypeContext {
         Ok(Self {
             global_context: previous_context.global_context,
             signer_account_id: previous_context.owner_account_id.into(),
+            // Gas keys must be created empty: the protocol rejects an AddKey that
+            // sets a non-zero gas-key balance. Fund it afterwards with `fund-gas-key`.
             permission: near_primitives::account::AccessKeyPermission::GasKeyFullAccess(
                 near_primitives::account::GasKeyInfo {
-                    balance: scope.balance.into(),
+                    balance: near_token::NearToken::from_yoctonear(0),
                     num_nonces: validate_num_nonces(scope.num_nonces)?,
                 },
             ),
@@ -238,12 +228,6 @@ impl From<GasKeyFullAccessTypeContext> for AccessTypeContext {
 }
 
 impl GasKeyFullAccessType {
-    pub fn input_balance(
-        _context: &super::AddKeyCommandContext,
-    ) -> color_eyre::eyre::Result<Option<crate::types::near_token::NearToken>> {
-        Ok(Some(input_gas_key_balance()?))
-    }
-
     pub fn input_num_nonces(
         _context: &super::AddKeyCommandContext,
     ) -> color_eyre::eyre::Result<Option<u64>> {
@@ -255,9 +239,6 @@ impl GasKeyFullAccessType {
 #[interactive_clap(input_context = super::AddKeyCommandContext)]
 #[interactive_clap(output_context = GasKeyFunctionCallTypeContext)]
 pub struct GasKeyFunctionCallType {
-    #[interactive_clap(long)]
-    #[interactive_clap(skip_default_input_arg)]
-    balance: crate::types::near_token::NearToken,
     #[interactive_clap(long)]
     #[interactive_clap(skip_default_input_arg)]
     num_nonces: u64,
@@ -289,9 +270,11 @@ impl GasKeyFunctionCallTypeContext {
         Ok(Self {
             global_context: previous_context.global_context,
             signer_account_id: previous_context.owner_account_id.into(),
+            // Gas keys must be created empty: the protocol rejects an AddKey that
+            // sets a non-zero gas-key balance. Fund it afterwards with `fund-gas-key`.
             permission: near_primitives::account::AccessKeyPermission::GasKeyFunctionCall(
                 near_primitives::account::GasKeyInfo {
-                    balance: scope.balance.into(),
+                    balance: near_token::NearToken::from_yoctonear(0),
                     num_nonces: validate_num_nonces(scope.num_nonces)?,
                 },
                 near_primitives::account::FunctionCallPermission {
@@ -315,12 +298,6 @@ impl From<GasKeyFunctionCallTypeContext> for AccessTypeContext {
 }
 
 impl GasKeyFunctionCallType {
-    pub fn input_balance(
-        _context: &super::AddKeyCommandContext,
-    ) -> color_eyre::eyre::Result<Option<crate::types::near_token::NearToken>> {
-        Ok(Some(input_gas_key_balance()?))
-    }
-
     pub fn input_num_nonces(
         _context: &super::AddKeyCommandContext,
     ) -> color_eyre::eyre::Result<Option<u64>> {

--- a/src/commands/account/add_key/access_key_type/mod.rs
+++ b/src/commands/account/add_key/access_key_type/mod.rs
@@ -244,9 +244,9 @@ pub struct GasKeyFunctionCallType {
     #[interactive_clap(long)]
     #[interactive_clap(skip_default_input_arg)]
     num_nonces: u64,
-    #[interactive_clap(long)]
-    #[interactive_clap(skip_default_input_arg)]
-    allowance: crate::types::near_allowance::NearAllowance,
+    // No `allowance`: the protocol rejects an AddKey that sets an allowance on a
+    // gas-key function-call key (`GasKeyFunctionCallAllowanceNotAllowed`) - a
+    // gas key pays for gas from its own balance, not from an access-key allowance.
     #[interactive_clap(long)]
     /// Enter the contract account ID that this gas key can be used to sign call function transactions for:
     contract_account_id: crate::types::account_id::AccountId,
@@ -280,7 +280,9 @@ impl GasKeyFunctionCallTypeContext {
                     num_nonces: validate_num_nonces(scope.num_nonces)?,
                 },
                 near_primitives::account::FunctionCallPermission {
-                    allowance: scope.allowance.optional_near_token().map(Into::into),
+                    // Always `None`: the protocol rejects a gas-key function-call
+                    // key that carries an allowance (see the struct field above).
+                    allowance: None,
                     receiver_id: scope.contract_account_id.to_string(),
                     method_names: scope.function_names.clone().into(),
                 },
@@ -304,12 +306,6 @@ impl GasKeyFunctionCallType {
         _context: &super::AddKeyCommandContext,
     ) -> color_eyre::eyre::Result<Option<u64>> {
         Ok(Some(input_num_nonces()?))
-    }
-
-    pub fn input_allowance(
-        context: &super::AddKeyCommandContext,
-    ) -> color_eyre::eyre::Result<Option<crate::types::near_allowance::NearAllowance>> {
-        FunctionCallType::input_allowance(context)
     }
 
     pub fn input_function_names(

--- a/src/commands/account/add_key/access_key_type/mod.rs
+++ b/src/commands/account/add_key/access_key_type/mod.rs
@@ -159,10 +159,12 @@ impl FunctionCallType {
 /// context builder, where it is also bounded by the protocol limit
 /// `AccessKeyPermission::MAX_NONCES_FOR_GAS_KEY`.
 fn input_num_nonces() -> color_eyre::eyre::Result<u64> {
-    let num_nonces: u64 =
-        CustomType::new("How many parallel nonces should this gas key have (1..=1024)?")
-            .with_starting_input("1")
-            .prompt()?;
+    let max = near_primitives::account::AccessKeyPermission::MAX_NONCES_FOR_GAS_KEY;
+    let num_nonces: u64 = CustomType::new(&format!(
+        "How many parallel nonces should this gas key have (1..={max})?"
+    ))
+    .with_starting_input("1")
+    .prompt()?;
     Ok(num_nonces)
 }
 

--- a/src/commands/account/add_key/access_key_type/mod.rs
+++ b/src/commands/account/add_key/access_key_type/mod.rs
@@ -151,3 +151,191 @@ impl FunctionCallType {
         Ok(Some(allowance_near_balance))
     }
 }
+
+/// Prompt for the number of parallel nonces of a gas key.
+///
+/// `interactive_clap` only implements `ToCli` for `u64`/`u128` (not `u16`), so
+/// the CLI field is a `u64` and is narrowed to `NonceIndex` (`u16`) in the
+/// context builder, where it is also bounded by the protocol limit
+/// `AccessKeyPermission::MAX_NONCES_FOR_GAS_KEY`.
+fn input_num_nonces() -> color_eyre::eyre::Result<u64> {
+    let num_nonces: u64 =
+        CustomType::new("How many parallel nonces should this gas key have (1..=1024)?")
+            .with_starting_input("1")
+            .prompt()?;
+    Ok(num_nonces)
+}
+
+/// Narrow a CLI-provided `u64` nonce count to a protocol-valid `NonceIndex`.
+fn validate_num_nonces(
+    num_nonces: u64,
+) -> color_eyre::eyre::Result<near_primitives::types::NonceIndex> {
+    let max = near_primitives::account::AccessKeyPermission::MAX_NONCES_FOR_GAS_KEY;
+    if num_nonces == 0 || num_nonces > u64::from(max) {
+        color_eyre::eyre::bail!(
+            "A gas key must have between 1 and {max} parallel nonces, got {num_nonces}"
+        );
+    }
+    Ok(num_nonces as near_primitives::types::NonceIndex)
+}
+
+/// Prompt for the initial NEAR balance funded into the gas key.
+fn input_gas_key_balance() -> color_eyre::eyre::Result<crate::types::near_token::NearToken> {
+    let balance: crate::types::near_token::NearToken = CustomType::new(
+        "How much NEAR do you want to deposit into the gas key balance (example: 1 NEAR or 0.5 NEAR or 10000 yoctonear)?",
+    )
+    .prompt()?;
+    Ok(balance)
+}
+
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(input_context = super::AddKeyCommandContext)]
+#[interactive_clap(output_context = GasKeyFullAccessTypeContext)]
+pub struct GasKeyFullAccessType {
+    #[interactive_clap(long)]
+    #[interactive_clap(skip_default_input_arg)]
+    balance: crate::types::near_token::NearToken,
+    #[interactive_clap(long)]
+    #[interactive_clap(skip_default_input_arg)]
+    num_nonces: u64,
+    #[interactive_clap(subcommand)]
+    pub access_key_mode: super::AccessKeyMode,
+}
+
+#[derive(Debug, Clone)]
+pub struct GasKeyFullAccessTypeContext {
+    global_context: crate::GlobalContext,
+    signer_account_id: near_primitives::types::AccountId,
+    permission: near_primitives::account::AccessKeyPermission,
+}
+
+impl GasKeyFullAccessTypeContext {
+    pub fn from_previous_context(
+        previous_context: super::AddKeyCommandContext,
+        scope: &<GasKeyFullAccessType as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+    ) -> color_eyre::eyre::Result<Self> {
+        Ok(Self {
+            global_context: previous_context.global_context,
+            signer_account_id: previous_context.owner_account_id.into(),
+            permission: near_primitives::account::AccessKeyPermission::GasKeyFullAccess(
+                near_primitives::account::GasKeyInfo {
+                    balance: scope.balance.into(),
+                    num_nonces: validate_num_nonces(scope.num_nonces)?,
+                },
+            ),
+        })
+    }
+}
+
+impl From<GasKeyFullAccessTypeContext> for AccessTypeContext {
+    fn from(item: GasKeyFullAccessTypeContext) -> Self {
+        Self {
+            global_context: item.global_context,
+            signer_account_id: item.signer_account_id,
+            permission: item.permission,
+        }
+    }
+}
+
+impl GasKeyFullAccessType {
+    pub fn input_balance(
+        _context: &super::AddKeyCommandContext,
+    ) -> color_eyre::eyre::Result<Option<crate::types::near_token::NearToken>> {
+        Ok(Some(input_gas_key_balance()?))
+    }
+
+    pub fn input_num_nonces(
+        _context: &super::AddKeyCommandContext,
+    ) -> color_eyre::eyre::Result<Option<u64>> {
+        Ok(Some(input_num_nonces()?))
+    }
+}
+
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(input_context = super::AddKeyCommandContext)]
+#[interactive_clap(output_context = GasKeyFunctionCallTypeContext)]
+pub struct GasKeyFunctionCallType {
+    #[interactive_clap(long)]
+    #[interactive_clap(skip_default_input_arg)]
+    balance: crate::types::near_token::NearToken,
+    #[interactive_clap(long)]
+    #[interactive_clap(skip_default_input_arg)]
+    num_nonces: u64,
+    #[interactive_clap(long)]
+    #[interactive_clap(skip_default_input_arg)]
+    allowance: crate::types::near_allowance::NearAllowance,
+    #[interactive_clap(long)]
+    /// Enter the contract account ID that this gas key can be used to sign call function transactions for:
+    contract_account_id: crate::types::account_id::AccountId,
+    #[interactive_clap(long)]
+    #[interactive_clap(skip_default_input_arg)]
+    function_names: crate::types::vec_string::VecString,
+    #[interactive_clap(subcommand)]
+    access_key_mode: super::AccessKeyMode,
+}
+
+#[derive(Debug, Clone)]
+pub struct GasKeyFunctionCallTypeContext {
+    global_context: crate::GlobalContext,
+    signer_account_id: near_primitives::types::AccountId,
+    permission: near_primitives::account::AccessKeyPermission,
+}
+
+impl GasKeyFunctionCallTypeContext {
+    pub fn from_previous_context(
+        previous_context: super::AddKeyCommandContext,
+        scope: &<GasKeyFunctionCallType as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+    ) -> color_eyre::eyre::Result<Self> {
+        Ok(Self {
+            global_context: previous_context.global_context,
+            signer_account_id: previous_context.owner_account_id.into(),
+            permission: near_primitives::account::AccessKeyPermission::GasKeyFunctionCall(
+                near_primitives::account::GasKeyInfo {
+                    balance: scope.balance.into(),
+                    num_nonces: validate_num_nonces(scope.num_nonces)?,
+                },
+                near_primitives::account::FunctionCallPermission {
+                    allowance: scope.allowance.optional_near_token().map(Into::into),
+                    receiver_id: scope.contract_account_id.to_string(),
+                    method_names: scope.function_names.clone().into(),
+                },
+            ),
+        })
+    }
+}
+
+impl From<GasKeyFunctionCallTypeContext> for AccessTypeContext {
+    fn from(item: GasKeyFunctionCallTypeContext) -> Self {
+        Self {
+            global_context: item.global_context,
+            signer_account_id: item.signer_account_id,
+            permission: item.permission,
+        }
+    }
+}
+
+impl GasKeyFunctionCallType {
+    pub fn input_balance(
+        _context: &super::AddKeyCommandContext,
+    ) -> color_eyre::eyre::Result<Option<crate::types::near_token::NearToken>> {
+        Ok(Some(input_gas_key_balance()?))
+    }
+
+    pub fn input_num_nonces(
+        _context: &super::AddKeyCommandContext,
+    ) -> color_eyre::eyre::Result<Option<u64>> {
+        Ok(Some(input_num_nonces()?))
+    }
+
+    pub fn input_allowance(
+        context: &super::AddKeyCommandContext,
+    ) -> color_eyre::eyre::Result<Option<crate::types::near_allowance::NearAllowance>> {
+        FunctionCallType::input_allowance(context)
+    }
+
+    pub fn input_function_names(
+        context: &super::AddKeyCommandContext,
+    ) -> color_eyre::eyre::Result<Option<crate::types::vec_string::VecString>> {
+        FunctionCallType::input_function_names(context)
+    }
+}

--- a/src/commands/account/add_key/autogenerate_new_keypair/save_keypair_to_keychain/mod.rs
+++ b/src/commands/account/add_key/autogenerate_new_keypair/save_keypair_to_keychain/mod.rs
@@ -58,7 +58,7 @@ impl From<SaveKeypairToKeychainContext> for crate::commands::ActionContext {
                         network_config.clone(),
                         credentials_home_dir.clone(),
                         &item.0.generated_key_pair.keychain_json()?,
-                        item.0.generated_key_pair.public_key_str(),
+                        &item.0.generated_key_pair.keychain_key_id()?,
                         account_id.as_ref(),
                     )
                 }

--- a/src/commands/account/add_key/autogenerate_new_keypair/save_keypair_to_legacy_keychain/mod.rs
+++ b/src/commands/account/add_key/autogenerate_new_keypair/save_keypair_to_legacy_keychain/mod.rs
@@ -70,18 +70,16 @@ impl From<SaveKeypairToLegacyKeychainContext> for crate::commands::ActionContext
                         ) => signed_delegate_action.delegate_action.sender_id.clone()
                     };
                     let key_pair_properties_buf = item.generated_key_pair.keychain_json()?;
+                    let key_id = item.generated_key_pair.keychain_key_id()?;
                     crate::common::save_access_key_to_legacy_keychain(
                         network_config.clone(),
                         credentials_home_dir.clone(),
                         &key_pair_properties_buf,
-                        item.generated_key_pair.public_key_str(),
+                        &key_id,
                         account_id.as_ref(),
                     )
                     .wrap_err_with(|| {
-                        format!(
-                            "Failed to save a file with access key: {}",
-                            item.generated_key_pair.public_key_str()
-                        )
+                        format!("Failed to save a file with access key: {key_id}")
                     })
                 }
             });

--- a/src/commands/account/add_key/mod.rs
+++ b/src/commands/account/add_key/mod.rs
@@ -64,14 +64,14 @@ pub enum AccessKeyPermission {
     /// Provide data for a function-call access key
     GrantFunctionCallAccess(self::access_key_type::FunctionCallType),
     #[strum_discriminants(strum(
-        message = "grant-gas-key-full-access   - A gas key with full access (balance + parallel nonces)"
+        message = "grant-gas-key-full-access   - A gas key with full access (created empty; fund with fund-gas-key)"
     ))]
-    /// Provide data for a gas key with full access
+    /// Provide data for a gas key with full access (created with zero balance; fund it later with `fund-gas-key`)
     GrantGasKeyFullAccess(self::access_key_type::GasKeyFullAccessType),
     #[strum_discriminants(strum(
-        message = "grant-gas-key-function-call - A gas key with function call (balance + parallel nonces)"
+        message = "grant-gas-key-function-call - A gas key with function call (created empty; fund with fund-gas-key)"
     ))]
-    /// Provide data for a gas key with function call
+    /// Provide data for a gas key with function call (created with zero balance; fund it later with `fund-gas-key`)
     GrantGasKeyFunctionCallAccess(self::access_key_type::GasKeyFunctionCallType),
 }
 

--- a/src/commands/account/add_key/mod.rs
+++ b/src/commands/account/add_key/mod.rs
@@ -63,6 +63,16 @@ pub enum AccessKeyPermission {
     ))]
     /// Provide data for a function-call access key
     GrantFunctionCallAccess(self::access_key_type::FunctionCallType),
+    #[strum_discriminants(strum(
+        message = "grant-gas-key-full-access   - A gas key with full access (balance + parallel nonces)"
+    ))]
+    /// Provide data for a gas key with full access
+    GrantGasKeyFullAccess(self::access_key_type::GasKeyFullAccessType),
+    #[strum_discriminants(strum(
+        message = "grant-gas-key-function-call - A gas key with function call (balance + parallel nonces)"
+    ))]
+    /// Provide data for a gas key with function call
+    GrantGasKeyFunctionCallAccess(self::access_key_type::GasKeyFunctionCallType),
 }
 
 #[derive(Debug, Clone, EnumDiscriminants, interactive_clap::InteractiveClap)]

--- a/src/commands/account/create_account/fund_myself_create_account/add_key/autogenerate_new_keypair/mod.rs
+++ b/src/commands/account/create_account/fund_myself_create_account/add_key/autogenerate_new_keypair/mod.rs
@@ -107,7 +107,7 @@ impl SaveModeContext {
                                 network_config.clone(),
                                 credentials_home_dir.clone(),
                                 &generated_key_pair.keychain_json()?,
-                                generated_key_pair.public_key_str(),
+                                &generated_key_pair.keychain_key_id()?,
                                 new_account_id.as_ref(),
                             )
                         }
@@ -116,7 +116,7 @@ impl SaveModeContext {
                                 network_config.clone(),
                                 credentials_home_dir.clone(),
                                 &generated_key_pair.keychain_json()?,
-                                generated_key_pair.public_key_str(),
+                                &generated_key_pair.keychain_key_id()?,
                                 new_account_id.as_ref(),
                             )
                         }

--- a/src/commands/account/create_account/sponsor_by_faucet_service/add_key/autogenerate_new_keypair/mod.rs
+++ b/src/commands/account/create_account/sponsor_by_faucet_service/add_key/autogenerate_new_keypair/mod.rs
@@ -95,7 +95,7 @@ impl SaveModeContext {
                                 network_config.clone(),
                                 credentials_home_dir.clone(),
                                 &generated_key_pair.keychain_json()?,
-                                generated_key_pair.public_key_str(),
+                                &generated_key_pair.keychain_key_id()?,
                                 &new_account_id_str,
                             )
                         }
@@ -104,7 +104,7 @@ impl SaveModeContext {
                                 network_config.clone(),
                                 credentials_home_dir.clone(),
                                 &generated_key_pair.keychain_json()?,
-                                generated_key_pair.public_key_str(),
+                                &generated_key_pair.keychain_key_id()?,
                                 &new_account_id_str,
                             )
                         }

--- a/src/commands/account/fund_gas_key/mod.rs
+++ b/src/commands/account/fund_gas_key/mod.rs
@@ -1,0 +1,89 @@
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(input_context = crate::GlobalContext)]
+#[interactive_clap(output_context = FundGasKeyContext)]
+pub struct FundGasKeyCommand {
+    #[interactive_clap(skip_default_input_arg)]
+    /// Which account owns the gas key you want to fund?
+    owner_account_id: crate::types::account_id::AccountId,
+    /// Enter the public key of the gas key:
+    public_key: crate::types::public_key::PublicKey,
+    /// How much NEAR do you want to transfer into the gas key balance? (example: 1 NEAR or 0.5 NEAR or 10000 yoctonear)
+    amount: crate::types::near_token::NearToken,
+    #[interactive_clap(named_arg)]
+    /// Select network
+    network_config: crate::network_for_transaction::NetworkForTransactionArgs,
+}
+
+#[derive(Debug, Clone)]
+pub struct FundGasKeyContext {
+    global_context: crate::GlobalContext,
+    owner_account_id: near_primitives::types::AccountId,
+    public_key: crate::types::public_key::PublicKey,
+    amount: crate::types::near_token::NearToken,
+}
+
+impl FundGasKeyContext {
+    pub fn from_previous_context(
+        previous_context: crate::GlobalContext,
+        scope: &<FundGasKeyCommand as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+    ) -> color_eyre::eyre::Result<Self> {
+        Ok(Self {
+            global_context: previous_context,
+            owner_account_id: scope.owner_account_id.clone().into(),
+            public_key: scope.public_key.clone(),
+            amount: scope.amount,
+        })
+    }
+}
+
+impl From<FundGasKeyContext> for crate::commands::ActionContext {
+    fn from(item: FundGasKeyContext) -> Self {
+        let get_prepopulated_transaction_after_getting_network_callback: crate::commands::GetPrepopulatedTransactionAfterGettingNetworkCallback =
+            std::sync::Arc::new({
+                let owner_account_id = item.owner_account_id.clone();
+                let public_key = item.public_key.clone();
+                let amount = item.amount;
+
+                move |_network_config| {
+                    Ok(crate::commands::PrepopulatedTransaction {
+                        signer_id: owner_account_id.clone(),
+                        receiver_id: owner_account_id.clone(),
+                        actions: vec![near_primitives::transaction::Action::TransferToGasKey(
+                            Box::new(near_primitives::action::TransferToGasKeyAction {
+                                public_key: public_key.clone().into(),
+                                deposit: amount.into(),
+                            }),
+                        )],
+                    })
+                }
+            });
+
+        Self {
+            global_context: item.global_context,
+            interacting_with_account_ids: vec![item.owner_account_id],
+            get_prepopulated_transaction_after_getting_network_callback,
+            on_before_signing_callback: std::sync::Arc::new(
+                |_prepopulated_unsigned_transaction, _network_config| Ok(()),
+            ),
+            on_before_sending_transaction_callback: std::sync::Arc::new(
+                |_signed_transaction, _network_config| Ok(String::new()),
+            ),
+            on_after_sending_transaction_callback: std::sync::Arc::new(
+                |_outcome_view, _network_config| Ok(()),
+            ),
+            sign_as_delegate_action: false,
+            on_sending_delegate_action_callback: None,
+        }
+    }
+}
+
+impl FundGasKeyCommand {
+    pub fn input_owner_account_id(
+        context: &crate::GlobalContext,
+    ) -> color_eyre::eyre::Result<Option<crate::types::account_id::AccountId>> {
+        crate::common::input_signer_account_id_from_used_account_list(
+            &context.config.credentials_home_dir,
+            "Which account owns the gas key you want to fund?",
+        )
+    }
+}

--- a/src/commands/account/mod.rs
+++ b/src/commands/account/mod.rs
@@ -5,6 +5,7 @@ pub mod create_account;
 pub mod delete_account;
 pub mod delete_key;
 pub mod export_account;
+mod fund_gas_key;
 mod get_public_key;
 mod import_account;
 mod list_keys;
@@ -12,6 +13,7 @@ pub mod storage_management;
 pub mod update_social_profile;
 pub mod view_account_summary;
 mod view_gas_key_nonces;
+mod withdraw_from_gas_key;
 
 pub const MIN_ALLOWED_TOP_LEVEL_ACCOUNT_LENGTH: usize = 32;
 
@@ -70,6 +72,16 @@ pub enum AccountActions {
     ))]
     /// Add an access key to an account
     AddKey(self::add_key::AddKeyCommand),
+    #[strum_discriminants(strum(
+        message = "fund-gas-key            - Transfer NEAR into a gas key's balance"
+    ))]
+    /// Transfer NEAR into a gas key's balance
+    FundGasKey(self::fund_gas_key::FundGasKeyCommand),
+    #[strum_discriminants(strum(
+        message = "withdraw-from-gas-key   - Withdraw NEAR from a gas key's balance back to the account"
+    ))]
+    /// Withdraw NEAR from a gas key's balance back to the account
+    WithdrawFromGasKey(self::withdraw_from_gas_key::WithdrawFromGasKeyCommand),
     #[strum_discriminants(strum(
         message = "delete-keys             - Delete access keys from an account"
     ))]

--- a/src/commands/account/mod.rs
+++ b/src/commands/account/mod.rs
@@ -11,6 +11,7 @@ mod list_keys;
 pub mod storage_management;
 pub mod update_social_profile;
 pub mod view_account_summary;
+mod view_gas_key_nonces;
 
 pub const MIN_ALLOWED_TOP_LEVEL_ACCOUNT_LENGTH: usize = 32;
 
@@ -54,6 +55,11 @@ pub enum AccountActions {
     ))]
     /// View a list of access keys of an account
     ListKeys(self::list_keys::ViewListKeys),
+    #[strum_discriminants(strum(
+        message = "view-gas-key-nonces     - View the parallel nonces of a gas key"
+    ))]
+    /// View the parallel nonces of a gas key
+    ViewGasKeyNonces(self::view_gas_key_nonces::ViewGasKeyNonces),
     #[strum_discriminants(strum(
         message = "get-public-key          - Get the public key to your account"
     ))]

--- a/src/commands/account/view_gas_key_nonces/mod.rs
+++ b/src/commands/account/view_gas_key_nonces/mod.rs
@@ -39,7 +39,7 @@ impl ViewGasKeyNoncesContext {
                     )
                     .wrap_err_with(|| {
                         format!(
-                            "Failed to fetch query GasKeyNonces for {} on account <{}>",
+                            "Failed to fetch the gas key nonces for {} on account <{}>",
                             &public_key, &account_id
                         )
                     })?

--- a/src/commands/account/view_gas_key_nonces/mod.rs
+++ b/src/commands/account/view_gas_key_nonces/mod.rs
@@ -1,0 +1,76 @@
+use color_eyre::eyre::Context;
+
+use crate::common::JsonRpcClientExt;
+use crate::common::RpcQueryResponseExt;
+
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(input_context = crate::GlobalContext)]
+#[interactive_clap(output_context = ViewGasKeyNoncesContext)]
+pub struct ViewGasKeyNonces {
+    #[interactive_clap(skip_default_input_arg)]
+    /// What Account ID does the gas key belong to?
+    account_id: crate::types::account_id::AccountId,
+    /// Enter the public key of the gas key:
+    public_key: crate::types::public_key::PublicKey,
+    #[interactive_clap(named_arg)]
+    /// Select network
+    network_config: crate::network_view_at_block::NetworkViewAtBlockArgs,
+}
+
+#[derive(Clone)]
+pub struct ViewGasKeyNoncesContext(crate::network_view_at_block::ArgsForViewContext);
+
+impl ViewGasKeyNoncesContext {
+    pub fn from_previous_context(
+        previous_context: crate::GlobalContext,
+        scope: &<ViewGasKeyNonces as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+    ) -> color_eyre::eyre::Result<Self> {
+        let on_after_getting_block_reference_callback: crate::network_view_at_block::OnAfterGettingBlockReferenceCallback = std::sync::Arc::new({
+            let account_id: near_primitives::types::AccountId = scope.account_id.clone().into();
+            let public_key: near_crypto::PublicKey = scope.public_key.clone().into();
+
+            move |network_config, block_reference| {
+                let gas_key_nonces = network_config
+                    .json_rpc_client()
+                    .blocking_call_view_gas_key_nonces(
+                        &account_id,
+                        &public_key,
+                        block_reference.clone(),
+                    )
+                    .wrap_err_with(|| {
+                        format!(
+                            "Failed to fetch query GasKeyNonces for {} on account <{}>",
+                            &public_key, &account_id
+                        )
+                    })?
+                    .gas_key_nonces_view()?;
+
+                crate::common::display_gas_key_nonces(&public_key, &gas_key_nonces.nonces);
+                Ok(())
+            }
+        });
+
+        Ok(Self(crate::network_view_at_block::ArgsForViewContext {
+            config: previous_context.config,
+            interacting_with_account_ids: vec![scope.account_id.clone().into()],
+            on_after_getting_block_reference_callback,
+        }))
+    }
+}
+
+impl From<ViewGasKeyNoncesContext> for crate::network_view_at_block::ArgsForViewContext {
+    fn from(item: ViewGasKeyNoncesContext) -> Self {
+        item.0
+    }
+}
+
+impl ViewGasKeyNonces {
+    pub fn input_account_id(
+        context: &crate::GlobalContext,
+    ) -> color_eyre::eyre::Result<Option<crate::types::account_id::AccountId>> {
+        crate::common::input_non_signer_account_id_from_used_account_list(
+            &context.config.credentials_home_dir,
+            "What Account ID does the gas key belong to?",
+        )
+    }
+}

--- a/src/commands/account/withdraw_from_gas_key/mod.rs
+++ b/src/commands/account/withdraw_from_gas_key/mod.rs
@@ -1,0 +1,89 @@
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(input_context = crate::GlobalContext)]
+#[interactive_clap(output_context = WithdrawFromGasKeyContext)]
+pub struct WithdrawFromGasKeyCommand {
+    #[interactive_clap(skip_default_input_arg)]
+    /// Which account owns the gas key you want to withdraw from?
+    owner_account_id: crate::types::account_id::AccountId,
+    /// Enter the public key of the gas key:
+    public_key: crate::types::public_key::PublicKey,
+    /// How much NEAR do you want to withdraw from the gas key balance back to the account? (example: 1 NEAR or 0.5 NEAR or 10000 yoctonear)
+    amount: crate::types::near_token::NearToken,
+    #[interactive_clap(named_arg)]
+    /// Select network
+    network_config: crate::network_for_transaction::NetworkForTransactionArgs,
+}
+
+#[derive(Debug, Clone)]
+pub struct WithdrawFromGasKeyContext {
+    global_context: crate::GlobalContext,
+    owner_account_id: near_primitives::types::AccountId,
+    public_key: crate::types::public_key::PublicKey,
+    amount: crate::types::near_token::NearToken,
+}
+
+impl WithdrawFromGasKeyContext {
+    pub fn from_previous_context(
+        previous_context: crate::GlobalContext,
+        scope: &<WithdrawFromGasKeyCommand as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+    ) -> color_eyre::eyre::Result<Self> {
+        Ok(Self {
+            global_context: previous_context,
+            owner_account_id: scope.owner_account_id.clone().into(),
+            public_key: scope.public_key.clone(),
+            amount: scope.amount,
+        })
+    }
+}
+
+impl From<WithdrawFromGasKeyContext> for crate::commands::ActionContext {
+    fn from(item: WithdrawFromGasKeyContext) -> Self {
+        let get_prepopulated_transaction_after_getting_network_callback: crate::commands::GetPrepopulatedTransactionAfterGettingNetworkCallback =
+            std::sync::Arc::new({
+                let owner_account_id = item.owner_account_id.clone();
+                let public_key = item.public_key.clone();
+                let amount = item.amount;
+
+                move |_network_config| {
+                    Ok(crate::commands::PrepopulatedTransaction {
+                        signer_id: owner_account_id.clone(),
+                        receiver_id: owner_account_id.clone(),
+                        actions: vec![near_primitives::transaction::Action::WithdrawFromGasKey(
+                            Box::new(near_primitives::action::WithdrawFromGasKeyAction {
+                                public_key: public_key.clone().into(),
+                                amount: amount.into(),
+                            }),
+                        )],
+                    })
+                }
+            });
+
+        Self {
+            global_context: item.global_context,
+            interacting_with_account_ids: vec![item.owner_account_id],
+            get_prepopulated_transaction_after_getting_network_callback,
+            on_before_signing_callback: std::sync::Arc::new(
+                |_prepopulated_unsigned_transaction, _network_config| Ok(()),
+            ),
+            on_before_sending_transaction_callback: std::sync::Arc::new(
+                |_signed_transaction, _network_config| Ok(String::new()),
+            ),
+            on_after_sending_transaction_callback: std::sync::Arc::new(
+                |_outcome_view, _network_config| Ok(()),
+            ),
+            sign_as_delegate_action: false,
+            on_sending_delegate_action_callback: None,
+        }
+    }
+}
+
+impl WithdrawFromGasKeyCommand {
+    pub fn input_owner_account_id(
+        context: &crate::GlobalContext,
+    ) -> color_eyre::eyre::Result<Option<crate::types::account_id::AccountId>> {
+        crate::common::input_signer_account_id_from_used_account_list(
+            &context.config.credentials_home_dir,
+            "Which account owns the gas key you want to withdraw from?",
+        )
+    }
+}

--- a/src/commands/generate_keypair/mod.rs
+++ b/src/commands/generate_keypair/mod.rs
@@ -170,4 +170,37 @@ mod tests {
         assert!(properties.public_key_str.starts_with("ed25519:"));
         assert!(near_crypto::PublicKey::from_str(&properties.public_key_str).is_ok());
     }
+
+    // The keychain / legacy-keychain identifier a key is *saved* under must
+    // equal the string the RPC access-key list reports (a
+    // `near_crypto::PublicKeyHandle`), because that is what the signers look the
+    // key up by. For ed25519 that is the full public key; for ML-DSA-65 it is
+    // the short `ml-dsa-65-hash:...` handle, never the ~1952-byte full key.
+    #[test]
+    fn ed25519_keychain_id_is_the_full_public_key() {
+        let key_pair = GeneratedKeyPair::generate(&SignatureScheme::Ed25519).unwrap();
+        assert_eq!(
+            key_pair.keychain_key_id().unwrap(),
+            key_pair.public_key_str()
+        );
+    }
+
+    #[test]
+    fn ml_dsa_65_keychain_id_is_the_on_chain_handle() {
+        let key_pair = GeneratedKeyPair::generate(&SignatureScheme::MlDsa65).unwrap();
+        let key_id = key_pair.keychain_key_id().unwrap();
+
+        // The saved id is the on-trie handle, not the full key.
+        assert!(key_id.starts_with("ml-dsa-65-hash:"), "{key_id}");
+        assert_ne!(key_id, key_pair.public_key_str());
+        // Bounded length (well under any filesystem name limit), unlike the
+        // ~2.6KB full ML-DSA-65 key string.
+        assert!(key_id.len() < 80, "{} chars", key_id.len());
+
+        // It must be exactly what the RPC access-key list would report for this
+        // key (`PublicKeyHandle`), so a saved key can be found again for signing.
+        let public_key = key_pair.public_key().unwrap();
+        let handle = near_crypto::PublicKeyHandle::from(&public_key).to_string();
+        assert_eq!(key_id, handle);
+    }
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -946,6 +946,26 @@ impl GeneratedKeyPair {
         Ok(near_crypto::PublicKey::from_str(self.public_key_str())?)
     }
 
+    /// Identifier under which this key's credentials are stored: the keychain
+    /// entry name and the legacy-keychain file name. It must equal the
+    /// public-key string the RPC access-key list returns, because that is what
+    /// `sign_with_keychain` / the legacy-keychain signer look the saved key up
+    /// by — otherwise a key saved here can never be found again.
+    ///
+    /// For ed25519 this is the full public-key string, unchanged. For ML-DSA-65
+    /// the on-chain identifier is the short `ml-dsa-65-hash:...` SHA3-256 handle
+    /// (`near_crypto::PublicKeyHandle`), not the ~1952-byte full key: the full
+    /// key would blow past filesystem name limits and would never match the
+    /// handle the chain reports for the key.
+    pub fn keychain_key_id(&self) -> color_eyre::eyre::Result<String> {
+        Ok(match self {
+            Self::Ed25519(properties) => properties.public_key_str.clone(),
+            Self::MlDsa65 { .. } => {
+                near_crypto::PublicKeyHandle::from(&self.public_key()?).to_string()
+            }
+        })
+    }
+
     /// JSON written to the keychain / legacy keychain credentials file. Ed25519
     /// preserves the historical full `KeyPairProperties` layout; ML-DSA-65 uses
     /// the minimal `{ public_key, private_key }` credentials format (which the

--- a/src/common.rs
+++ b/src/common.rs
@@ -2914,6 +2914,22 @@ pub fn display_access_key_list(access_keys: &[near_primitives::views::AccessKeyI
     table.printstd();
 }
 
+pub fn display_gas_key_nonces(
+    public_key: &near_crypto::PublicKey,
+    nonces: &[near_primitives::types::Nonce],
+) {
+    eprintln!("Gas key nonces for public key {public_key}:");
+    let mut table = Table::new();
+    table.set_titles(prettytable::row![Fg=>"Nonce index", "Nonce"]);
+
+    for (nonce_index, nonce) in nonces.iter().enumerate() {
+        table.add_row(prettytable::row![Fg->nonce_index, nonce]);
+    }
+
+    table.set_format(*prettytable::format::consts::FORMAT_NO_LINESEP_WITH_TITLE);
+    table.printstd();
+}
+
 /// Interactive prompt for network name.
 ///
 /// If account_ids is provided, show the network connections that are more
@@ -2993,6 +3009,16 @@ pub trait JsonRpcClientExt {
     fn blocking_call_view_access_key_list(
         &self,
         account_id: &near_primitives::types::AccountId,
+        block_reference: near_primitives::types::BlockReference,
+    ) -> BoxedJsonRpcResult<
+        near_jsonrpc_primitives::types::query::RpcQueryResponse,
+        near_jsonrpc_primitives::types::query::RpcQueryError,
+    >;
+
+    fn blocking_call_view_gas_key_nonces(
+        &self,
+        account_id: &near_primitives::types::AccountId,
+        public_key: &near_crypto::PublicKey,
         block_reference: near_primitives::types::BlockReference,
     ) -> BoxedJsonRpcResult<
         near_jsonrpc_primitives::types::query::RpcQueryResponse,
@@ -3225,6 +3251,41 @@ impl JsonRpcClientExt for near_jsonrpc_client::JsonRpcClient {
             .inspect(teach_me_call_response)
     }
 
+    #[tracing::instrument(name = "Getting gas key nonces for", skip_all)]
+    fn blocking_call_view_gas_key_nonces(
+        &self,
+        account_id: &near_primitives::types::AccountId,
+        public_key: &near_crypto::PublicKey,
+        block_reference: near_primitives::types::BlockReference,
+    ) -> BoxedJsonRpcResult<
+        near_jsonrpc_primitives::types::query::RpcQueryResponse,
+        near_jsonrpc_primitives::types::query::RpcQueryError,
+    > {
+        tracing::Span::current().pb_set_message(&format!(
+            "gas key {public_key} on account <{account_id}>..."
+        ));
+        tracing::info!(target: "near_teach_me", "Getting gas key nonces for public key {public_key} on account <{account_id}>...");
+
+        let query_view_method_request = near_jsonrpc_client::methods::query::RpcQueryRequest {
+            block_reference,
+            request: near_primitives::views::QueryRequest::ViewGasKeyNonces {
+                account_id: account_id.clone(),
+                public_key: public_key.clone(),
+            },
+        };
+
+        tracing::info!(
+            target: "near_teach_me",
+            parent: &tracing::Span::none(),
+            "I am making HTTP call to NEAR JSON RPC to get the gas key nonces for public key {} on account <{}>",
+            public_key,
+            account_id
+        );
+
+        self.blocking_call(query_view_method_request)
+            .inspect(teach_me_call_response)
+    }
+
     #[tracing::instrument(name = "Getting information about", skip_all)]
     fn blocking_call_view_account(
         &self,
@@ -3411,6 +3472,21 @@ pub impl near_jsonrpc_primitives::types::query::RpcQueryResponse {
         } else {
             color_eyre::eyre::bail!(
                 "Internal error: Received unexpected query kind in response to a View Access Key List query call",
+            );
+        }
+    }
+
+    fn gas_key_nonces_view(
+        &self,
+    ) -> color_eyre::eyre::Result<near_primitives::views::GasKeyNoncesView> {
+        if let near_jsonrpc_primitives::types::query::QueryResponseKind::GasKeyNonces(
+            gas_key_nonces,
+        ) = &self.kind
+        {
+            Ok(gas_key_nonces.clone())
+        } else {
+            color_eyre::eyre::bail!(
+                "Internal error: Received unexpected query kind in response to a View Gas Key Nonces query call",
             );
         }
     }

--- a/src/transaction_signature_options/sign_with_mpc/mod.rs
+++ b/src/transaction_signature_options/sign_with_mpc/mod.rs
@@ -641,8 +641,10 @@ pub fn near_key_type_to_mpc_domain_id(key_type: near_crypto::KeyType) -> u64 {
     match key_type {
         near_crypto::KeyType::SECP256K1 => 0u64,
         near_crypto::KeyType::ED25519 => 1u64,
-        // MPC only derives ecdsa/eddsa keys; callers reject ML-DSA-65 before
-        // reaching this point (see the payload match above).
+        // MPC has no domain for post-quantum keys. Both callers exclude
+        // ML-DSA-65 before reaching here: the signing payload match returns an
+        // error for it, and `derive_public_key` is only ever given a key type
+        // chosen from `MpcKeyType`, which offers ed25519 / secp256k1 only.
         near_crypto::KeyType::MLDSA65 => {
             unreachable!("MPC does not support post-quantum ML-DSA-65 keys")
         }


### PR DESCRIPTION
## Cause

nearcore 2.13 (protocol v85) introduces gas keys: an access-key permission that
carries its own NEAR balance and `N` parallel nonces. near-cli has no way to
create one, fund it, or inspect its nonces.

## Fix

Stacked on the nearcore-2.13 branch (#605):

- **Create** — `account add-key` gains two permission variants,
  `grant-gas-key-full-access` and `grant-gas-key-function-call`, that build an
  `AddKey` action with `AccessKeyPermission::GasKeyFullAccess` /
  `GasKeyFunctionCall`. Gas keys are created **empty** (the protocol rejects an
  `AddKey` with a non-zero gas-key balance), so there is no balance argument;
  fund the key afterwards with `fund-gas-key`. The function-call variant takes a
  contract id and method names but **no allowance** (the protocol rejects an
  allowance on a gas-key function-call key). The parallel-nonce count is
  collected as `u64` (interactive-clap has no `ToCli for u16`) and narrowed to
  `NonceIndex` with a `1..=MAX_NONCES_FOR_GAS_KEY` bound check.
- **Fund** — `account fund-gas-key` transfers NEAR from the account into a gas
  key's balance.
- **Withdraw** — `account withdraw-from-gas-key` moves NEAR from a gas key's
  balance back to the account.
- **View** — `account view-gas-key-nonces <account> <public-key>` issues the
  `view_gas_key_nonces` query (via the generic `QueryRequest::ViewGasKeyNonces`
  path) and prints the per-index nonces from `GasKeyNoncesView`.

Signing a transaction with a specific `GasKeyNonce` (DelegateV2 / parallel-nonce
signing) remains a follow-up increment.
