### PR TITLE
feat: sign transactions with a gas key (nonce_index)

### DIFF
--- a/src/transaction_signature_options/mod.rs
+++ b/src/transaction_signature_options/mod.rs
@@ -262,7 +262,9 @@ pub fn nonce_index_from_cli(
 }
 
 /// Returns `true` if the access key permission is a gas key.
-fn is_gas_key_permission(permission: &near_primitives::views::AccessKeyPermissionView) -> bool {
+pub(crate) fn is_gas_key_permission(
+    permission: &near_primitives::views::AccessKeyPermissionView,
+) -> bool {
     matches!(
         permission,
         near_primitives::views::AccessKeyPermissionView::GasKeyFullAccess { .. }
@@ -334,8 +336,10 @@ pub fn resolve_online_nonce(
         }
     } else {
         if let Some(nonce_index) = nonce_index {
-            tracing::warn!(
-                "--nonce-index {nonce_index} was provided but {public_key} is not a gas key; ignoring it"
+            // Refuse rather than silently sign with a plain nonce: the user asked
+            // for a specific gas-key parallel nonce, but this key isn't a gas key.
+            color_eyre::eyre::bail!(
+                "--nonce-index {nonce_index} was provided, but access key {public_key} on {signer_id} is not a gas key. Only gas keys have parallel nonces; omit --nonce-index to sign with an ordinary access key."
             );
         }
         NonceResolution::Plain {

--- a/src/transaction_signature_options/mod.rs
+++ b/src/transaction_signature_options/mod.rs
@@ -153,13 +153,33 @@ impl From<near_primitives::action::delegate::SignedDelegateAction>
     }
 }
 
+/// A gas key cannot be used to sign a meta-transaction yet: a (v1)
+/// `DelegateAction` only carries a plain `nonce`, so delegating a gas-key
+/// transaction would drop its `nonce_index` and the runtime would reject the
+/// result (`DelegateActionRequiresNonGasKey`). Full support needs DelegateV2,
+/// which is out of the 2.13 scope. Reject the combination up front with a clear
+/// error. Called from every delegate-action path (the shared
+/// [`get_signed_delegate_action`] and the two Ledger manual branches).
+pub fn ensure_gas_key_not_delegated(
+    unsigned_transaction: &near_primitives::transaction::Transaction,
+) -> color_eyre::eyre::Result<()> {
+    if unsigned_transaction.nonce().nonce_index().is_some() {
+        color_eyre::eyre::bail!(
+            "Signing with a gas key is not supported for meta-transactions (--sign-as-delegate-action) yet: a DelegateAction cannot carry the gas key's nonce index (requires DelegateV2). Re-run without --sign-as-delegate-action, or sign with an ordinary access key."
+        );
+    }
+    Ok(())
+}
+
 pub fn get_signed_delegate_action(
     unsigned_transaction: near_primitives::transaction::Transaction,
     public_key: &near_crypto::PublicKey,
     private_key: near_crypto::SecretKey,
     max_block_height: u64,
-) -> near_primitives::action::delegate::SignedDelegateAction {
+) -> color_eyre::eyre::Result<near_primitives::action::delegate::SignedDelegateAction> {
     use near_primitives::signable_message::{SignableMessage, SignableMessageType};
+
+    ensure_gas_key_not_delegated(&unsigned_transaction)?;
 
     let mut delegate_action = near_primitives::action::delegate::DelegateAction {
         sender_id: unsigned_transaction.signer_id().clone(),
@@ -193,10 +213,10 @@ pub fn get_signed_delegate_action(
         ))
     );
 
-    near_primitives::action::delegate::SignedDelegateAction {
+    Ok(near_primitives::action::delegate::SignedDelegateAction {
         delegate_action,
         signature,
-    }
+    })
 }
 
 /// The nonce (and, for gas keys, the nonce index) to use for the next transaction.
@@ -364,5 +384,50 @@ pub fn build_unsigned_transaction(
                 },
             )
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_tx_v0() -> near_primitives::transaction::TransactionV0 {
+        near_primitives::transaction::TransactionV0 {
+            signer_id: "alice.near".parse().unwrap(),
+            public_key: near_crypto::SecretKey::from_random(near_crypto::KeyType::ED25519)
+                .public_key(),
+            nonce: 1,
+            receiver_id: "bob.near".parse().unwrap(),
+            block_hash: near_primitives::hash::CryptoHash::default(),
+            actions: vec![],
+        }
+    }
+
+    #[test]
+    fn nonce_index_from_cli_bounds() {
+        let max = u64::from(near_primitives::account::AccessKeyPermission::MAX_NONCES_FOR_GAS_KEY);
+        // The largest valid index is `max - 1`; `max` and above are rejected.
+        assert!(nonce_index_from_cli(max - 1).is_ok());
+        assert!(nonce_index_from_cli(max).is_err());
+    }
+
+    #[test]
+    fn plain_transactions_may_be_delegated() {
+        let tx = build_unsigned_transaction(sample_tx_v0(), NonceResolution::Plain { nonce: 1 });
+        assert!(ensure_gas_key_not_delegated(&tx).is_ok());
+    }
+
+    #[test]
+    fn gas_key_transactions_cannot_be_delegated() {
+        // A gas-key nonce carries a nonce_index that a v1 DelegateAction can't
+        // encode, so meta-transactions must be refused up front.
+        let tx = build_unsigned_transaction(
+            sample_tx_v0(),
+            NonceResolution::GasKey {
+                nonce: 1,
+                nonce_index: 0,
+            },
+        );
+        assert!(ensure_gas_key_not_delegated(&tx).is_err());
     }
 }

--- a/src/transaction_signature_options/mod.rs
+++ b/src/transaction_signature_options/mod.rs
@@ -198,3 +198,171 @@ pub fn get_signed_delegate_action(
         signature,
     }
 }
