### PR TITLE
chore: release v0.28.0-rc.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2569,7 +2569,7 @@ dependencies = [
 
 [[package]]
 name = "near-cli-rs"
-version = "0.28.0"
+version = "0.28.0-rc.1"
 dependencies = [
  "bip39",
  "borsh",


### PR DESCRIPTION



## 🤖 New release

* `near-cli-rs`: 0.27.0 -> 0.28.0-rc.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.28.0-rc.1](https://github.com/near/near-cli-rs/compare/v0.27.0...v0.28.0-rc.1) - 2026-07-02

### Added

- sign transactions with a gas key (nonce_index) ([#608](https://github.com/near/near-cli-rs/pull/608))
- gas-key support (nearcore 2.13) ([#607](https://github.com/near/near-cli-rs/pull/607))
- post-quantum (ML-DSA-65) key generation (draft) ([#605](https://github.com/near/near-cli-rs/pull/605))
- Validate beneficiary account before deleting account ([#596](https://github.com/near/near-cli-rs/pull/596))

### Fixed

- Fixed output information for transaction status "Started" ([#594](https://github.com/near/near-cli-rs/pull/594))

### Other

- Fixed NPM Trusted Publishing ([#603](https://github.com/near/near-cli-rs/pull/603))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).