### PR TITLE
chore: pin to nearcore 2.13.0 stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.28.0-rc.1](https://github.com/near/near-cli-rs/compare/v0.27.0...v0.28.0-rc.1) - 2026-07-02
+## [0.28.0](https://github.com/near/near-cli-rs/compare/v0.27.0...v0.28.0) - 2026-07-09
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2544,9 +2544,9 @@ dependencies = [
 
 [[package]]
 name = "near-chain-configs"
-version = "0.37.0-rc.2"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139112ed78ed5f62ace80e88f4fe2de3edad1a94b90431263b18654d62473e9a"
+checksum = "3bf7f65155e58f46a815199e406dc55400a745129ee53c345ed473e07c938dca"
 dependencies = [
  "anyhow",
  "bytesize",
@@ -2569,7 +2569,7 @@ dependencies = [
 
 [[package]]
 name = "near-cli-rs"
-version = "0.28.0-rc.1"
+version = "0.28.0"
 dependencies = [
  "bip39",
  "borsh",
@@ -2638,9 +2638,9 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "0.37.0-rc.2"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4b30e07d9eb158f1084a36db8963262f75a353b0093a033aa0529faae9db108"
+checksum = "e16c9503c54bf8a30614798bd8ed5e9c24f39a2cc24600326c625b58c1192720"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -2650,9 +2650,9 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "0.37.0-rc.2"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ee338484a9348f3768f4d636a98875f746b9dfeb58f4d7761e70ff74f3ddbb5"
+checksum = "39867e452d80d3dc49dd73bff9532a3c45a979621a4be23a428f19f4764c0295"
 dependencies = [
  "aws-lc-rs",
  "blake2",
@@ -2678,9 +2678,9 @@ dependencies = [
 
 [[package]]
 name = "near-fmt"
-version = "0.37.0-rc.2"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf5e92ed9616818b0cbedcc582d2a582194334f9b622276580453624712380b"
+checksum = "856cfe4ca4c02cbc8173208d0fe5244db8d5c172adac83a40fced1610c18625e"
 dependencies = [
  "near-primitives-core",
 ]
@@ -2698,9 +2698,9 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-client"
-version = "0.22.0-rc.1"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "249aacedbd175416a3635a83752581225b08a80e34bcba7ff65959c8954cf8e7"
+checksum = "2d89c387760380551514795ac1d1b9de102fc09d3bc0a6ded75e88ded33d6822"
 dependencies = [
  "borsh",
  "lazy_static",
@@ -2717,9 +2717,9 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "0.37.0-rc.2"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79ada6f8e357a6eecba4947cb21e56abc58036fcab2136a438b358a4042b62a6"
+checksum = "852ef64fd5e86c5dfa24caae15bc30e3d070770b3c66edb952090d4bba7d6833"
 dependencies = [
  "arbitrary",
  "near-chain-configs",
@@ -2756,9 +2756,9 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "0.37.0-rc.2"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9a94eb0bc87f470537646ea6bc5b5b9272bcceb8a798a1bd47e938f8737454a"
+checksum = "c8a7b0a2a671e8122e0685ba4f164a0d563be8ce1f17e1f3cf8c2f1a82876d38"
 dependencies = [
  "borsh",
  "enum-map",
@@ -2775,9 +2775,9 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "0.37.0-rc.2"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5704a32bee9023c61c725ed6403f6bfdd21226e4798d74312b427c5a0f7022c"
+checksum = "9c9d50f756f3090ff71e48ea159c0e849c856f867cbe6043b4faaceda8e819d6"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -2818,9 +2818,9 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "0.37.0-rc.2"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f94564d97ca478c94b8a34fdcda0a0077b967fa83e7187c6b8267e9b6e441d47"
+checksum = "fb4ca8694b859cf7c7d894e756bbd46bf09b0bc5f243494ed7698eee1bc799a7"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -2864,15 +2864,15 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-core"
-version = "0.37.0-rc.2"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "481ec75b745264fa2403643acde2402536ed4273fbf05ea8749a5d1813f683a0"
+checksum = "396465c4d441ad832b49f485cda5f5072f13696b1c46c9277d49b4937fb0eeee"
 
 [[package]]
 name = "near-schema-checker-lib"
-version = "0.37.0-rc.2"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb4a7f0e4eb5aaa1032a396ef0b840f6b3cda399dfa74b9d5cfaf0c1b537260"
+checksum = "d4dff8ead107faf2f5744d1f126ecc3a3bde129c3e36902ad4020464beac0651"
 dependencies = [
  "near-schema-checker-core",
  "near-schema-checker-macro",
@@ -2880,9 +2880,9 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-macro"
-version = "0.37.0-rc.2"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24abafad706a94a56a687618ae7e13b296b0443f54c7b7d92477b3b3c82e336d"
+checksum = "732349f01e6f6e47edf921900d6a085b7ed3088464df21b312fec6ade44f8da2"
 
 [[package]]
 name = "near-slip10"
@@ -2897,9 +2897,9 @@ dependencies = [
 
 [[package]]
 name = "near-socialdb-client"
-version = "0.16.0-rc.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf155a85c6b9bd805beff5f7d0cfae6bcd113a952d13d21733d6bc3b9090a89"
+checksum = "7c94b3a6c2271c80d22a118e66bb093dd98d8ae4fab608125352e3f8cd192d1e"
 dependencies = [
  "eyre",
  "near-crypto",
@@ -2914,15 +2914,15 @@ dependencies = [
 
 [[package]]
 name = "near-stdx"
-version = "0.37.0-rc.2"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1e1cf6e256646ef9cabf86759582b2e7b06edfde846edaa68fc7d3e69d833f8"
+checksum = "305f4222ee62ff3ec872210f4d3871091d088063d1b51b957a19014d724dacfc"
 
 [[package]]
 name = "near-time"
-version = "0.37.0-rc.2"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3014c3edcc10d38313abd8401700b565ab555423eee090a1b1491c700ed711a2"
+checksum = "e9286bbc85a0701cf75cda7ca295f56bda904e6535903e06f8d8d3e494d03ffa"
 dependencies = [
  "parking_lot",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-cli-rs"
-version = "0.28.0-rc.1"
+version = "0.28.0"
 authors = ["FroVolod <frol_off@meta.ua>", "Near Inc <hello@nearprotocol.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2024"
@@ -78,16 +78,12 @@ bytesize = "1.1.0"
 prettytable = "0.10.0"
 textwrap = "0.16.1"
 
-# TODO(post-quantum): nearcore 2.13 (post-quantum ML-DSA-65 access keys,
-# nearcore#15731) has no stable crates.io release yet, so every near-* crate
-# below is pinned to an exact `=` 2.13 pre-release (no git deps). Relax these
-# to `0.37` / stable jsonrpc + socialdb once 2.13 ships to mainnet.
-near-crypto = "=0.37.0-rc.2"
-near-primitives = "=0.37.0-rc.2"
-near-jsonrpc-client = { version = "=0.22.0-rc.1", features = ["any"] }
-near-jsonrpc-primitives = "=0.37.0-rc.2"
-near-parameters = "=0.37.0-rc.2"
-near-socialdb-client = "=0.16.0-rc.1"
+near-crypto = "0.37.0"
+near-primitives = "0.37.0"
+near-jsonrpc-client = { version = "0.22.0", features = ["any"] }
+near-jsonrpc-primitives = "0.37.0"
+near-parameters = "0.37.0"
+near-socialdb-client = "0.16.0"
 
 near-ledger = { version = "0.9.4", optional = true }
 

--- a/src/commands/account/create_account/fund_myself_create_account/mod.rs
+++ b/src/commands/account/create_account/fund_myself_create_account/mod.rs
@@ -91,7 +91,7 @@ impl NewAccount {
                 if let Some(network_config) = network_where_account_exist {
                     tracing::warn!("{}", format!(
                         "Heads up! You will only waste tokens if you proceed creating <{}> account on <{}> as the account already exists.",
-                        &account_id, network_config.network_name
+                        account_id, network_config.network_name
                     ).red()
                     );
                     if !crate::common::ask_if_different_account_id_wanted()? {

--- a/src/commands/account/create_account/sponsor_by_faucet_service/mod.rs
+++ b/src/commands/account/create_account/sponsor_by_faucet_service/mod.rs
@@ -80,7 +80,7 @@ pub fn before_creating_account(
         None => {
             return Err(color_eyre::Report::msg(format!(
                 "The <{}> network does not have a faucet (helper service) that can sponsor the creation of an account.",
-                &network_config.network_name
+                network_config.network_name
             )));
         }
     };

--- a/src/commands/account/create_account/sponsor_by_faucet_service/network/mod.rs
+++ b/src/commands/account/create_account/sponsor_by_faucet_service/network/mod.rs
@@ -35,17 +35,17 @@ impl NetworkContext {
         let mut info_str: String = String::new();
         info_str.push_str(&format!(
             "\n{:<13} {}",
-            "signer_id:", &network_config.network_name
+            "signer_id:", network_config.network_name
         ));
         info_str.push_str("\nactions:");
         info_str.push_str(&format!(
             "\n{:>5} {:<20} {}",
-            "--", "create account:", &previous_context.new_account_id
+            "--", "create account:", previous_context.new_account_id
         ));
         info_str.push_str(&format!("\n{:>5} {:<20}", "--", "add access key:"));
         info_str.push_str(&format!(
             "\n{:>18} {:<13} {}",
-            "", "public key:", &previous_context.public_key
+            "", "public key:", previous_context.public_key
         ));
         info_str.push_str(&format!("\n{:>18} {:<13} FullAccess", "", "permission:"));
         info_str.push_str("\n ");

--- a/src/commands/account/delete_account/mod.rs
+++ b/src/commands/account/delete_account/mod.rs
@@ -157,7 +157,7 @@ pub fn validate_beneficiary_in_network(
             "{}{}",
             format!(
                 "Skipping verification of account <{}> as a beneficiary in offline mode.",
-                &beneficiary_account_id,
+                beneficiary_account_id,
             ).red(),
             crate::common::indent_payload(&format!("\n{}",
                 "Make sure you specify an existing account as a beneficiary to avoid losing your funds.\nIt is currently possible to continue deleting an account offline.\nYou can sign and send the created transaction later.\n "

--- a/src/commands/account/export_account/mod.rs
+++ b/src/commands/account/export_account/mod.rs
@@ -134,7 +134,7 @@ pub fn get_account_key_pair_from_legacy_keychain(
     let data = std::fs::read_to_string(&data_path).wrap_err("Access key file not found!")?;
     let account_key_pair: crate::transaction_signature_options::AccountKeyPair =
         serde_json::from_str(&data)
-            .wrap_err_with(|| format!("Error reading data from file: {:?}", &data_path))?;
+            .wrap_err_with(|| format!("Error reading data from file: {:?}", data_path))?;
     Ok(account_key_pair)
 }
 

--- a/src/commands/account/export_account/using_seed_phrase/mod.rs
+++ b/src/commands/account/export_account/using_seed_phrase/mod.rs
@@ -47,7 +47,7 @@ impl ExportAccountFromSeedPhraseContext {
                         .wrap_err("Access key file not found!")?;
                     let key_pair_properties: crate::common::KeyPairProperties =
                         serde_json::from_str(&data).wrap_err_with(|| {
-                            format!("Error reading data from file: {:?}", &data_path)
+                            format!("Error reading data from file: {:?}", data_path)
                         })?;
                     println!(
                         "Here is the secret recovery seed phrase for account <{}>: \"{}\" (HD Path: {}).",

--- a/src/commands/account/export_account/using_web_wallet/mod.rs
+++ b/src/commands/account/export_account/using_web_wallet/mod.rs
@@ -68,7 +68,7 @@ fn auto_import_secret_key(
     url.set_fragment(Some(&fragment));
     eprintln!(
         "If your browser doesn't automatically open, please visit this URL:\n {}\n",
-        &url.as_str()
+        url.as_str()
     );
     // url.open();
     open::that(url.as_ref()).ok();

--- a/src/commands/account/get_public_key/from_keychain/mod.rs
+++ b/src/commands/account/get_public_key/from_keychain/mod.rs
@@ -36,7 +36,7 @@ impl PublicKeyFromKeychainContext {
                     }
                     let service_name = std::borrow::Cow::Owned(format!(
                         "near-{}-{}",
-                        network_config.network_name, &account_id
+                        network_config.network_name, account_id
                     ));
 
                     let password = {

--- a/src/commands/account/get_public_key/from_legacy_keychain/mod.rs
+++ b/src/commands/account/get_public_key/from_legacy_keychain/mod.rs
@@ -93,7 +93,7 @@ impl PublicKeyFromLegacyKeychainContext {
                         serde_json::from_slice(&signer_access_key_json).wrap_err_with(|| {
                             format!(
                                 "Error reading data from file: {:?}",
-                                &signer_access_key_file_path
+                                signer_access_key_file_path
                             )
                         })?;
 

--- a/src/commands/account/import_account/using_web_wallet/mod.rs
+++ b/src/commands/account/import_account/using_web_wallet/mod.rs
@@ -30,7 +30,7 @@ impl LoginFromWebWalletContext {
                     //.append_pair("success_url", "http://127.0.0.1:8080");
                     eprintln!(
                         "If your browser doesn't automatically open, please visit this URL:\n {}\n",
-                        &url.as_str()
+                        url.as_str()
                     );
                     // url.open();
                     open::that(url.as_ref()).ok();
@@ -38,7 +38,7 @@ impl LoginFromWebWalletContext {
                     let key_pair_properties_buf = serde_json::to_string(&key_pair_properties)?;
                     let error_message = format!(
                         "\nIt is currently not possible to verify the account access key.\nYou may not be logged in to {} or you may have entered an incorrect account_id.\nYou have the option to reconfirm your account or save your access key information.\n ",
-                        &url.as_str()
+                        url.as_str()
                     );
                     super::login(
                         network_config.clone(),

--- a/src/commands/account/list_keys/mod.rs
+++ b/src/commands/account/list_keys/mod.rs
@@ -36,7 +36,7 @@ impl ViewListKeysContext {
                     .wrap_err_with(|| {
                         format!(
                             "Failed to fetch query AccessKeyList for {}",
-                            &account_id
+                            account_id
                         )
                     })?
                     .access_key_list_view()?;

--- a/src/commands/account/view_gas_key_nonces/mod.rs
+++ b/src/commands/account/view_gas_key_nonces/mod.rs
@@ -40,7 +40,7 @@ impl ViewGasKeyNoncesContext {
                     .wrap_err_with(|| {
                         format!(
                             "Failed to fetch the gas key nonces for {} on account <{}>",
-                            &public_key, &account_id
+                            public_key, account_id
                         )
                     })?
                     .gas_key_nonces_view()?;

--- a/src/commands/config/add_connection/mod.rs
+++ b/src/commands/config/add_connection/mod.rs
@@ -108,7 +108,7 @@ impl AddNetworkConnectionContext {
         config.write_config_toml()?;
         eprintln!(
             "Network connection \"{}\" was successfully added to config.toml",
-            &scope.connection_name
+            scope.connection_name
         );
         Ok(Self)
     }

--- a/src/commands/config/delete_connection/mod.rs
+++ b/src/commands/config/delete_connection/mod.rs
@@ -21,7 +21,7 @@ impl DeleteNetworkConnectionContext {
         config.write_config_toml()?;
         eprintln!(
             "Network connection \"{}\" was successfully removed from config.toml",
-            &scope.connection_name
+            scope.connection_name
         );
         Ok(Self)
     }

--- a/src/commands/config/edit_connection/mod.rs
+++ b/src/commands/config/edit_connection/mod.rs
@@ -30,7 +30,7 @@ impl EditConnectionContext {
             .unwrap_or_else(|| {
                 panic!(
                     "Network connection \"{}\" not found",
-                    &scope.connection_name
+                    scope.connection_name
                 )
             })
             .clone();
@@ -160,7 +160,7 @@ impl ParameterContext {
         config.write_config_toml()?;
         eprintln!(
             "Network connection \"{}\" was successfully updated with the new value for <{}>",
-            &previous_context.connection_name, &scope.key
+            previous_context.connection_name, scope.key
         );
         Ok(Self)
     }

--- a/src/commands/config/edit_connection/mod.rs
+++ b/src/commands/config/edit_connection/mod.rs
@@ -27,12 +27,7 @@ impl EditConnectionContext {
             .config
             .network_connection
             .get(&scope.connection_name)
-            .unwrap_or_else(|| {
-                panic!(
-                    "Network connection \"{}\" not found",
-                    scope.connection_name
-                )
-            })
+            .unwrap_or_else(|| panic!("Network connection \"{}\" not found", scope.connection_name))
             .clone();
 
         Ok(Self {

--- a/src/commands/config/mod.rs
+++ b/src/commands/config/mod.rs
@@ -52,10 +52,10 @@ impl ShowConnectionsContext {
         path_config_toml.push("near-cli/config.toml");
         eprintln!(
             "\nConfiguration data is stored in a file {:?}",
-            &path_config_toml
+            path_config_toml
         );
         let config_toml = toml::to_string(&previous_context.config)?;
-        eprintln!("{}", &config_toml);
+        eprintln!("{}", config_toml);
         Ok(Self)
     }
 }

--- a/src/commands/contract/call_function/call_function_args_type/mod.rs
+++ b/src/commands/contract/call_function/call_function_args_type/mod.rs
@@ -104,7 +104,7 @@ pub fn function_args(
         super::call_function_args_type::FunctionArgsType::FileArgs => {
             let data_path = std::path::PathBuf::from(args);
             let data = std::fs::read(&data_path)
-                .wrap_err_with(|| format!("Access to data file <{:?}> not found!", &data_path))?;
+                .wrap_err_with(|| format!("Access to data file <{:?}> not found!", data_path))?;
             Ok(data)
         }
     }

--- a/src/commands/contract/deploy/mod.rs
+++ b/src/commands/contract/deploy/mod.rs
@@ -97,7 +97,7 @@ impl ContractFileContext {
         scope: &<ContractFile as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
     ) -> color_eyre::eyre::Result<Self> {
         let code = std::fs::read(&scope.file_path).wrap_err_with(|| {
-            format!("Failed to open or read the file: {:?}.", &scope.file_path.0,)
+            format!("Failed to open or read the file: {:?}.", scope.file_path.0,)
         })?;
         Ok(Self(GenericDeployContext {
             global_context: previous_context.global_context,

--- a/src/commands/contract/deploy_global/mod.rs
+++ b/src/commands/contract/deploy_global/mod.rs
@@ -31,7 +31,7 @@ impl ContractFileContext {
         scope: &<ContractFile as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
     ) -> color_eyre::eyre::Result<Self> {
         let code = std::fs::read(&scope.file_path).wrap_err_with(|| {
-            format!("Failed to open or read the file: {:?}.", &scope.file_path.0,)
+            format!("Failed to open or read the file: {:?}.", scope.file_path.0,)
         })?;
         Ok(Self {
             global_context: previous_context,

--- a/src/commands/contract/inspect/mod.rs
+++ b/src/commands/contract/inspect/mod.rs
@@ -89,7 +89,7 @@ async fn get_contract_code(
         .wrap_err_with(|| {
             format!(
                 "Failed to fetch query ViewCode for <{}> on network <{}>",
-                &account_id, network_config.network_name
+                account_id, network_config.network_name
             )
         })
 }
@@ -593,7 +593,7 @@ pub async fn get_contract_source_metadata(
                             parent: &tracing::Span::none(),
                             "Decoding the \"result\" array of bytes as UTF-8 string (tip: you can use this Python snippet to do it: `\"\".join([chr(c) for c in result])`):\n{}",
                             crate::common::indent_payload(&format!("{}\n ",
-                                &String::from_utf8(call_result.result.clone())
+                                String::from_utf8(call_result.result.clone())
                                     .unwrap_or_else(|_| "<decoding failed - the result is not a UTF-8 string>".to_owned())
                             ))
                         );

--- a/src/commands/contract/verify/mod.rs
+++ b/src/commands/contract/verify/mod.rs
@@ -250,7 +250,7 @@ fn get_contract_properties_from_docker_build(
         )
     })?;
     let contract_code = std::fs::read(&contract_path_buf)
-        .wrap_err_with(|| format!("Failed to open or read the file: {:?}.", &contract_path_buf,))?;
+        .wrap_err_with(|| format!("Failed to open or read the file: {:?}.", contract_path_buf,))?;
     let contract_code_hash = near_verify_rs::logic::compute_hash(contract_path_buf)?;
 
     let contract_properties = ContractProperties {
@@ -306,7 +306,7 @@ fn get_contract_code_from_contract_account_id(
         .wrap_err_with(|| {
             format!(
                 "Failed to fetch query ViewCode for <{}> on network <{}>",
-                &account_id, network_config.network_name
+                account_id, network_config.network_name
             )
         })?;
 

--- a/src/commands/message/sign_nep413/signature_options/sign_with_access_key_file.rs
+++ b/src/commands/message/sign_nep413/signature_options/sign_with_access_key_file.rs
@@ -19,9 +19,8 @@ impl SignAccessKeyFileContext {
         let data =
             std::fs::read_to_string(&scope.file_path).wrap_err("Access key file not found!")?;
         let account_json: crate::transaction_signature_options::AccountKeyPair =
-            serde_json::from_str(&data).wrap_err_with(|| {
-                format!("Error reading data from file: {:?}", scope.file_path)
-            })?;
+            serde_json::from_str(&data)
+                .wrap_err_with(|| format!("Error reading data from file: {:?}", scope.file_path))?;
 
         let signature = super::super::sign_nep413_payload(
             &previous_context.payload,

--- a/src/commands/message/sign_nep413/signature_options/sign_with_access_key_file.rs
+++ b/src/commands/message/sign_nep413/signature_options/sign_with_access_key_file.rs
@@ -20,7 +20,7 @@ impl SignAccessKeyFileContext {
             std::fs::read_to_string(&scope.file_path).wrap_err("Access key file not found!")?;
         let account_json: crate::transaction_signature_options::AccountKeyPair =
             serde_json::from_str(&data).wrap_err_with(|| {
-                format!("Error reading data from file: {:?}", &scope.file_path)
+                format!("Error reading data from file: {:?}", scope.file_path)
             })?;
 
         let signature = super::super::sign_nep413_payload(

--- a/src/commands/tokens/send_ft_call/amount_ft.rs
+++ b/src/commands/tokens/send_ft_call/amount_ft.rs
@@ -215,7 +215,7 @@ impl MsgFileContext {
         scope: &<MsgFile as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
     ) -> color_eyre::eyre::Result<Self> {
         let msg = std::fs::read_to_string(&scope.file_path)
-            .wrap_err_with(|| format!("Failed to read msg from file: {:?}", &scope.file_path))?
+            .wrap_err_with(|| format!("Failed to read msg from file: {:?}", scope.file_path))?
             .trim()
             .to_string();
         Ok(Self(build_action_context(previous_context, msg)?))

--- a/src/commands/transaction/construct_transaction/add_action_1/add_action/deploy_contract/mod.rs
+++ b/src/commands/transaction/construct_transaction/add_action_1/add_action/deploy_contract/mod.rs
@@ -29,7 +29,7 @@ impl ContractFileContext {
         scope: &<ContractFile as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
     ) -> color_eyre::eyre::Result<Self> {
         let code = std::fs::read(&scope.file_path).wrap_err_with(|| {
-            format!("Failed to open or read the file: {:?}.", &scope.file_path.0,)
+            format!("Failed to open or read the file: {:?}.", scope.file_path.0,)
         })?;
         let action = near_primitives::transaction::Action::DeployContract(
             near_primitives::transaction::DeployContractAction { code },

--- a/src/commands/transaction/construct_transaction/add_action_1/add_action/deploy_global_contract/mod.rs
+++ b/src/commands/transaction/construct_transaction/add_action_1/add_action/deploy_global_contract/mod.rs
@@ -23,7 +23,7 @@ impl DeployGlobalContractActionContext {
         scope: &<DeployGlobalContractAction as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
     ) -> color_eyre::eyre::Result<Self> {
         let code = std::fs::read(&scope.file_path).wrap_err_with(|| {
-            format!("Failed to open or read the file: {:?}.", &scope.file_path.0,)
+            format!("Failed to open or read the file: {:?}.", scope.file_path.0,)
         })?;
         Ok(Self {
             context: previous_context,

--- a/src/commands/transaction/construct_transaction/add_action_2/add_action/deploy_contract/mod.rs
+++ b/src/commands/transaction/construct_transaction/add_action_2/add_action/deploy_contract/mod.rs
@@ -29,7 +29,7 @@ impl ContractFileContext {
         scope: &<ContractFile as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
     ) -> color_eyre::eyre::Result<Self> {
         let code = std::fs::read(&scope.file_path).wrap_err_with(|| {
-            format!("Failed to open or read the file: {:?}.", &scope.file_path.0,)
+            format!("Failed to open or read the file: {:?}.", scope.file_path.0,)
         })?;
         let action = near_primitives::transaction::Action::DeployContract(
             near_primitives::transaction::DeployContractAction { code },

--- a/src/commands/transaction/construct_transaction/add_action_2/add_action/deploy_global_contract/mod.rs
+++ b/src/commands/transaction/construct_transaction/add_action_2/add_action/deploy_global_contract/mod.rs
@@ -23,7 +23,7 @@ impl DeployGlobalContractActionContext {
         scope: &<DeployGlobalContractAction as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
     ) -> color_eyre::eyre::Result<Self> {
         let code = std::fs::read(&scope.file_path).wrap_err_with(|| {
-            format!("Failed to open or read the file: {:?}.", &scope.file_path.0,)
+            format!("Failed to open or read the file: {:?}.", scope.file_path.0,)
         })?;
         Ok(Self {
             context: previous_context,

--- a/src/commands/transaction/construct_transaction/add_action_3/add_action/deploy_contract/mod.rs
+++ b/src/commands/transaction/construct_transaction/add_action_3/add_action/deploy_contract/mod.rs
@@ -29,7 +29,7 @@ impl ContractFileContext {
         scope: &<ContractFile as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
     ) -> color_eyre::eyre::Result<Self> {
         let code = std::fs::read(&scope.file_path).wrap_err_with(|| {
-            format!("Failed to open or read the file: {:?}.", &scope.file_path.0,)
+            format!("Failed to open or read the file: {:?}.", scope.file_path.0,)
         })?;
         let action = near_primitives::transaction::Action::DeployContract(
             near_primitives::transaction::DeployContractAction { code },

--- a/src/commands/transaction/construct_transaction/add_action_3/add_action/deploy_global_contract/mod.rs
+++ b/src/commands/transaction/construct_transaction/add_action_3/add_action/deploy_global_contract/mod.rs
@@ -23,7 +23,7 @@ impl DeployGlobalContractActionContext {
         scope: &<DeployGlobalContractAction as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
     ) -> color_eyre::eyre::Result<Self> {
         let code = std::fs::read(&scope.file_path).wrap_err_with(|| {
-            format!("Failed to open or read the file: {:?}.", &scope.file_path.0,)
+            format!("Failed to open or read the file: {:?}.", scope.file_path.0,)
         })?;
         Ok(Self {
             context: previous_context,

--- a/src/commands/transaction/send_meta_transaction/mod.rs
+++ b/src/commands/transaction/send_meta_transaction/mod.rs
@@ -92,10 +92,10 @@ impl FileWithBase64SignedMetaTransactionContext {
         scope: &<FileWithBase64SignedMetaTransaction as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
     ) -> color_eyre::eyre::Result<Self> {
         let data = std::fs::read_to_string(&scope.file_path)
-            .wrap_err_with(|| format!("File {:?} not found!", &scope.file_path))?;
+            .wrap_err_with(|| format!("File {:?} not found!", scope.file_path))?;
 
         let signed_delegate_action = serde_json::from_str::<FileSignedMetaTransaction>(&data)
-            .wrap_err_with(|| format!("Error reading data from file: {:?}", &scope.file_path))?
+            .wrap_err_with(|| format!("Error reading data from file: {:?}", scope.file_path))?
             .signed_delegate_action;
 
         Ok(Self(SignedMetaTransactionContext {

--- a/src/commands/transaction/send_signed_transaction/mod.rs
+++ b/src/commands/transaction/send_signed_transaction/mod.rs
@@ -92,10 +92,10 @@ impl FileWithBase64SignedTransactionContext {
         scope: &<FileWithBase64SignedTransaction as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
     ) -> color_eyre::eyre::Result<Self> {
         let data = std::fs::read_to_string(&scope.file_path)
-            .wrap_err_with(|| format!("File {:?} not found!", &scope.file_path))?;
+            .wrap_err_with(|| format!("File {:?} not found!", scope.file_path))?;
 
         let signed_transaction = serde_json::from_str::<FileSignedTransaction>(&data)
-            .wrap_err_with(|| format!("Error reading data from file: {:?}", &scope.file_path))?
+            .wrap_err_with(|| format!("Error reading data from file: {:?}", scope.file_path))?
             .signed_transaction;
 
         Ok(Self(SignedTransactionContext {

--- a/src/common.rs
+++ b/src/common.rs
@@ -1029,7 +1029,7 @@ pub fn print_full_unsigned_transaction(
     info_str.push_str(&format!(
         "\n{:<13} {}",
         "public_key:",
-        &transaction.public_key()
+        transaction.public_key()
     ));
     info_str.push_str(&format!(
         "\n{:<13} {}",
@@ -1039,7 +1039,7 @@ pub fn print_full_unsigned_transaction(
     info_str.push_str(&format!(
         "\n{:<13} {}",
         "block_hash:",
-        &transaction.block_hash()
+        transaction.block_hash()
     ));
 
     let prepopulated = crate::commands::PrepopulatedTransaction::from(transaction);
@@ -1074,7 +1074,7 @@ pub fn print_unsigned_transaction(
             near_primitives::transaction::Action::CreateAccount(_) => {
                 info_str.push_str(&format!(
                     "\n{:>5} {:<20} {}",
-                    "--", "create account:", &transaction.receiver_id
+                    "--", "create account:", transaction.receiver_id
                 ));
             }
             near_primitives::transaction::Action::DeployContract(code) => {
@@ -1092,7 +1092,7 @@ pub fn print_unsigned_transaction(
                 info_str.push_str(&format!("\n{:>5} {:<20}", "--", "function call:"));
                 info_str.push_str(&format!(
                     "\n{:>18} {:<13} {}",
-                    "", "method name:", &function_call_action.method_name
+                    "", "method name:", function_call_action.method_name
                 ));
                 info_str.push_str(&format!(
                     "\n{:>18} {:<13} {}",
@@ -1139,7 +1139,7 @@ pub fn print_unsigned_transaction(
                 info_str.push_str(&format!("\n{:>5} {:<20}", "--", "stake:"));
                 info_str.push_str(&format!(
                     "\n{:>18} {:<13} {}",
-                    "", "public key:", &stake_action.public_key
+                    "", "public key:", stake_action.public_key
                 ));
                 info_str.push_str(&format!(
                     "\n{:>18} {:<13} {}",
@@ -1152,32 +1152,32 @@ pub fn print_unsigned_transaction(
                 info_str.push_str(&format!("\n{:>5} {:<20}", "--", "add access key:"));
                 info_str.push_str(&format!(
                     "\n{:>18} {:<13} {}",
-                    "", "public key:", &add_key_action.public_key
+                    "", "public key:", add_key_action.public_key
                 ));
                 info_str.push_str(&format!(
                     "\n{:>18} {:<13} {}",
-                    "", "nonce:", &add_key_action.access_key.nonce
+                    "", "nonce:", add_key_action.access_key.nonce
                 ));
                 info_str.push_str(&format!(
                     "\n{:>18} {:<13} {:?}",
-                    "", "permission:", &add_key_action.access_key.permission
+                    "", "permission:", add_key_action.access_key.permission
                 ));
             }
             near_primitives::transaction::Action::DeleteKey(delete_key_action) => {
                 info_str.push_str(&format!("\n{:>5} {:<20}", "--", "delete access key:"));
                 info_str.push_str(&format!(
                     "\n{:>18} {:<13} {}",
-                    "", "public key:", &delete_key_action.public_key
+                    "", "public key:", delete_key_action.public_key
                 ));
             }
             near_primitives::transaction::Action::DeleteAccount(delete_account_action) => {
                 info_str.push_str(&format!(
                     "\n{:>5} {:<20} {}",
-                    "--", "delete account:", &transaction.receiver_id
+                    "--", "delete account:", transaction.receiver_id
                 ));
                 info_str.push_str(&format!(
                     "\n{:>8} {:<17} {}",
-                    "", "beneficiary id:", &delete_account_action.beneficiary_id
+                    "", "beneficiary id:", delete_account_action.beneficiary_id
                 ));
             }
             near_primitives::transaction::Action::Delegate(signed_delegate_action) => {
@@ -1266,7 +1266,7 @@ pub fn print_unsigned_transaction(
                 info_str.push_str(&format!("\n{:>5} {:<20}", "--", "transfer to gas key:"));
                 info_str.push_str(&format!(
                     "\n{:>18} {:<13} {}",
-                    "", "public key:", &transfer_to_gas_key.public_key
+                    "", "public key:", transfer_to_gas_key.public_key
                 ));
                 info_str.push_str(&format!(
                     "\n{:>18} {:<13} {}",
@@ -1279,7 +1279,7 @@ pub fn print_unsigned_transaction(
                 info_str.push_str(&format!("\n{:>5} {:<20}", "--", "withdraw from gas key:"));
                 info_str.push_str(&format!(
                     "\n{:>18} {:<13} {}",
-                    "", "public key:", &withdraw_from_gas_key.public_key
+                    "", "public key:", withdraw_from_gas_key.public_key
                 ));
                 info_str.push_str(&format!(
                     "\n{:>18} {:<13} {}",
@@ -2200,7 +2200,7 @@ pub fn save_access_key_to_legacy_keychain(
     let message_1 = if path_with_key_name.exists() {
         format!(
             "The file: {} already exists! Therefore it was not overwritten.",
-            &path_with_key_name.display()
+            path_with_key_name.display()
         )
     } else {
         std::fs::File::create(&path_with_key_name)
@@ -2209,7 +2209,7 @@ pub fn save_access_key_to_legacy_keychain(
             .wrap_err_with(|| format!("Failed to write to file: {path_with_key_name:?}"))?;
         format!(
             "The data for the access key is saved in a file {}",
-            &path_with_key_name.display()
+            path_with_key_name.display()
         )
     };
 
@@ -2221,7 +2221,7 @@ pub fn save_access_key_to_legacy_keychain(
         Ok(format!(
             "{}\nThe file: {} already exists! Therefore it was not overwritten.",
             message_1,
-            &path_with_account_name.display()
+            path_with_account_name.display()
         ))
     } else {
         std::fs::File::create(&path_with_account_name)
@@ -2231,7 +2231,7 @@ pub fn save_access_key_to_legacy_keychain(
         Ok(format!(
             "{}\nThe data for the access key is saved in a file {}",
             message_1,
-            &path_with_account_name.display()
+            path_with_account_name.display()
         ))
     }
 }
@@ -2245,7 +2245,7 @@ pub fn try_external_subcommand_execution(error: clap::Error) -> CliResult {
         (subcommand, args.collect::<Vec<String>>())
     };
     let is_top_level_command_known = crate::commands::TopLevelCommandDiscriminants::iter()
-        .map(|x| format!("{:?}", &x).to_lowercase())
+        .map(|x| format!("{:?}", x).to_lowercase())
         .any(|x| x == subcommand);
     if is_top_level_command_known {
         error.exit()
@@ -3190,7 +3190,7 @@ impl JsonRpcClientExt for near_jsonrpc_client::JsonRpcClient {
                     parent: &tracing::Span::none(),
                     "Decoding the \"result\" array of bytes as UTF-8 string (tip: you can use this Python snippet to do it: `\"\".join([chr(c) for c in result])`):\n{}",
                     indent_payload(&format!("{}\n ", 
-                        &String::from_utf8(call_result.result.clone())
+                        String::from_utf8(call_result.result.clone())
                             .unwrap_or_else(|_| "<decoding failed - the result is not a UTF-8 string>".to_owned())
                     ))
                 );
@@ -3366,7 +3366,7 @@ fn replace_params_with_file(
             Err(err) => {
                 return Err(format!(
                     "Failed to save payload to `{}`. Serialization error:\n{}",
-                    &file_path.display(),
+                    file_path.display(),
                     indent_payload(&format!("{err:#?}"))
                 ));
             }
@@ -3389,23 +3389,23 @@ fn replace_params_with_file(
                 Ok(buf) => match file.write(&buf) {
                     Ok(_) => Ok(Some(format!(
                         "The file `{}` was created successfully. It has a signed transaction (serialized as base64).",
-                        &file_path.display()
+                        file_path.display()
                     ))),
                     Err(err) => Err(format!(
                         "Failed to save payload to `{}`. Failed to write file:\n{}",
-                        &file_path.display(),
+                        file_path.display(),
                         indent_payload(&format!("{err:#?}"))
                     )),
                 },
                 Err(err) => Err(format!(
                     "Failed to save payload to `{}`. Serialization error:\n{}",
-                    &file_path.display(),
+                    file_path.display(),
                     indent_payload(&format!("{err:#?}"))
                 )),
             },
             Err(err) => Err(format!(
                 "Failed to save payload to `{}`. Failed to create file:\n{}",
-                &file_path.display(),
+                file_path.display(),
                 indent_payload(&format!("{err:#?}"))
             )),
         };
@@ -3604,7 +3604,7 @@ pub fn create_used_account_list_from_legacy_keychain(
     std::fs::create_dir_all(credentials_home_dir)?;
     if !used_account_list_path.exists() {
         std::fs::File::create(&used_account_list_path)
-            .wrap_err_with(|| format!("Failed to create file: {:?}", &used_account_list_path))?;
+            .wrap_err_with(|| format!("Failed to create file: {:?}", used_account_list_path))?;
     }
     if !used_account_list.is_empty() {
         let used_account_list_buf = serde_json::to_string(

--- a/src/transaction_signature_options/save_to_file/mod.rs
+++ b/src/transaction_signature_options/save_to_file/mod.rs
@@ -39,12 +39,12 @@ impl SaveToFileContext {
                     serde_json::to_value(FileSignedTransaction { signed_transaction })?;
 
                 std::fs::File::create(&file_path)
-                    .wrap_err_with(|| format!("Failed to create file: {:?}", &file_path))?
+                    .wrap_err_with(|| format!("Failed to create file: {:?}", file_path))?
                     .write(&serde_json::to_vec(&data_signed_transaction)?)
-                    .wrap_err_with(|| format!("Failed to write to file: {:?}", &file_path))?;
+                    .wrap_err_with(|| format!("Failed to write to file: {:?}", file_path))?;
                 eprintln!(
                     "\nThe file {:?} was created successfully. It has a signed transaction (serialized as base64).",
-                    &file_path
+                    file_path
                 );
 
                 eprintln!(
@@ -62,12 +62,12 @@ impl SaveToFileContext {
                     })?;
 
                 std::fs::File::create(&file_path)
-                    .wrap_err_with(|| format!("Failed to create file: {:?}", &file_path))?
+                    .wrap_err_with(|| format!("Failed to create file: {:?}", file_path))?
                     .write(&serde_json::to_vec(&data_signed_delegate_action)?)
-                    .wrap_err_with(|| format!("Failed to write to file: {:?}", &file_path))?;
+                    .wrap_err_with(|| format!("Failed to write to file: {:?}", file_path))?;
                 eprintln!(
                     "\nThe file {:?} was created successfully. It has a signed delegate action (serialized as base64).",
-                    &file_path
+                    file_path
                 );
 
                 eprintln!(

--- a/src/transaction_signature_options/sign_later/save_to_file.rs
+++ b/src/transaction_signature_options/sign_later/save_to_file.rs
@@ -28,16 +28,16 @@ impl SaveToFileContext {
         });
 
         std::fs::File::create(&file_path)
-            .wrap_err_with(|| format!("Failed to create file: {:?}", &file_path))?
+            .wrap_err_with(|| format!("Failed to create file: {:?}", file_path))?
             .write(&serde_json::to_vec_pretty(&data_unsigned_transaction)?)
-            .wrap_err_with(|| format!("Failed to write to file: {:?}", &file_path))?;
+            .wrap_err_with(|| format!("Failed to write to file: {:?}", file_path))?;
 
         if let crate::Verbosity::Quiet = previous_context.global_context.verbosity {
             return Ok(Self);
         }
         eprintln!(
             "\nThe file {:?} was created successfully. It has a unsigned transaction (serialized as base64).\nThis base64-encoded transaction can be signed and sent later. There is a helper command on near CLI that can do that:\n$ {} transaction sign-transaction",
-            &file_path,
+            file_path,
             crate::common::get_near_exec_path()
         );
         Ok(Self)

--- a/src/transaction_signature_options/sign_with_access_key_file/mod.rs
+++ b/src/transaction_signature_options/sign_with_access_key_file/mod.rs
@@ -56,7 +56,7 @@ impl SignAccessKeyFileContext {
         let data =
             std::fs::read_to_string(&scope.file_path).wrap_err("Access key file not found!")?;
         let account_json: super::AccountKeyPair = serde_json::from_str(&data)
-            .wrap_err_with(|| format!("Error reading data from file: {:?}", &scope.file_path))?;
+            .wrap_err_with(|| format!("Error reading data from file: {:?}", scope.file_path))?;
 
         let nonce_index = scope
             .nonce_index

--- a/src/transaction_signature_options/sign_with_legacy_keychain/mod.rs
+++ b/src/transaction_signature_options/sign_with_legacy_keychain/mod.rs
@@ -151,7 +151,7 @@ impl SignLegacyKeychainContext {
             serde_json::from_slice(&signer_access_key_json).wrap_err_with(|| {
                 format!(
                     "Error reading data from file: {:?}",
-                    &signer_access_key_file_path
+                    signer_access_key_file_path
                 )
             })?;
 


### PR DESCRIPTION
nearcore 2.13.0 is now on crates.io, so the DevEx stack can drop its RC pins.

Swaps the exact `=` 2.13 pre-release pins for stable crates.io versions:
- `near-crypto`, `near-primitives`, `near-jsonrpc-primitives`, `near-parameters`: `=0.37.0-rc.2` → `0.37.0`
- `near-jsonrpc-client`: `=0.22.0-rc.1` → `0.22.0` (keeps `any` feature)
- `near-socialdb-client`: `=0.16.0-rc.1` → `0.16.0`

Releases near-cli `0.28.0` (`0.28.0-rc.1` → `0.28.0`).

**Draft:** gated on `near-jsonrpc-client 0.22.0` and `near-socialdb-client 0.16.0` publishing (the 2.13.0 stable cascade). It cannot fully build until those land.