+
+/// The nonce (and, for gas keys, the nonce index) to use for the next transaction.
+///
+/// Determined once by [`resolve_online_nonce`] / [`resolve_offline_nonce`] and then
+/// consumed by [`build_unsigned_transaction`] to pick the transaction version.
+#[derive(Debug, Clone, Copy)]
+pub enum NonceResolution {
+    /// Ordinary access key: a plain nonce, builds a (V0) transaction.
+    Plain {
+        nonce: near_primitives::types::Nonce,
+    },
+    /// Gas key: a nonce at a specific parallel-nonce index, builds a V1 transaction.
+    GasKey {
+        nonce: near_primitives::types::Nonce,
+        nonce_index: near_primitives::types::NonceIndex,
+    },
+}
+
+impl NonceResolution {
+    /// The nonce value, used to populate the intermediate `TransactionV0.nonce` field
+    /// (which is preserved as-is for the plain path and superseded for the gas-key path).
+    pub fn nonce(&self) -> near_primitives::types::Nonce {
+        match self {
+            NonceResolution::Plain { nonce } | NonceResolution::GasKey { nonce, .. } => *nonce,
+        }
+    }
+}
+
+/// `interactive-clap` only implements `ToCli` for `u64`/`u128`, not `u16`, so the
+/// `--nonce-index` CLI field is collected as `u64` and narrowed here, bounded by the
+/// protocol limit `AccessKeyPermission::MAX_NONCES_FOR_GAS_KEY`.
+pub fn nonce_index_from_cli(
+    nonce_index: u64,
+) -> color_eyre::eyre::Result<near_primitives::types::NonceIndex> {
+    let max = near_primitives::account::AccessKeyPermission::MAX_NONCES_FOR_GAS_KEY;
+    if nonce_index >= u64::from(max) {
+        color_eyre::eyre::bail!(
+            "--nonce-index must be less than the gas key's number of parallel nonces (at most {max}), got {nonce_index}"
+        );
+    }
+    Ok(nonce_index as near_primitives::types::NonceIndex)
+}
+
+/// Returns `true` if the access key permission is a gas key.
+fn is_gas_key_permission(permission: &near_primitives::views::AccessKeyPermissionView) -> bool {
+    matches!(
+        permission,
+        near_primitives::views::AccessKeyPermissionView::GasKeyFullAccess { .. }
+            | near_primitives::views::AccessKeyPermissionView::GasKeyFunctionCall { .. }
+    )
+}
+
+/// Online path: query the access key for `signer_id`/`public_key` and resolve the next
+/// nonce, the recent block hash and block height.
+///
+/// For an ordinary access key this is `access_key.nonce + 1` (unchanged behavior). For a
+/// gas key it queries `view_gas_key_nonces` and uses `nonces[nonce_index] + 1`; when no
+/// `--nonce-index` was given, index 0 is used.
+pub fn resolve_online_nonce(
+    json_rpc_client: &near_jsonrpc_client::JsonRpcClient,
+    signer_id: &near_primitives::types::AccountId,
+    public_key: &near_crypto::PublicKey,
+    nonce_index: Option<near_primitives::types::NonceIndex>,
+    network_name: &str,
+) -> color_eyre::eyre::Result<(
+    NonceResolution,
+    near_primitives::hash::CryptoHash,
+    near_primitives::types::BlockHeight,
+)> {
+    use crate::common::JsonRpcClientExt;
+    use crate::common::RpcQueryResponseExt;
+    use color_eyre::eyre::WrapErr;
+
+    let rpc_query_response = json_rpc_client
+        .blocking_call_view_access_key(
+            signer_id,
+            public_key,
+            near_primitives::types::BlockReference::latest(),
+        )
+        .wrap_err_with(|| {
+            format!("Cannot sign a transaction due to an error while fetching the most recent nonce value on network <{network_name}>")
+        })?;
+    let access_key = rpc_query_response
+        .access_key_view()
+        .wrap_err("Error current_nonce")?;
+    let block_hash = rpc_query_response.block_hash;
+    let block_height = rpc_query_response.block_height;
+
+    let resolution = if is_gas_key_permission(&access_key.permission) {
+        let nonce_index = nonce_index.unwrap_or(0);
+        let gas_key_nonces = json_rpc_client
+            .blocking_call_view_gas_key_nonces(
+                signer_id,
+                public_key,
+                near_primitives::types::BlockReference::latest(),
+            )
+            .wrap_err_with(|| {
+                format!("Cannot sign a transaction due to an error while fetching gas key nonces on network <{network_name}>")
+            })?
+            .gas_key_nonces_view()?;
+        let current = *gas_key_nonces
+            .nonces
+            .get(usize::from(nonce_index))
+            .ok_or_else(|| {
+                color_eyre::eyre::eyre!(
+                    "Gas key has {} parallel nonce(s); --nonce-index {} is out of range",
+                    gas_key_nonces.nonces.len(),
+                    nonce_index
+                )
+            })?;
+        NonceResolution::GasKey {
+            nonce: current + 1,
+            nonce_index,
+        }
+    } else {
+        if let Some(nonce_index) = nonce_index {
+            tracing::warn!(
+                "--nonce-index {nonce_index} was provided but {public_key} is not a gas key; ignoring it"
+            );
+        }
+        NonceResolution::Plain {
+            nonce: access_key.nonce + 1,
+        }
+    };
+
+    Ok((resolution, block_hash, block_height))
+}
+
+/// Offline path: build the nonce resolution from a user-provided nonce and optional
+/// `--nonce-index` (a gas-key nonce when an index is given, otherwise a plain nonce).
+pub fn resolve_offline_nonce(
+    nonce: near_primitives::types::Nonce,
+    nonce_index: Option<near_primitives::types::NonceIndex>,
+) -> NonceResolution {
+    match nonce_index {
+        Some(nonce_index) => NonceResolution::GasKey { nonce, nonce_index },
+        None => NonceResolution::Plain { nonce },
+    }
+}
+
+/// Wrap a (post-`on_before_signing_callback`) [`TransactionV0`] into the right transaction
+/// version: V0 for an ordinary nonce, V1 with `TransactionNonce::GasKeyNonce` for a gas key.
+///
+/// All gas-key / versioning logic lives here so the signer modules stay version-agnostic.
+pub fn build_unsigned_transaction(
+    tx: near_primitives::transaction::TransactionV0,
+    resolution: NonceResolution,
+) -> near_primitives::transaction::Transaction {
+    match resolution {
+        NonceResolution::Plain { .. } => near_primitives::transaction::Transaction::V0(tx),
+        NonceResolution::GasKey { nonce, nonce_index } => {
+            near_primitives::transaction::Transaction::V1(
+                near_primitives::transaction::TransactionV1 {
+                    signer_id: tx.signer_id,
+                    public_key: tx.public_key,
+                    nonce: near_primitives::transaction::TransactionNonce::GasKeyNonce {
+                        nonce,
+                        nonce_index,
+                    },
+                    receiver_id: tx.receiver_id,
+                    block_hash: tx.block_hash,
+                    actions: tx.actions,
+                    nonce_mode: near_primitives::transaction::NonceMode::default(),
+                },
+            )
+        }
+    }
+}

--- a/src/transaction_signature_options/mod.rs
+++ b/src/transaction_signature_options/mod.rs
@@ -255,7 +255,7 @@ pub fn nonce_index_from_cli(
     let max = near_primitives::account::AccessKeyPermission::MAX_NONCES_FOR_GAS_KEY;
     if nonce_index >= u64::from(max) {
         color_eyre::eyre::bail!(
-            "--nonce-index must be less than the gas key's number of parallel nonces (at most {max}), got {nonce_index}"
+            "--nonce-index must be less than {max}, the maximum number of parallel nonces a gas key can have, got {nonce_index}"
         );
     }
     Ok(nonce_index as near_primitives::types::NonceIndex)

--- a/src/transaction_signature_options/sign_with_access_key_file/mod.rs
+++ b/src/transaction_signature_options/sign_with_access_key_file/mod.rs
@@ -1,10 +1,6 @@
 use color_eyre::eyre::{ContextCompat, WrapErr};
 use inquire::CustomType;
-use near_primitives::transaction::Transaction;
 use near_primitives::transaction::TransactionV0;
-
-use crate::common::JsonRpcClientExt;
-use crate::common::RpcQueryResponseExt;
 
 #[derive(Debug, Clone, interactive_clap_derive::InteractiveClap)]
 #[interactive_clap(input_context = crate::commands::TransactionContext)]
@@ -21,6 +17,9 @@ pub struct SignAccessKeyFile {
     #[interactive_clap(long)]
     #[interactive_clap(skip_default_input_arg)]
     pub block_height: Option<near_primitives::types::BlockHeight>,
+    #[interactive_clap(long)]
+    #[interactive_clap(skip_interactive_input)]
+    pub nonce_index: Option<u64>,
     #[interactive_clap(long)]
     #[interactive_clap(skip_interactive_input)]
     meta_transaction_valid_for: Option<u64>,
@@ -59,46 +58,42 @@ impl SignAccessKeyFileContext {
         let account_json: super::AccountKeyPair = serde_json::from_str(&data)
             .wrap_err_with(|| format!("Error reading data from file: {:?}", &scope.file_path))?;
 
-        let (nonce, block_hash, block_height) = if previous_context.global_context.offline {
-            (
-                scope
-                    .nonce
-                    .wrap_err("Nonce is required to sign a transaction in offline mode")?,
-                scope
-                    .block_hash
-                    .wrap_err("Block Hash is required to sign a transaction in offline mode")?
-                    .0,
-                scope
-                    .block_height
-                    .wrap_err("Block Height is required to sign a transaction in offline mode")?,
-            )
-        } else {
-            let rpc_query_response = network_config
-            .json_rpc_client()
-            .blocking_call_view_access_key(
-                &previous_context.prepopulated_transaction.signer_id,
-                &account_json.public_key,
-                near_primitives::types::BlockReference::latest(),
-            )
-            .wrap_err_with(||
-                format!("Cannot sign a transaction due to an error while fetching the most recent nonce value on network <{}>", network_config.network_name)
-            )?;
+        let nonce_index = scope
+            .nonce_index
+            .map(super::nonce_index_from_cli)
+            .transpose()?;
 
-            (
-                rpc_query_response
-                    .access_key_view()
-                    .wrap_err("Error current_nonce")?
-                    .nonce
-                    + 1,
-                rpc_query_response.block_hash,
-                rpc_query_response.block_height,
-            )
-        };
+        let (nonce_resolution, block_hash, block_height) =
+            if previous_context.global_context.offline {
+                (
+                    super::resolve_offline_nonce(
+                        scope
+                            .nonce
+                            .wrap_err("Nonce is required to sign a transaction in offline mode")?,
+                        nonce_index,
+                    ),
+                    scope
+                        .block_hash
+                        .wrap_err("Block Hash is required to sign a transaction in offline mode")?
+                        .0,
+                    scope.block_height.wrap_err(
+                        "Block Height is required to sign a transaction in offline mode",
+                    )?,
+                )
+            } else {
+                super::resolve_online_nonce(
+                    &network_config.json_rpc_client(),
+                    &previous_context.prepopulated_transaction.signer_id,
+                    &account_json.public_key,
+                    nonce_index,
+                    &network_config.network_name,
+                )?
+            };
 
         let mut unsigned_transaction = TransactionV0 {
             public_key: account_json.public_key.clone(),
             block_hash,
-            nonce,
+            nonce: nonce_resolution.nonce(),
             signer_id: previous_context.prepopulated_transaction.signer_id,
             receiver_id: previous_context.prepopulated_transaction.receiver_id,
             actions: previous_context.prepopulated_transaction.actions,
@@ -106,7 +101,8 @@ impl SignAccessKeyFileContext {
 
         (previous_context.on_before_signing_callback)(&mut unsigned_transaction, &network_config)?;
 
-        let unsigned_transaction = Transaction::V0(unsigned_transaction);
+        let unsigned_transaction =
+            super::build_unsigned_transaction(unsigned_transaction, nonce_resolution);
 
         let signature = account_json
             .private_key

--- a/src/transaction_signature_options/sign_with_access_key_file/mod.rs
+++ b/src/transaction_signature_options/sign_with_access_key_file/mod.rs
@@ -119,7 +119,7 @@ impl SignAccessKeyFileContext {
                 &account_json.public_key,
                 account_json.private_key,
                 max_block_height,
-            );
+            )?;
 
             return Ok(Self {
                 network_config: previous_context.network_config,

--- a/src/transaction_signature_options/sign_with_keychain/mod.rs
+++ b/src/transaction_signature_options/sign_with_keychain/mod.rs
@@ -1,6 +1,5 @@
 use color_eyre::eyre::{ContextCompat, WrapErr};
 use inquire::CustomType;
-use near_primitives::transaction::Transaction;
 use near_primitives::transaction::TransactionV0;
 use tracing_indicatif::span_ext::IndicatifSpanExt;
 
@@ -23,6 +22,9 @@ pub struct SignKeychain {
     #[interactive_clap(long)]
     #[interactive_clap(skip_default_input_arg)]
     block_height: Option<near_primitives::types::BlockHeight>,
+    #[interactive_clap(long)]
+    #[interactive_clap(skip_interactive_input)]
+    nonce_index: Option<u64>,
     #[interactive_clap(long)]
     #[interactive_clap(skip_interactive_input)]
     meta_transaction_valid_for: Option<u64>,
@@ -151,46 +153,42 @@ impl SignKeychainContext {
         let account_json: super::AccountKeyPair =
             serde_json::from_str(&password).wrap_err("Error reading data")?;
 
-        let (nonce, block_hash, block_height) = if previous_context.global_context.offline {
-            (
-                scope
-                    .nonce
-                    .wrap_err("Nonce is required to sign a transaction in offline mode")?,
-                scope
-                    .block_hash
-                    .wrap_err("Block Hash is required to sign a transaction in offline mode")?
-                    .0,
-                scope
-                    .block_height
-                    .wrap_err("Block Height is required to sign a transaction in offline mode")?,
-            )
-        } else {
-            let rpc_query_response = network_config
-                .json_rpc_client()
-                .blocking_call_view_access_key(
+        let nonce_index = scope
+            .nonce_index
+            .map(super::nonce_index_from_cli)
+            .transpose()?;
+
+        let (nonce_resolution, block_hash, block_height) =
+            if previous_context.global_context.offline {
+                (
+                    super::resolve_offline_nonce(
+                        scope
+                            .nonce
+                            .wrap_err("Nonce is required to sign a transaction in offline mode")?,
+                        nonce_index,
+                    ),
+                    scope
+                        .block_hash
+                        .wrap_err("Block Hash is required to sign a transaction in offline mode")?
+                        .0,
+                    scope.block_height.wrap_err(
+                        "Block Height is required to sign a transaction in offline mode",
+                    )?,
+                )
+            } else {
+                super::resolve_online_nonce(
+                    &network_config.json_rpc_client(),
                     &previous_context.prepopulated_transaction.signer_id,
                     &account_json.public_key,
-                    near_primitives::types::BlockReference::latest(),
-                )
-                .wrap_err_with(||
-                    format!("Cannot sign a transaction due to an error while fetching the most recent nonce value on network <{}>", network_config.network_name)
-                )?;
-
-            (
-                rpc_query_response
-                    .access_key_view()
-                    .wrap_err("Error current_nonce")?
-                    .nonce
-                    + 1,
-                rpc_query_response.block_hash,
-                rpc_query_response.block_height,
-            )
-        };
+                    nonce_index,
+                    &network_config.network_name,
+                )?
+            };
 
         let mut unsigned_transaction = TransactionV0 {
             public_key: account_json.public_key.clone(),
             block_hash,
-            nonce,
+            nonce: nonce_resolution.nonce(),
             signer_id: previous_context.prepopulated_transaction.signer_id,
             receiver_id: previous_context.prepopulated_transaction.receiver_id,
             actions: previous_context.prepopulated_transaction.actions,
@@ -198,7 +196,8 @@ impl SignKeychainContext {
 
         (previous_context.on_before_signing_callback)(&mut unsigned_transaction, &network_config)?;
 
-        let unsigned_transaction = Transaction::V0(unsigned_transaction);
+        let unsigned_transaction =
+            super::build_unsigned_transaction(unsigned_transaction, nonce_resolution);
 
         let signature = account_json
             .private_key
@@ -283,6 +282,7 @@ fn from_legacy_keychain(
             nonce: scope.nonce,
             block_hash: scope.block_hash,
             block_height: scope.block_height,
+            nonce_index: scope.nonce_index,
             meta_transaction_valid_for: scope.meta_transaction_valid_for,
         };
 

--- a/src/transaction_signature_options/sign_with_keychain/mod.rs
+++ b/src/transaction_signature_options/sign_with_keychain/mod.rs
@@ -214,7 +214,7 @@ impl SignKeychainContext {
                 &account_json.public_key,
                 account_json.private_key,
                 max_block_height,
-            );
+            )?;
 
             return Ok(Self {
                 network_config: previous_context.network_config,

--- a/src/transaction_signature_options/sign_with_keychain/mod.rs
+++ b/src/transaction_signature_options/sign_with_keychain/mod.rs
@@ -78,6 +78,11 @@ impl SignKeychainContext {
             previous_context.prepopulated_transaction.signer_id.as_str()
         ));
 
+        // A `--nonce-index` means the user wants to sign with a gas key, so select
+        // one from the keychain (gas keys are excluded from the ordinary
+        // full-access selection); otherwise keep the full-access-only behavior.
+        let want_gas_key = scope.nonce_index.is_some();
+
         let password = if previous_context.global_context.offline {
             let res = keyring::Entry::new(
                 &service_name,
@@ -122,10 +127,14 @@ impl SignKeychainContext {
                 .keys
                 .into_iter()
                 .filter(|key| {
-                    matches!(
-                        key.access_key.permission,
-                        near_primitives::views::AccessKeyPermissionView::FullAccess
-                    )
+                    if want_gas_key {
+                        super::is_gas_key_permission(&key.access_key.permission)
+                    } else {
+                        matches!(
+                            key.access_key.permission,
+                            near_primitives::views::AccessKeyPermissionView::FullAccess
+                        )
+                    }
                 })
                 .map(|key| key.public_key)
                 .find_map(|public_key| {

--- a/src/transaction_signature_options/sign_with_ledger/mod.rs
+++ b/src/transaction_signature_options/sign_with_ledger/mod.rs
@@ -261,6 +261,8 @@ fn sign_transaction_with_usb(
         super::build_unsigned_transaction(unsigned_transaction, nonce_resolution);
 
     if previous_context.sign_as_delegate_action {
+        super::ensure_gas_key_not_delegated(&unsigned_transaction)?;
+
         let max_block_height = block_height
             + meta_transaction_valid_for.unwrap_or(super::META_TRANSACTION_VALID_FOR_DEFAULT);
 
@@ -525,6 +527,8 @@ fn sign_transaction_with_ble(
         super::build_unsigned_transaction(unsigned_transaction, nonce_resolution);
 
     if previous_context.sign_as_delegate_action {
+        super::ensure_gas_key_not_delegated(&unsigned_transaction)?;
+
         let max_block_height = block_height
             + meta_transaction_valid_for.unwrap_or(super::META_TRANSACTION_VALID_FOR_DEFAULT);
 

--- a/src/transaction_signature_options/sign_with_ledger/mod.rs
+++ b/src/transaction_signature_options/sign_with_ledger/mod.rs
@@ -3,12 +3,8 @@ use inquire::CustomType;
 use near_ledger::NEARLedgerError;
 use near_primitives::action::delegate::SignedDelegateAction;
 use near_primitives::borsh;
-use near_primitives::transaction::Transaction;
 use near_primitives::transaction::TransactionV0;
 use strum::{EnumDiscriminants, EnumIter, EnumMessage};
-
-use crate::common::JsonRpcClientExt;
-use crate::common::RpcQueryResponseExt;
 
 #[cfg(feature = "ledger-ble")]
 pub mod ble_helpers;
@@ -37,6 +33,9 @@ pub struct SignLedger {
     block_height: Option<near_primitives::types::BlockHeight>,
     #[interactive_clap(long)]
     #[interactive_clap(skip_interactive_input)]
+    nonce_index: Option<u64>,
+    #[interactive_clap(long)]
+    #[interactive_clap(skip_interactive_input)]
     meta_transaction_valid_for: Option<u64>,
     #[interactive_clap(subcommand)]
     connection: LedgerConnectionType,
@@ -49,6 +48,7 @@ pub struct SignLedgerContext {
     pub nonce: Option<u64>,
     pub block_hash: Option<crate::types::crypto_hash::CryptoHash>,
     pub block_height: Option<near_primitives::types::BlockHeight>,
+    pub nonce_index: Option<u64>,
     pub meta_transaction_valid_for: Option<u64>,
 }
 
@@ -63,6 +63,7 @@ impl SignLedgerContext {
             nonce: scope.nonce,
             block_hash: scope.block_hash,
             block_height: scope.block_height,
+            nonce_index: scope.nonce_index,
             meta_transaction_valid_for: scope.meta_transaction_valid_for,
         })
     }
@@ -170,6 +171,7 @@ impl interactive_clap::FromCli for UsbConnection {
             context.nonce,
             context.block_hash,
             context.block_height,
+            context.nonce_index,
             context.meta_transaction_valid_for,
         ) {
             Ok(ctx) => ctx,
@@ -194,6 +196,9 @@ impl interactive_clap::FromCli for UsbConnection {
     }
 }
 
+// One extra signing parameter (`nonce_index`) over clippy's 7-argument limit;
+// the parameters are all sibling tx-building inputs forwarded from the context.
+#[allow(clippy::too_many_arguments)]
 #[tracing::instrument(
     name = "Signing the transaction with Ledger device via USB. Follow the instructions on the ledger ...",
     skip_all
@@ -205,6 +210,7 @@ fn sign_transaction_with_usb(
     nonce: Option<u64>,
     block_hash: Option<crate::types::crypto_hash::CryptoHash>,
     block_height: Option<near_primitives::types::BlockHeight>,
+    nonce_index: Option<u64>,
     meta_transaction_valid_for: Option<u64>,
 ) -> color_eyre::eyre::Result<UsbConnectionContext> {
     tracing::info!(target: "near_teach_me", "Signing the transaction with Ledger device via USB. Follow the instructions on the ledger ...");
@@ -213,9 +219,14 @@ fn sign_transaction_with_usb(
     let seed_phrase_hd_path_raw: near_slip10::BIP32Path = seed_phrase_hd_path.clone().into();
     let public_key: near_crypto::PublicKey = signer_public_key.clone().into();
 
-    let (nonce, block_hash, block_height) = if previous_context.global_context.offline {
+    let nonce_index = nonce_index.map(super::nonce_index_from_cli).transpose()?;
+
+    let (nonce_resolution, block_hash, block_height) = if previous_context.global_context.offline {
         (
-            nonce.wrap_err("Nonce is required to sign a transaction in offline mode")?,
+            super::resolve_offline_nonce(
+                nonce.wrap_err("Nonce is required to sign a transaction in offline mode")?,
+                nonce_index,
+            ),
             block_hash
                 .wrap_err("Block Hash is required to sign a transaction in offline mode")?
                 .0,
@@ -223,32 +234,19 @@ fn sign_transaction_with_usb(
                 .wrap_err("Block Height is required to sign a transaction in offline mode")?,
         )
     } else {
-        let rpc_query_response = network_config
-            .json_rpc_client()
-            .blocking_call_view_access_key(
-                &previous_context.prepopulated_transaction.signer_id,
-                &public_key,
-                near_primitives::types::BlockReference::latest(),
-            )
-            .wrap_err_with(||
-                format!("Cannot sign a transaction due to an error while fetching the most recent nonce value on network <{}>", network_config.network_name)
-            )?;
-
-        (
-            rpc_query_response
-                .access_key_view()
-                .wrap_err("Error current_nonce")?
-                .nonce
-                + 1,
-            rpc_query_response.block_hash,
-            rpc_query_response.block_height,
-        )
+        super::resolve_online_nonce(
+            &network_config.json_rpc_client(),
+            &previous_context.prepopulated_transaction.signer_id,
+            &public_key,
+            nonce_index,
+            &network_config.network_name,
+        )?
     };
 
     let mut unsigned_transaction = TransactionV0 {
         public_key: signer_public_key.clone().into(),
         block_hash,
-        nonce,
+        nonce: nonce_resolution.nonce(),
         signer_id: previous_context.prepopulated_transaction.signer_id.clone(),
         receiver_id: previous_context
             .prepopulated_transaction
@@ -259,7 +257,8 @@ fn sign_transaction_with_usb(
 
     (previous_context.on_before_signing_callback)(&mut unsigned_transaction, &network_config)?;
 
-    let unsigned_transaction = Transaction::V0(unsigned_transaction);
+    let unsigned_transaction =
+        super::build_unsigned_transaction(unsigned_transaction, nonce_resolution);
 
     if previous_context.sign_as_delegate_action {
         let max_block_height = block_height
@@ -436,6 +435,7 @@ impl interactive_clap::FromCli for BluetoothConnection {
             context.nonce,
             context.block_hash,
             context.block_height,
+            context.nonce_index,
             context.meta_transaction_valid_for,
         ) {
             Ok(ctx) => ctx,
@@ -474,6 +474,7 @@ fn sign_transaction_with_ble(
     nonce: Option<u64>,
     block_hash: Option<crate::types::crypto_hash::CryptoHash>,
     block_height: Option<near_primitives::types::BlockHeight>,
+    nonce_index: Option<u64>,
     meta_transaction_valid_for: Option<u64>,
 ) -> color_eyre::eyre::Result<BluetoothConnectionContext> {
     tracing::info!(target: "near_teach_me", "Signing the transaction with Ledger device via Bluetooth. Follow the instructions on the ledger ...");
@@ -482,9 +483,14 @@ fn sign_transaction_with_ble(
     let seed_phrase_hd_path_raw: near_slip10::BIP32Path = seed_phrase_hd_path.clone().into();
     let public_key: near_crypto::PublicKey = signer_public_key.clone().into();
 
-    let (nonce, block_hash, block_height) = if previous_context.global_context.offline {
+    let nonce_index = nonce_index.map(super::nonce_index_from_cli).transpose()?;
+
+    let (nonce_resolution, block_hash, block_height) = if previous_context.global_context.offline {
         (
-            nonce.wrap_err("Nonce is required to sign a transaction in offline mode")?,
+            super::resolve_offline_nonce(
+                nonce.wrap_err("Nonce is required to sign a transaction in offline mode")?,
+                nonce_index,
+            ),
             block_hash
                 .wrap_err("Block Hash is required to sign a transaction in offline mode")?
                 .0,
@@ -492,32 +498,19 @@ fn sign_transaction_with_ble(
                 .wrap_err("Block Height is required to sign a transaction in offline mode")?,
         )
     } else {
-        let rpc_query_response = network_config
-            .json_rpc_client()
-            .blocking_call_view_access_key(
-                &previous_context.prepopulated_transaction.signer_id,
-                &public_key,
-                near_primitives::types::BlockReference::latest(),
-            )
-            .wrap_err_with(||
-                format!("Cannot sign a transaction due to an error while fetching the most recent nonce value on network <{}>", network_config.network_name)
-            )?;
-
-        (
-            rpc_query_response
-                .access_key_view()
-                .wrap_err("Error current_nonce")?
-                .nonce
-                + 1,
-            rpc_query_response.block_hash,
-            rpc_query_response.block_height,
-        )
+        super::resolve_online_nonce(
+            &network_config.json_rpc_client(),
+            &previous_context.prepopulated_transaction.signer_id,
+            &public_key,
+            nonce_index,
+            &network_config.network_name,
+        )?
     };
 
     let mut unsigned_transaction = TransactionV0 {
         public_key: signer_public_key.clone().into(),
         block_hash,
-        nonce,
+        nonce: nonce_resolution.nonce(),
         signer_id: previous_context.prepopulated_transaction.signer_id.clone(),
         receiver_id: previous_context
             .prepopulated_transaction
@@ -528,7 +521,8 @@ fn sign_transaction_with_ble(
 
     (previous_context.on_before_signing_callback)(&mut unsigned_transaction, &network_config)?;
 
-    let unsigned_transaction = Transaction::V0(unsigned_transaction);
+    let unsigned_transaction =
+        super::build_unsigned_transaction(unsigned_transaction, nonce_resolution);
 
     if previous_context.sign_as_delegate_action {
         let max_block_height = block_height

--- a/src/transaction_signature_options/sign_with_legacy_keychain/mod.rs
+++ b/src/transaction_signature_options/sign_with_legacy_keychain/mod.rs
@@ -62,6 +62,11 @@ impl SignLegacyKeychainContext {
 
         let network_config = previous_context.network_config.clone();
 
+        // A `--nonce-index` means the user wants to sign with a gas key, so match
+        // gas-key credential files (gas keys are excluded from the ordinary
+        // full-access selection); otherwise keep the full-access-only behavior.
+        let want_gas_key = scope.nonce_index.is_some();
+
         let keychain_folder = previous_context
             .global_context
             .config
@@ -99,10 +104,14 @@ impl SignLegacyKeychainContext {
                     .keys
                     .iter()
                     .filter(|access_key_info| {
-                        matches!(
-                            access_key_info.access_key.permission,
-                            near_primitives::views::AccessKeyPermissionView::FullAccess
-                        )
+                        if want_gas_key {
+                            super::is_gas_key_permission(&access_key_info.access_key.permission)
+                        } else {
+                            matches!(
+                                access_key_info.access_key.permission,
+                                near_primitives::views::AccessKeyPermissionView::FullAccess
+                            )
+                        }
                     })
                     .map(|access_key_info| {
                         format!(

--- a/src/transaction_signature_options/sign_with_legacy_keychain/mod.rs
+++ b/src/transaction_signature_options/sign_with_legacy_keychain/mod.rs
@@ -4,7 +4,6 @@ use std::str::FromStr;
 
 use color_eyre::eyre::{ContextCompat, WrapErr};
 use inquire::{CustomType, Select};
-use near_primitives::transaction::Transaction;
 use near_primitives::transaction::TransactionV0;
 
 use crate::common::JsonRpcClientExt;
@@ -26,6 +25,9 @@ pub struct SignLegacyKeychain {
     #[interactive_clap(long)]
     #[interactive_clap(skip_default_input_arg)]
     pub block_height: Option<near_primitives::types::BlockHeight>,
+    #[interactive_clap(long)]
+    #[interactive_clap(skip_interactive_input)]
+    nonce_index: Option<u64>,
     #[interactive_clap(long)]
     #[interactive_clap(skip_interactive_input)]
     meta_transaction_valid_for: Option<u64>,
@@ -144,45 +146,42 @@ impl SignLegacyKeychainContext {
                 )
             })?;
 
-        let (nonce, block_hash, block_height) = if previous_context.global_context.offline {
-            (
-                scope
-                    .nonce
-                    .wrap_err("Nonce is required to sign a transaction in offline mode")?,
-                scope
-                    .block_hash
-                    .wrap_err("Block Hash is required to sign a transaction in offline mode")?
-                    .0,
-                scope
-                    .block_height
-                    .wrap_err("Block Height is required to sign a transaction in offline mode")?,
-            )
-        } else {
-            let rpc_query_response = network_config
-                .json_rpc_client()
-                .blocking_call_view_access_key(
+        let nonce_index = scope
+            .nonce_index
+            .map(super::nonce_index_from_cli)
+            .transpose()?;
+
+        let (nonce_resolution, block_hash, block_height) =
+            if previous_context.global_context.offline {
+                (
+                    super::resolve_offline_nonce(
+                        scope
+                            .nonce
+                            .wrap_err("Nonce is required to sign a transaction in offline mode")?,
+                        nonce_index,
+                    ),
+                    scope
+                        .block_hash
+                        .wrap_err("Block Hash is required to sign a transaction in offline mode")?
+                        .0,
+                    scope.block_height.wrap_err(
+                        "Block Height is required to sign a transaction in offline mode",
+                    )?,
+                )
+            } else {
+                super::resolve_online_nonce(
+                    &network_config.json_rpc_client(),
                     &previous_context.prepopulated_transaction.signer_id,
                     &signer_access_key.public_key,
-                    near_primitives::types::BlockReference::latest()
-                )
-                .wrap_err(
-                    "Cannot sign a transaction due to an error while fetching the most recent nonce value",
-                )?;
-            (
-                rpc_query_response
-                    .access_key_view()
-                    .wrap_err("Error current_nonce")?
-                    .nonce
-                    + 1,
-                rpc_query_response.block_hash,
-                rpc_query_response.block_height,
-            )
-        };
+                    nonce_index,
+                    &network_config.network_name,
+                )?
+            };
 
         let mut unsigned_transaction = TransactionV0 {
             public_key: signer_access_key.public_key.clone(),
             block_hash,
-            nonce,
+            nonce: nonce_resolution.nonce(),
             signer_id: previous_context.prepopulated_transaction.signer_id,
             receiver_id: previous_context.prepopulated_transaction.receiver_id,
             actions: previous_context.prepopulated_transaction.actions,
@@ -190,7 +189,8 @@ impl SignLegacyKeychainContext {
 
         (previous_context.on_before_signing_callback)(&mut unsigned_transaction, &network_config)?;
 
-        let unsigned_transaction = Transaction::V0(unsigned_transaction);
+        let unsigned_transaction =
+            super::build_unsigned_transaction(unsigned_transaction, nonce_resolution);
 
         if previous_context.sign_as_delegate_action {
             let max_block_height = block_height

--- a/src/transaction_signature_options/sign_with_legacy_keychain/mod.rs
+++ b/src/transaction_signature_options/sign_with_legacy_keychain/mod.rs
@@ -203,7 +203,7 @@ impl SignLegacyKeychainContext {
                 &signer_access_key.public_key,
                 signer_access_key.private_key,
                 max_block_height,
-            );
+            )?;
 
             return Ok(Self {
                 network_config: previous_context.network_config,

--- a/src/transaction_signature_options/sign_with_private_key/mod.rs
+++ b/src/transaction_signature_options/sign_with_private_key/mod.rs
@@ -114,7 +114,7 @@ impl SignPrivateKeyContext {
                 &public_key,
                 signer_secret_key,
                 max_block_height,
-            );
+            )?;
 
             return Ok(Self {
                 network_config: previous_context.network_config,

--- a/src/transaction_signature_options/sign_with_private_key/mod.rs
+++ b/src/transaction_signature_options/sign_with_private_key/mod.rs
@@ -1,10 +1,6 @@
-use color_eyre::eyre::{ContextCompat, WrapErr};
+use color_eyre::eyre::ContextCompat;
 use inquire::CustomType;
-use near_primitives::transaction::Transaction;
 use near_primitives::transaction::TransactionV0;
-
-use crate::common::JsonRpcClientExt;
-use crate::common::RpcQueryResponseExt;
 
 #[derive(Debug, Clone, interactive_clap::InteractiveClap)]
 #[interactive_clap(input_context = crate::commands::TransactionContext)]
@@ -21,6 +17,9 @@ pub struct SignPrivateKey {
     #[interactive_clap(long)]
     #[interactive_clap(skip_default_input_arg)]
     pub block_height: Option<near_primitives::types::BlockHeight>,
+    #[interactive_clap(long)]
+    #[interactive_clap(skip_interactive_input)]
+    pub nonce_index: Option<u64>,
     #[interactive_clap(long)]
     #[interactive_clap(skip_interactive_input)]
     meta_transaction_valid_for: Option<u64>,
@@ -56,45 +55,42 @@ impl SignPrivateKeyContext {
         let signer_secret_key: near_crypto::SecretKey = scope.signer_private_key.clone().into();
         let public_key = signer_secret_key.public_key();
 
-        let (nonce, block_hash, block_height) = if previous_context.global_context.offline {
-            (
-                scope
-                    .nonce
-                    .wrap_err("Nonce is required to sign a transaction in offline mode")?,
-                scope
-                    .block_hash
-                    .wrap_err("Block Hash is required to sign a transaction in offline mode")?
-                    .0,
-                scope
-                    .block_height
-                    .wrap_err("Block Height is required to sign a transaction in offline mode")?,
-            )
-        } else {
-            let rpc_query_response = network_config
-                .json_rpc_client()
-                .blocking_call_view_access_key(
+        let nonce_index = scope
+            .nonce_index
+            .map(super::nonce_index_from_cli)
+            .transpose()?;
+
+        let (nonce_resolution, block_hash, block_height) =
+            if previous_context.global_context.offline {
+                (
+                    super::resolve_offline_nonce(
+                        scope
+                            .nonce
+                            .wrap_err("Nonce is required to sign a transaction in offline mode")?,
+                        nonce_index,
+                    ),
+                    scope
+                        .block_hash
+                        .wrap_err("Block Hash is required to sign a transaction in offline mode")?
+                        .0,
+                    scope.block_height.wrap_err(
+                        "Block Height is required to sign a transaction in offline mode",
+                    )?,
+                )
+            } else {
+                super::resolve_online_nonce(
+                    &network_config.json_rpc_client(),
                     &previous_context.prepopulated_transaction.signer_id,
                     &public_key,
-                    near_primitives::types::BlockReference::latest()
-                )
-                .wrap_err_with(||
-                    format!("Cannot sign a transaction due to an error while fetching the most recent nonce value on network <{}>", network_config.network_name)
-                )?;
-            (
-                rpc_query_response
-                    .access_key_view()
-                    .wrap_err("Error current_nonce")?
-                    .nonce
-                    + 1,
-                rpc_query_response.block_hash,
-                rpc_query_response.block_height,
-            )
-        };
+                    nonce_index,
+                    &network_config.network_name,
+                )?
+            };
 
         let mut unsigned_transaction = TransactionV0 {
             public_key: public_key.clone(),
             block_hash,
-            nonce,
+            nonce: nonce_resolution.nonce(),
             signer_id: previous_context.prepopulated_transaction.signer_id,
             receiver_id: previous_context.prepopulated_transaction.receiver_id,
             actions: previous_context.prepopulated_transaction.actions,
@@ -102,7 +98,8 @@ impl SignPrivateKeyContext {
 
         (previous_context.on_before_signing_callback)(&mut unsigned_transaction, &network_config)?;
 
-        let unsigned_transaction = Transaction::V0(unsigned_transaction);
+        let unsigned_transaction =
+            super::build_unsigned_transaction(unsigned_transaction, nonce_resolution);
 
         let signature = signer_secret_key.sign(unsigned_transaction.get_hash_and_size().0.as_ref());
 

--- a/src/transaction_signature_options/sign_with_seed_phrase/mod.rs
+++ b/src/transaction_signature_options/sign_with_seed_phrase/mod.rs
@@ -1,12 +1,8 @@
 use std::str::FromStr;
 
-use color_eyre::eyre::{ContextCompat, WrapErr};
+use color_eyre::eyre::ContextCompat;
 use inquire::CustomType;
-use near_primitives::transaction::Transaction;
 use near_primitives::transaction::TransactionV0;
-
-use crate::common::JsonRpcClientExt;
-use crate::common::RpcQueryResponseExt;
 
 #[derive(Debug, Clone, interactive_clap_derive::InteractiveClap)]
 #[interactive_clap(input_context = crate::commands::TransactionContext)]
@@ -26,6 +22,9 @@ pub struct SignSeedPhrase {
     #[interactive_clap(long)]
     #[interactive_clap(skip_default_input_arg)]
     pub block_height: Option<near_primitives::types::BlockHeight>,
+    #[interactive_clap(long)]
+    #[interactive_clap(skip_interactive_input)]
+    pub nonce_index: Option<u64>,
     #[interactive_clap(long)]
     #[interactive_clap(skip_interactive_input)]
     meta_transaction_valid_for: Option<u64>,
@@ -66,45 +65,42 @@ impl SignSeedPhraseContext {
         let signer_public_key =
             near_crypto::PublicKey::from_str(&key_pair_properties.public_key_str)?;
 
-        let (nonce, block_hash, block_height) = if previous_context.global_context.offline {
-            (
-                scope
-                    .nonce
-                    .wrap_err("Nonce is required to sign a transaction in offline mode")?,
-                scope
-                    .block_hash
-                    .wrap_err("Block Hash is required to sign a transaction in offline mode")?
-                    .0,
-                scope
-                    .block_height
-                    .wrap_err("Block Height is required to sign a transaction in offline mode")?,
-            )
-        } else {
-            let rpc_query_response = network_config
-                .json_rpc_client()
-                .blocking_call_view_access_key(
+        let nonce_index = scope
+            .nonce_index
+            .map(super::nonce_index_from_cli)
+            .transpose()?;
+
+        let (nonce_resolution, block_hash, block_height) =
+            if previous_context.global_context.offline {
+                (
+                    super::resolve_offline_nonce(
+                        scope
+                            .nonce
+                            .wrap_err("Nonce is required to sign a transaction in offline mode")?,
+                        nonce_index,
+                    ),
+                    scope
+                        .block_hash
+                        .wrap_err("Block Hash is required to sign a transaction in offline mode")?
+                        .0,
+                    scope.block_height.wrap_err(
+                        "Block Height is required to sign a transaction in offline mode",
+                    )?,
+                )
+            } else {
+                super::resolve_online_nonce(
+                    &network_config.json_rpc_client(),
                     &previous_context.prepopulated_transaction.signer_id,
                     &signer_public_key,
-                    near_primitives::types::BlockReference::latest()
-                )
-                .wrap_err_with(||
-                    format!("Cannot sign a transaction due to an error while fetching the most recent nonce value on network <{}>", network_config.network_name)
-                )?;
-            (
-                rpc_query_response
-                    .access_key_view()
-                    .wrap_err("Error current_nonce")?
-                    .nonce
-                    + 1,
-                rpc_query_response.block_hash,
-                rpc_query_response.block_height,
-            )
-        };
+                    nonce_index,
+                    &network_config.network_name,
+                )?
+            };
 
         let mut unsigned_transaction = TransactionV0 {
             public_key: signer_public_key.clone(),
             block_hash,
-            nonce,
+            nonce: nonce_resolution.nonce(),
             signer_id: previous_context.prepopulated_transaction.signer_id,
             receiver_id: previous_context.prepopulated_transaction.receiver_id,
             actions: previous_context.prepopulated_transaction.actions,
@@ -112,7 +108,8 @@ impl SignSeedPhraseContext {
 
         (previous_context.on_before_signing_callback)(&mut unsigned_transaction, &network_config)?;
 
-        let unsigned_transaction = Transaction::V0(unsigned_transaction);
+        let unsigned_transaction =
+            super::build_unsigned_transaction(unsigned_transaction, nonce_resolution);
 
         let signature = signer_secret_key.sign(unsigned_transaction.get_hash_and_size().0.as_ref());
 

--- a/src/transaction_signature_options/sign_with_seed_phrase/mod.rs
+++ b/src/transaction_signature_options/sign_with_seed_phrase/mod.rs
@@ -124,7 +124,7 @@ impl SignSeedPhraseContext {
                 &signer_public_key,
                 signer_secret_key,
                 max_block_height,
-            );
+            )?;
 
             return Ok(Self {
                 network_config: previous_context.network_config,


### PR DESCRIPTION
## Cause

A gas key (nearcore 2.13 / protocol v85) pays for transactions from its own
balance and uses N parallel nonces. Signing a transaction with one requires a
versioned (V1) transaction whose nonce is `TransactionNonce::GasKeyNonce { nonce,
nonce_index }`; near-cli only ever builds the legacy (V0) `TransactionNonce::Nonce`
transaction, so a gas key can be created/funded but not used to sign.

## Fix

A single shared nonce resolver in `transaction_signature_options` that all six
`sign_with_*` modules call, keeping the gas-key + tx-version logic in one place:

- `resolve_online_nonce()` queries the access key; an ordinary key resolves to
  `nonce + 1` and a V0 transaction (unchanged behavior). A gas key additionally
  queries `view_gas_key_nonces` and resolves to `nonces[nonce_index] + 1`.
- `build_unsigned_transaction()` wraps the (post-`on_before_signing_callback`)
  `TransactionV0` into a V0 transaction for an ordinary nonce, or a V1
  transaction with `GasKeyNonce` (+ default `NonceMode`) for a gas key.

Each signer gains an optional `--nonce-index <N>` (default 0; `u64` narrowed to
`NonceIndex` with a bound check, per the interactive-clap `ToCli` constraint) and
otherwise just calls the resolver and the builder — the gas-key path is invisible
to the six modules.

## Verification

The signing path can't be unit-tested against RPC, so compile + clippy is the CI
gate here (`cargo check --tests --no-default-features` [+`--features ledger`],
`cargo fmt --all --check`, `cargo clippy -- -D warnings` all pass). Manual
sandbox/testnet verification of an end-to-end gas-key-signed transaction is
recommended before this leaves draft.

Stacked on #607 (fund/withdraw). Draft.
