### PR TITLE
feat: sign gas-key meta-transactions as DelegateV2 (NEP-611)

### DIFF
--- a/src/commands/account/add_key/autogenerate_new_keypair/save_keypair_to_keychain/mod.rs
+++ b/src/commands/account/add_key/autogenerate_new_keypair/save_keypair_to_keychain/mod.rs
@@ -52,7 +52,14 @@ impl From<SaveKeypairToKeychainContext> for crate::commands::ActionContext {
                         ) => signed_transaction.transaction.signer_id().clone(),
                         crate::transaction_signature_options::SignedTransactionOrSignedDelegateAction::SignedDelegateAction(
                             signed_delegate_action,
-                        ) => signed_delegate_action.delegate_action.sender_id.clone()
+                        ) => signed_delegate_action.delegate_action.sender_id.clone(),
+                        crate::transaction_signature_options::SignedTransactionOrSignedDelegateAction::SignedDelegateActionV2(
+                            signed_delegate_action,
+                        ) => match &signed_delegate_action.delegate_action {
+                            near_primitives::action::delegate::VersionedDelegateActionPayload::V2(
+                                delegate_action,
+                            ) => delegate_action.sender_id.clone(),
+                        },
                     };
                     crate::common::save_access_key_to_keychain_or_save_to_legacy_keychain(
                         network_config.clone(),

--- a/src/commands/account/add_key/autogenerate_new_keypair/save_keypair_to_legacy_keychain/mod.rs
+++ b/src/commands/account/add_key/autogenerate_new_keypair/save_keypair_to_legacy_keychain/mod.rs
@@ -67,7 +67,14 @@ impl From<SaveKeypairToLegacyKeychainContext> for crate::commands::ActionContext
                         ) => signed_transaction.transaction.signer_id().clone(),
                         crate::transaction_signature_options::SignedTransactionOrSignedDelegateAction::SignedDelegateAction(
                             signed_delegate_action,
-                        ) => signed_delegate_action.delegate_action.sender_id.clone()
+                        ) => signed_delegate_action.delegate_action.sender_id.clone(),
+                        crate::transaction_signature_options::SignedTransactionOrSignedDelegateAction::SignedDelegateActionV2(
+                            signed_delegate_action,
+                        ) => match &signed_delegate_action.delegate_action {
+                            near_primitives::action::delegate::VersionedDelegateActionPayload::V2(
+                                delegate_action,
+                            ) => delegate_action.sender_id.clone(),
+                        },
                     };
                     let key_pair_properties_buf = item.generated_key_pair.keychain_json()?;
                     let key_id = item.generated_key_pair.keychain_key_id()?;

--- a/src/commands/transaction/reconstruct_transaction/mod.rs
+++ b/src/commands/transaction/reconstruct_transaction/mod.rs
@@ -288,9 +288,9 @@ fn action_transformation(
                 }
             )))
         }
-        Action::Delegate(_) | Action::DelegateV2(_) => {
-            panic!("Internal error: Delegate/DelegateV2 action should have been handled before calling action_transformation.");
-        }
+        Action::Delegate(_) | Action::DelegateV2(_) => Err(color_eyre::eyre::eyre!(
+            "Reconstructing a delegate action (Delegate or DelegateV2) is only supported when it is the transaction's single action (a standalone meta-transaction), which is unwrapped into its inner actions beforehand. A delegate action alongside other actions cannot be reconstructed."
+        )),
         Action::DeployGlobalContract(action) => {
             let file_path = CustomType::<crate::types::path_buf::PathBuf>::new("Enter the file path where to save the contract:")
                 .with_starting_input("reconstruct-transaction-deploy-code.wasm")

--- a/src/commands/transaction/reconstruct_transaction/mod.rs
+++ b/src/commands/transaction/reconstruct_transaction/mod.rs
@@ -61,16 +61,42 @@ impl TransactionInfoContext {
                         ))
                     );
 
-                    if prepopulated_transaction.actions.len() == 1
-                        && let near_primitives::transaction::Action::Delegate(
-                            signed_delegate_action,
-                        ) = &prepopulated_transaction.actions[0]
-                    {
-                        prepopulated_transaction = crate::commands::PrepopulatedTransaction {
-                            signer_id: signed_delegate_action.delegate_action.sender_id.clone(),
-                            receiver_id: signed_delegate_action.delegate_action.receiver_id.clone(),
-                            actions: signed_delegate_action.delegate_action.get_actions(),
-                        };
+                    // A meta-transaction is reconstructed from its inner actions:
+                    // unwrap a lone Delegate (NEP-366) or DelegateV2 (NEP-611)
+                    // action into the sender/receiver/actions it delegates.
+                    if prepopulated_transaction.actions.len() == 1 {
+                        match &prepopulated_transaction.actions[0] {
+                            near_primitives::transaction::Action::Delegate(
+                                signed_delegate_action,
+                            ) => {
+                                prepopulated_transaction = crate::commands::PrepopulatedTransaction {
+                                    signer_id: signed_delegate_action
+                                        .delegate_action
+                                        .sender_id
+                                        .clone(),
+                                    receiver_id: signed_delegate_action
+                                        .delegate_action
+                                        .receiver_id
+                                        .clone(),
+                                    actions: signed_delegate_action.delegate_action.get_actions(),
+                                };
+                            }
+                            near_primitives::transaction::Action::DelegateV2(
+                                signed_delegate_action,
+                            ) => match &signed_delegate_action.delegate_action {
+                                near_primitives::action::delegate::VersionedDelegateActionPayload::V2(
+                                    delegate_action,
+                                ) => {
+                                    prepopulated_transaction =
+                                        crate::commands::PrepopulatedTransaction {
+                                            signer_id: delegate_action.sender_id.clone(),
+                                            receiver_id: delegate_action.receiver_id.clone(),
+                                            actions: delegate_action.get_actions(),
+                                        };
+                                }
+                            },
+                            _ => {}
+                        }
                     }
 
                     let cmd =
@@ -262,12 +288,9 @@ fn action_transformation(
                 }
             )))
         }
-        Action::Delegate(_) => {
-            panic!("Internal error: Delegate action should have been handled before calling action_transformation.");
+        Action::Delegate(_) | Action::DelegateV2(_) => {
+            panic!("Internal error: Delegate/DelegateV2 action should have been handled before calling action_transformation.");
         }
-        Action::DelegateV2(_) => Err(color_eyre::eyre::eyre!(
-            "Reconstructing DelegateV2 (meta) transactions is not supported."
-        )),
         Action::DeployGlobalContract(action) => {
             let file_path = CustomType::<crate::types::path_buf::PathBuf>::new("Enter the file path where to save the contract:")
                 .with_starting_input("reconstruct-transaction-deploy-code.wasm")

--- a/src/commands/transaction/send_meta_transaction/mod.rs
+++ b/src/commands/transaction/send_meta_transaction/mod.rs
@@ -31,7 +31,7 @@ pub enum SignedMetaTransactionType {
 #[derive(Debug, Clone)]
 pub struct SignedMetaTransactionContext {
     global_context: crate::GlobalContext,
-    signed_delegate_action: near_primitives::action::delegate::SignedDelegateAction,
+    signed_delegate_action: crate::types::signed_delegate_action::SignedDelegateActionAsBase64,
 }
 
 #[derive(Debug, Clone, interactive_clap::InteractiveClap)]
@@ -55,7 +55,7 @@ impl Base64SignedMetaTransactionContext {
     ) -> color_eyre::eyre::Result<Self> {
         Ok(Self(SignedMetaTransactionContext {
             global_context: previous_context,
-            signed_delegate_action: scope.signed_delegate_action.clone().into(),
+            signed_delegate_action: scope.signed_delegate_action.clone(),
         }))
     }
 }
@@ -100,7 +100,7 @@ impl FileWithBase64SignedMetaTransactionContext {
 
         Ok(Self(SignedMetaTransactionContext {
             global_context: previous_context,
-            signed_delegate_action: signed_delegate_action.into(),
+            signed_delegate_action,
         }))
     }
 }

--- a/src/commands/transaction/send_meta_transaction/sign_as/mod.rs
+++ b/src/commands/transaction/send_meta_transaction/sign_as/mod.rs
@@ -28,11 +28,11 @@ impl RelayerAccountIdContext {
                 let signed_delegate_action = previous_context.signed_delegate_action.clone();
 
                 move |_network_config| {
-                    let actions = vec![signed_delegate_action.clone().into()];
+                    let actions = vec![signed_delegate_action.clone().into_action()];
 
                     Ok(crate::commands::PrepopulatedTransaction {
                         signer_id: signer_id.clone(),
-                        receiver_id: signed_delegate_action.delegate_action.sender_id.clone(),
+                        receiver_id: signed_delegate_action.sender_id().clone(),
                         actions,
                     })
                 }
@@ -41,10 +41,12 @@ impl RelayerAccountIdContext {
         let on_before_signing_callback: crate::commands::OnBeforeSigningCallback =
             std::sync::Arc::new({
                 move |prepopulated_unsigned_transaction, _network_config| {
-                    prepopulated_unsigned_transaction.actions =
-                        vec![near_primitives::transaction::Action::Delegate(Box::new(
-                            previous_context.signed_delegate_action.clone(),
-                        ))];
+                    prepopulated_unsigned_transaction.actions = vec![
+                        previous_context
+                            .signed_delegate_action
+                            .clone()
+                            .into_action(),
+                    ];
                     Ok(())
                 }
             });

--- a/src/transaction_signature_options/display/mod.rs
+++ b/src/transaction_signature_options/display/mod.rs
@@ -36,19 +36,26 @@ impl DisplayContext {
             super::SignedTransactionOrSignedDelegateAction::SignedDelegateAction(
                 signed_delegate_action,
             ) => {
-                eprintln!(
-                    "\nSigned delegate action (serialized as base64):\n{}\n",
-                    crate::types::signed_delegate_action::SignedDelegateActionAsBase64::from(
-                        signed_delegate_action
-                    )
-                );
-                eprintln!(
-                    "This base64-encoded signed delegate action is ready to be sent to the meta-transaction relayer. There is a helper command on near CLI that can do that:\n$ {} transaction send-meta-transaction\n",
-                    crate::common::get_near_exec_path()
-                );
-                eprintln!("{storage_message}");
+                display_signed_delegate_action(signed_delegate_action.into(), &storage_message);
+            }
+            super::SignedTransactionOrSignedDelegateAction::SignedDelegateActionV2(
+                signed_delegate_action,
+            ) => {
+                display_signed_delegate_action(signed_delegate_action.into(), &storage_message);
             }
         }
         Ok(Self)
     }
+}
+
+fn display_signed_delegate_action(
+    signed_delegate_action: crate::types::signed_delegate_action::SignedDelegateActionAsBase64,
+    storage_message: &str,
+) {
+    eprintln!("\nSigned delegate action (serialized as base64):\n{signed_delegate_action}\n");
+    eprintln!(
+        "This base64-encoded signed delegate action is ready to be sent to the meta-transaction relayer. There is a helper command on near CLI that can do that:\n$ {} transaction send-meta-transaction\n",
+        crate::common::get_near_exec_path()
+    );
+    eprintln!("{storage_message}");
 }

--- a/src/transaction_signature_options/mod.rs
+++ b/src/transaction_signature_options/mod.rs
@@ -132,7 +132,11 @@ pub struct SubmitContext {
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub enum SignedTransactionOrSignedDelegateAction {
     SignedTransaction(near_primitives::transaction::SignedTransaction),
+    /// NEP-366 meta-transaction, signed with an ordinary access key.
     SignedDelegateAction(near_primitives::action::delegate::SignedDelegateAction),
+    /// NEP-611 meta-transaction, signed with a gas key (its nonce carries the
+    /// parallel-nonce index that a V1 `SignedDelegateAction` cannot encode).
+    SignedDelegateActionV2(near_primitives::action::delegate::VersionedSignedDelegateAction),
 }
 
 impl From<near_primitives::transaction::SignedTransaction>
@@ -153,57 +157,115 @@ impl From<near_primitives::action::delegate::SignedDelegateAction>
     }
 }
 
-/// A gas key cannot be used to sign a meta-transaction yet: a (v1)
-/// `DelegateAction` only carries a plain `nonce`, so delegating a gas-key
-/// transaction would drop its `nonce_index` and the runtime would reject the
-/// result (`DelegateActionRequiresNonGasKey`). Full support needs DelegateV2,
-/// which is out of the 2.13 scope. Reject the combination up front with a clear
-/// error. Called from every delegate-action path (the shared
-/// [`get_signed_delegate_action`] and the two Ledger manual branches).
-pub fn ensure_gas_key_not_delegated(
+impl From<near_primitives::action::delegate::VersionedSignedDelegateAction>
+    for SignedTransactionOrSignedDelegateAction
+{
+    fn from(
+        signed_delegate_action: near_primitives::action::delegate::VersionedSignedDelegateAction,
+    ) -> Self {
+        Self::SignedDelegateActionV2(signed_delegate_action)
+    }
+}
+
+/// A gas key cannot sign a meta-transaction on Ledger yet: the Ledger app only
+/// implements NEP-366 delegate-action signing (`sign_message_nep366_delegate_action`),
+/// which produces a V1 `DelegateAction` that has no room for the gas key's nonce
+/// index. Carrying it in a V1 delegate action would drop the index and the
+/// runtime would reject the result (`DelegateActionRequiresNonGasKey`); the fix
+/// (a NEP-611 `DelegateActionV2`) needs a Ledger-app signing instruction that
+/// does not exist. Reject the combination up front with a clear error. Called
+/// from the two Ledger manual delegate-action branches; the software signers use
+/// [`get_signed_delegate_action`], which builds a V2 delegate action instead.
+pub fn ensure_ledger_gas_key_not_delegated(
     unsigned_transaction: &near_primitives::transaction::Transaction,
 ) -> color_eyre::eyre::Result<()> {
     if unsigned_transaction.nonce().nonce_index().is_some() {
         color_eyre::eyre::bail!(
-            "Signing with a gas key is not supported for meta-transactions (--sign-as-delegate-action) yet: a DelegateAction cannot carry the gas key's nonce index (requires DelegateV2). Re-run without --sign-as-delegate-action, or sign with an ordinary access key."
+            "Signing a meta-transaction (--sign-as-delegate-action) with a gas key is not supported on Ledger yet: the Ledger app can only sign NEP-366 delegate actions, which cannot carry a gas key's nonce index (that requires a NEP-611 DelegateV2 action). Sign with a software key, or re-run without --sign-as-delegate-action."
         );
     }
     Ok(())
 }
 
+/// Build and sign a delegate action for a meta-transaction.
+///
+/// Branches on the nonce: an ordinary access key (plain nonce) produces a NEP-366
+/// V1 `SignedDelegateAction`; a gas key (`nonce_index.is_some()`) produces a
+/// NEP-611 `VersionedSignedDelegateAction` (V2), whose `TransactionNonce` carries
+/// the parallel-nonce index. Each version is signed under its own NEP-461 message
+/// domain, so the two signatures are never interchangeable.
 pub fn get_signed_delegate_action(
     unsigned_transaction: near_primitives::transaction::Transaction,
     public_key: &near_crypto::PublicKey,
     private_key: near_crypto::SecretKey,
     max_block_height: u64,
-) -> color_eyre::eyre::Result<near_primitives::action::delegate::SignedDelegateAction> {
+) -> color_eyre::eyre::Result<SignedTransactionOrSignedDelegateAction> {
     use near_primitives::signable_message::{SignableMessage, SignableMessageType};
 
-    ensure_gas_key_not_delegated(&unsigned_transaction)?;
+    let sender_id = unsigned_transaction.signer_id().clone();
+    let receiver_id = unsigned_transaction.receiver_id().clone();
+    let delegate_public_key = unsigned_transaction.public_key().clone();
+    let nonce = unsigned_transaction.nonce();
 
-    let mut delegate_action = near_primitives::action::delegate::DelegateAction {
-        sender_id: unsigned_transaction.signer_id().clone(),
-        receiver_id: unsigned_transaction.receiver_id().clone(),
-        actions: vec![],
-        nonce: unsigned_transaction.nonce().nonce(),
-        max_block_height,
-        public_key: unsigned_transaction.public_key().clone(),
-    };
-
-    delegate_action.actions = unsigned_transaction
+    let actions = unsigned_transaction
         .take_actions()
         .into_iter()
         .map(near_primitives::action::delegate::NonDelegateAction::try_from)
-        .collect::<Result<_, _>>()
+        .collect::<Result<Vec<_>, _>>()
         .expect("Internal error: can not convert the action to non delegate action (delegate action can not be delegated again).");
 
-    // create a new signature here signing the delegate action + discriminant
-    let signable = SignableMessage::new(&delegate_action, SignableMessageType::DelegateAction);
-    let signer = near_crypto::InMemorySigner::from_secret_key(
-        delegate_action.sender_id.clone(),
-        private_key,
-    );
-    let signature = signable.sign(&signer);
+    let signer = near_crypto::InMemorySigner::from_secret_key(sender_id.clone(), private_key);
+
+    let (signature, signed) = match nonce.nonce_index() {
+        None => {
+            // Ordinary access key: NEP-366 V1 delegate action (plain nonce).
+            let delegate_action = near_primitives::action::delegate::DelegateAction {
+                sender_id,
+                receiver_id,
+                actions,
+                nonce: nonce.nonce(),
+                max_block_height,
+                public_key: delegate_public_key,
+            };
+            let signature =
+                SignableMessage::new(&delegate_action, SignableMessageType::DelegateAction)
+                    .sign(&signer);
+            (
+                signature.clone(),
+                SignedTransactionOrSignedDelegateAction::SignedDelegateAction(
+                    near_primitives::action::delegate::SignedDelegateAction {
+                        delegate_action,
+                        signature,
+                    },
+                ),
+            )
+        }
+        Some(_) => {
+            // Gas key: NEP-611 V2 delegate action; its nonce carries the parallel-nonce index.
+            let delegate_action = near_primitives::action::delegate::DelegateActionV2 {
+                sender_id,
+                receiver_id,
+                actions,
+                nonce,
+                max_block_height,
+                public_key: delegate_public_key,
+            };
+            let payload = near_primitives::action::delegate::VersionedDelegateActionPayload::V2(
+                delegate_action,
+            );
+            let signature =
+                SignableMessage::new(&payload, SignableMessageType::DelegateActionV2).sign(&signer);
+            (
+                signature.clone(),
+                SignedTransactionOrSignedDelegateAction::SignedDelegateActionV2(
+                    near_primitives::action::delegate::VersionedSignedDelegateAction {
+                        delegate_action: payload,
+                        signature,
+                    },
+                ),
+            )
+        }
+    };
 
     tracing::info!(
         parent: &tracing::Span::none(),
@@ -213,10 +275,7 @@ pub fn get_signed_delegate_action(
         ))
     );
 
-    Ok(near_primitives::action::delegate::SignedDelegateAction {
-        delegate_action,
-        signature,
-    })
+    Ok(signed)
 }
 
 /// The nonce (and, for gas keys, the nonce index) to use for the next transaction.
@@ -416,15 +475,15 @@ mod tests {
     }
 
     #[test]
-    fn plain_transactions_may_be_delegated() {
+    fn plain_transactions_may_be_delegated_on_ledger() {
         let tx = build_unsigned_transaction(sample_tx_v0(), NonceResolution::Plain { nonce: 1 });
-        assert!(ensure_gas_key_not_delegated(&tx).is_ok());
+        assert!(ensure_ledger_gas_key_not_delegated(&tx).is_ok());
     }
 
     #[test]
-    fn gas_key_transactions_cannot_be_delegated() {
-        // A gas-key nonce carries a nonce_index that a v1 DelegateAction can't
-        // encode, so meta-transactions must be refused up front.
+    fn gas_key_transactions_cannot_be_delegated_on_ledger() {
+        // The Ledger app can only sign NEP-366 (V1) delegate actions, which
+        // can't encode a gas key's nonce_index, so the combination is refused.
         let tx = build_unsigned_transaction(
             sample_tx_v0(),
             NonceResolution::GasKey {
@@ -432,6 +491,70 @@ mod tests {
                 nonce_index: 0,
             },
         );
-        assert!(ensure_gas_key_not_delegated(&tx).is_err());
+        assert!(ensure_ledger_gas_key_not_delegated(&tx).is_err());
+    }
+
+    fn sample_tx_v0_with_key(
+        public_key: near_crypto::PublicKey,
+        nonce: near_primitives::types::Nonce,
+    ) -> near_primitives::transaction::TransactionV0 {
+        near_primitives::transaction::TransactionV0 {
+            public_key,
+            nonce,
+            ..sample_tx_v0()
+        }
+    }
+
+    #[test]
+    fn plain_meta_transaction_signs_delegate_v1() {
+        // An ordinary access key signs a NEP-366 (V1) delegate action.
+        let secret_key = near_crypto::SecretKey::from_random(near_crypto::KeyType::ED25519);
+        let public_key = secret_key.public_key();
+        let tx = build_unsigned_transaction(
+            sample_tx_v0_with_key(public_key.clone(), 7),
+            NonceResolution::Plain { nonce: 7 },
+        );
+
+        match get_signed_delegate_action(tx, &public_key, secret_key, 1000).unwrap() {
+            SignedTransactionOrSignedDelegateAction::SignedDelegateAction(signed) => {
+                assert!(signed.verify(), "the V1 delegate signature must verify");
+                assert_eq!(signed.delegate_action.nonce, 7);
+                assert_eq!(signed.delegate_action.max_block_height, 1000);
+                assert_eq!(signed.delegate_action.public_key, public_key);
+            }
+            other => panic!("expected a V1 SignedDelegateAction, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn gas_key_meta_transaction_signs_delegate_v2() {
+        // A gas key signs a NEP-611 (V2) delegate action whose nonce carries the
+        // parallel-nonce index; the signature verifies under the V2 domain.
+        let secret_key = near_crypto::SecretKey::from_random(near_crypto::KeyType::ED25519);
+        let public_key = secret_key.public_key();
+        let tx = build_unsigned_transaction(
+            sample_tx_v0_with_key(public_key.clone(), 7),
+            NonceResolution::GasKey {
+                nonce: 7,
+                nonce_index: 3,
+            },
+        );
+
+        match get_signed_delegate_action(tx, &public_key, secret_key, 1000).unwrap() {
+            SignedTransactionOrSignedDelegateAction::SignedDelegateActionV2(signed) => {
+                assert!(signed.verify(), "the V2 delegate signature must verify");
+                match &signed.delegate_action {
+                    near_primitives::action::delegate::VersionedDelegateActionPayload::V2(
+                        delegate_action,
+                    ) => {
+                        assert_eq!(delegate_action.nonce.nonce(), 7);
+                        assert_eq!(delegate_action.nonce.nonce_index(), Some(3));
+                        assert_eq!(delegate_action.max_block_height, 1000);
+                        assert_eq!(delegate_action.public_key, public_key);
+                    }
+                }
+            }
+            other => panic!("expected a V2 SignedDelegateActionV2, got {other:?}"),
+        }
     }
 }

--- a/src/transaction_signature_options/save_to_file/mod.rs
+++ b/src/transaction_signature_options/save_to_file/mod.rs
@@ -87,7 +87,7 @@ fn save_signed_delegate_action_to_file(
 
     std::fs::File::create(file_path)
         .wrap_err_with(|| format!("Failed to create file: {:?}", file_path))?
-        .write(&serde_json::to_vec(&data_signed_delegate_action)?)
+        .write_all(&serde_json::to_vec(&data_signed_delegate_action)?)
         .wrap_err_with(|| format!("Failed to write to file: {:?}", file_path))?;
     eprintln!(
         "\nThe file {:?} was created successfully. It has a signed delegate action (serialized as base64).",

--- a/src/transaction_signature_options/save_to_file/mod.rs
+++ b/src/transaction_signature_options/save_to_file/mod.rs
@@ -56,29 +56,50 @@ impl SaveToFileContext {
             super::SignedTransactionOrSignedDelegateAction::SignedDelegateAction(
                 signed_delegate_action,
             ) => {
-                let data_signed_delegate_action =
-                    serde_json::to_value(&FileSignedMetaTransaction {
-                        signed_delegate_action: signed_delegate_action.into(),
-                    })?;
-
-                std::fs::File::create(&file_path)
-                    .wrap_err_with(|| format!("Failed to create file: {:?}", file_path))?
-                    .write(&serde_json::to_vec(&data_signed_delegate_action)?)
-                    .wrap_err_with(|| format!("Failed to write to file: {:?}", file_path))?;
-                eprintln!(
-                    "\nThe file {:?} was created successfully. It has a signed delegate action (serialized as base64).",
-                    file_path
-                );
-
-                eprintln!(
-                    "This base64-encoded signed delegate action is ready to be sent to the meta-transaction relayer. There is a helper command on near CLI that can do that:\n$ {} transaction send-meta-transaction\n",
-                    crate::common::get_near_exec_path()
-                );
-                eprintln!("{storage_message}");
+                save_signed_delegate_action_to_file(
+                    &file_path,
+                    signed_delegate_action.into(),
+                    &storage_message,
+                )?;
+            }
+            super::SignedTransactionOrSignedDelegateAction::SignedDelegateActionV2(
+                signed_delegate_action,
+            ) => {
+                save_signed_delegate_action_to_file(
+                    &file_path,
+                    signed_delegate_action.into(),
+                    &storage_message,
+                )?;
             }
         }
         Ok(Self)
     }
+}
+
+fn save_signed_delegate_action_to_file(
+    file_path: &std::path::Path,
+    signed_delegate_action: crate::types::signed_delegate_action::SignedDelegateActionAsBase64,
+    storage_message: &str,
+) -> color_eyre::eyre::Result<()> {
+    let data_signed_delegate_action = serde_json::to_value(FileSignedMetaTransaction {
+        signed_delegate_action,
+    })?;
+
+    std::fs::File::create(file_path)
+        .wrap_err_with(|| format!("Failed to create file: {:?}", file_path))?
+        .write(&serde_json::to_vec(&data_signed_delegate_action)?)
+        .wrap_err_with(|| format!("Failed to write to file: {:?}", file_path))?;
+    eprintln!(
+        "\nThe file {:?} was created successfully. It has a signed delegate action (serialized as base64).",
+        file_path
+    );
+
+    eprintln!(
+        "This base64-encoded signed delegate action is ready to be sent to the meta-transaction relayer. There is a helper command on near CLI that can do that:\n$ {} transaction send-meta-transaction\n",
+        crate::common::get_near_exec_path()
+    );
+    eprintln!("{storage_message}");
+    Ok(())
 }
 
 impl SaveToFile {
@@ -89,7 +110,8 @@ impl SaveToFile {
             super::SignedTransactionOrSignedDelegateAction::SignedTransaction(_) => {
                 "signed-transaction-info.json"
             }
-            super::SignedTransactionOrSignedDelegateAction::SignedDelegateAction(_) => {
+            super::SignedTransactionOrSignedDelegateAction::SignedDelegateAction(_)
+            | super::SignedTransactionOrSignedDelegateAction::SignedDelegateActionV2(_) => {
                 "signed-meta-transaction-info.json"
             }
         };

--- a/src/transaction_signature_options/send/mod.rs
+++ b/src/transaction_signature_options/send/mod.rs
@@ -95,7 +95,7 @@ impl SendContext {
                 .is_some() =>
             {
                 match sending_delegate_action(
-                    signed_delegate_action,
+                    signed_delegate_action.into(),
                     previous_context.network_config
                         .meta_transaction_relayer_url
                         .expect("Internal error: Meta-transaction relayer URL must be Some() at this point"),
@@ -114,7 +114,35 @@ impl SendContext {
                     Err(report) => return Err(color_eyre::Report::msg(report)),
                 };
             }
-            super::SignedTransactionOrSignedDelegateAction::SignedDelegateAction(..) => {
+            super::SignedTransactionOrSignedDelegateAction::SignedDelegateActionV2(
+                signed_delegate_action,
+            ) if previous_context
+                .network_config
+                .meta_transaction_relayer_url
+                .is_some() =>
+            {
+                match sending_delegate_action(
+                    signed_delegate_action.into(),
+                    previous_context.network_config
+                        .meta_transaction_relayer_url
+                        .expect("Internal error: Meta-transaction relayer URL must be Some() at this point"),
+                ){
+                    Ok(relayer_response) => {
+                        if relayer_response.status().is_success() {
+                            let response_text = relayer_response.text().map_err(color_eyre::Report::msg)?;
+                            eprintln!("\nRelayer Response text: {response_text}");
+                        } else {
+                            eprintln!(
+                                "\nRequest failed with status code: {}",
+                                relayer_response.status()
+                            );
+                        }
+                    }
+                    Err(report) => return Err(color_eyre::Report::msg(report)),
+                };
+            }
+            super::SignedTransactionOrSignedDelegateAction::SignedDelegateAction(..)
+            | super::SignedTransactionOrSignedDelegateAction::SignedDelegateActionV2(..) => {
                 // Fallback to `display` command when `meta_transaction_relayer_url` is not configured.
                 super::display::DisplayContext::from_previous_context(
                     previous_context.clone(),
@@ -195,7 +223,7 @@ pub fn sleep_before_retry(context_message: String) {
 
 #[tracing::instrument(name = "Broadcasting delegate action via a relayer url", skip_all)]
 fn sending_delegate_action(
-    signed_delegate_action: near_primitives::action::delegate::SignedDelegateAction,
+    signed_delegate_action: crate::types::signed_delegate_action::SignedDelegateActionAsBase64,
     meta_transaction_relayer_url: url::Url,
 ) -> Result<reqwest::blocking::Response, reqwest::Error> {
     tracing::Span::current().pb_set_message(meta_transaction_relayer_url.as_str());
@@ -203,9 +231,7 @@ fn sending_delegate_action(
 
     let client = reqwest::blocking::Client::new();
     let request_payload = serde_json::json!({
-        "signed_delegate_action": crate::types::signed_delegate_action::SignedDelegateActionAsBase64::from(
-            signed_delegate_action
-        ).to_string()
+        "signed_delegate_action": signed_delegate_action.to_string()
     });
     tracing::info!(
         target: "near_teach_me",

--- a/src/transaction_signature_options/sign_with_access_key_file/mod.rs
+++ b/src/transaction_signature_options/sign_with_access_key_file/mod.rs
@@ -124,7 +124,7 @@ impl SignAccessKeyFileContext {
             return Ok(Self {
                 network_config: previous_context.network_config,
                 global_context: previous_context.global_context,
-                signed_transaction_or_signed_delegate_action: signed_delegate_action.into(),
+                signed_transaction_or_signed_delegate_action: signed_delegate_action,
                 on_before_sending_transaction_callback: previous_context
                     .on_before_sending_transaction_callback,
                 on_after_sending_transaction_callback: previous_context

--- a/src/transaction_signature_options/sign_with_keychain/mod.rs
+++ b/src/transaction_signature_options/sign_with_keychain/mod.rs
@@ -228,7 +228,7 @@ impl SignKeychainContext {
             return Ok(Self {
                 network_config: previous_context.network_config,
                 global_context: previous_context.global_context,
-                signed_transaction_or_signed_delegate_action: signed_delegate_action.into(),
+                signed_transaction_or_signed_delegate_action: signed_delegate_action,
                 on_before_sending_transaction_callback: previous_context
                     .on_before_sending_transaction_callback,
                 on_after_sending_transaction_callback: previous_context

--- a/src/transaction_signature_options/sign_with_ledger/mod.rs
+++ b/src/transaction_signature_options/sign_with_ledger/mod.rs
@@ -261,7 +261,7 @@ fn sign_transaction_with_usb(
         super::build_unsigned_transaction(unsigned_transaction, nonce_resolution);
 
     if previous_context.sign_as_delegate_action {
-        super::ensure_gas_key_not_delegated(&unsigned_transaction)?;
+        super::ensure_ledger_gas_key_not_delegated(&unsigned_transaction)?;
 
         let max_block_height = block_height
             + meta_transaction_valid_for.unwrap_or(super::META_TRANSACTION_VALID_FOR_DEFAULT);
@@ -527,7 +527,7 @@ fn sign_transaction_with_ble(
         super::build_unsigned_transaction(unsigned_transaction, nonce_resolution);
 
     if previous_context.sign_as_delegate_action {
-        super::ensure_gas_key_not_delegated(&unsigned_transaction)?;
+        super::ensure_ledger_gas_key_not_delegated(&unsigned_transaction)?;
 
         let max_block_height = block_height
             + meta_transaction_valid_for.unwrap_or(super::META_TRANSACTION_VALID_FOR_DEFAULT);

--- a/src/transaction_signature_options/sign_with_legacy_keychain/mod.rs
+++ b/src/transaction_signature_options/sign_with_legacy_keychain/mod.rs
@@ -217,7 +217,7 @@ impl SignLegacyKeychainContext {
             return Ok(Self {
                 network_config: previous_context.network_config,
                 global_context: previous_context.global_context,
-                signed_transaction_or_signed_delegate_action: signed_delegate_action.into(),
+                signed_transaction_or_signed_delegate_action: signed_delegate_action,
                 on_before_sending_transaction_callback: previous_context
                     .on_before_sending_transaction_callback,
                 on_after_sending_transaction_callback: previous_context

--- a/src/transaction_signature_options/sign_with_private_key/mod.rs
+++ b/src/transaction_signature_options/sign_with_private_key/mod.rs
@@ -119,7 +119,7 @@ impl SignPrivateKeyContext {
             return Ok(Self {
                 network_config: previous_context.network_config,
                 global_context: previous_context.global_context,
-                signed_transaction_or_signed_delegate_action: signed_delegate_action.into(),
+                signed_transaction_or_signed_delegate_action: signed_delegate_action,
                 on_before_sending_transaction_callback: previous_context
                     .on_before_sending_transaction_callback,
                 on_after_sending_transaction_callback: previous_context

--- a/src/transaction_signature_options/sign_with_seed_phrase/mod.rs
+++ b/src/transaction_signature_options/sign_with_seed_phrase/mod.rs
@@ -129,7 +129,7 @@ impl SignSeedPhraseContext {
             return Ok(Self {
                 network_config: previous_context.network_config,
                 global_context: previous_context.global_context,
-                signed_transaction_or_signed_delegate_action: signed_delegate_action.into(),
+                signed_transaction_or_signed_delegate_action: signed_delegate_action,
                 on_before_sending_transaction_callback: previous_context
                     .on_before_sending_transaction_callback,
                 on_after_sending_transaction_callback: previous_context

--- a/src/types/signed_delegate_action.rs
+++ b/src/types/signed_delegate_action.rs
@@ -91,7 +91,7 @@ impl<'de> serde::Deserialize<'de> for SignedDelegateActionAsBase64 {
         )
         .map_err(|err| {
             serde::de::Error::custom(format!(
-                "The value could not decoded from base64 due to: {err}"
+                "The value could not be decoded from base64 due to: {err}"
             ))
         })?;
         Self::from_borsh(&signed_delegate_action_borsh).map_err(serde::de::Error::custom)

--- a/src/types/signed_delegate_action.rs
+++ b/src/types/signed_delegate_action.rs
@@ -1,8 +1,66 @@
 use near_primitives::{borsh, borsh::BorshDeserialize};
 
+/// A signed delegate action of either meta-transaction version, carried in and
+/// out of the CLI as a base64-encoded borsh blob (the form relayers accept).
+///
+/// * `V1` — NEP-366 [`SignedDelegateAction`], signed with an ordinary access key
+///   (a plain nonce).
+/// * `V2` — NEP-611 [`VersionedSignedDelegateAction`], signed with a gas key; its
+///   nonce carries the parallel-nonce index that a V1 delegate action cannot
+///   encode.
+///
+/// [`SignedDelegateAction`]: near_primitives::action::delegate::SignedDelegateAction
+/// [`VersionedSignedDelegateAction`]: near_primitives::action::delegate::VersionedSignedDelegateAction
 #[derive(Debug, Clone)]
-pub struct SignedDelegateActionAsBase64 {
-    inner: near_primitives::action::delegate::SignedDelegateAction,
+pub enum SignedDelegateActionAsBase64 {
+    V1(near_primitives::action::delegate::SignedDelegateAction),
+    V2(near_primitives::action::delegate::VersionedSignedDelegateAction),
+}
+
+impl SignedDelegateActionAsBase64 {
+    /// The account on whose behalf the delegated actions run (the meta-transaction sender).
+    pub fn sender_id(&self) -> &near_primitives::types::AccountId {
+        match self {
+            Self::V1(signed_delegate_action) => &signed_delegate_action.delegate_action.sender_id,
+            Self::V2(signed_delegate_action) => match &signed_delegate_action.delegate_action {
+                near_primitives::action::delegate::VersionedDelegateActionPayload::V2(
+                    delegate_action,
+                ) => &delegate_action.sender_id,
+            },
+        }
+    }
+
+    /// Wrap the signed delegate action in the matching relay action
+    /// (`Action::Delegate` for V1, `Action::DelegateV2` for V2).
+    pub fn into_action(self) -> near_primitives::transaction::Action {
+        match self {
+            Self::V1(signed_delegate_action) => signed_delegate_action.into(),
+            Self::V2(signed_delegate_action) => signed_delegate_action.into(),
+        }
+    }
+
+    fn to_borsh(&self) -> std::io::Result<Vec<u8>> {
+        match self {
+            Self::V1(signed_delegate_action) => borsh::to_vec(signed_delegate_action),
+            Self::V2(signed_delegate_action) => borsh::to_vec(signed_delegate_action),
+        }
+    }
+
+    /// Decode a borsh blob into the right version. The two encodings can't
+    /// collide: a V2 blob begins with the payload enum discriminant `0x00`,
+    /// whereas a V1 blob begins with the borsh length prefix of the sender
+    /// account id (a little-endian `u32` that is always >= 2). Try V1 first and
+    /// fall back to V2.
+    fn from_borsh(bytes: &[u8]) -> Result<Self, String> {
+        if let Ok(signed_delegate_action) =
+            near_primitives::action::delegate::SignedDelegateAction::try_from_slice(bytes)
+        {
+            return Ok(Self::V1(signed_delegate_action));
+        }
+        near_primitives::action::delegate::VersionedSignedDelegateAction::try_from_slice(bytes)
+            .map(Self::V2)
+            .map_err(|err| format!("delegate action could not be deserialized from borsh: {err}"))
+    }
 }
 
 impl serde::Serialize for SignedDelegateActionAsBase64 {
@@ -10,7 +68,7 @@ impl serde::Serialize for SignedDelegateActionAsBase64 {
     where
         S: serde::Serializer,
     {
-        let signed_delegate_action_borsh = borsh::to_vec(&self.inner).map_err(|err| {
+        let signed_delegate_action_borsh = self.to_borsh().map_err(|err| {
             serde::ser::Error::custom(format!(
                 "The value could not be borsh encoded due to: {err}"
             ))
@@ -36,37 +94,25 @@ impl<'de> serde::Deserialize<'de> for SignedDelegateActionAsBase64 {
                 "The value could not decoded from base64 due to: {err}"
             ))
         })?;
-        let signed_delegate_action = borsh::from_slice::<
-            near_primitives::action::delegate::SignedDelegateAction,
-        >(&signed_delegate_action_borsh)
-        .map_err(|err| {
-            serde::de::Error::custom(format!(
-                "The value could not decoded from borsh due to: {err}"
-            ))
-        })?;
-        Ok(Self {
-            inner: signed_delegate_action,
-        })
+        Self::from_borsh(&signed_delegate_action_borsh).map_err(serde::de::Error::custom)
     }
 }
 
 impl std::str::FromStr for SignedDelegateActionAsBase64 {
     type Err = String;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(Self {
-            inner: near_primitives::action::delegate::SignedDelegateAction::try_from_slice(
-                &near_primitives::serialize::from_base64(s)
-                .map_err(|err| format!("parsing of signed delegate action failed due to base64 sequence being invalid: {err}"))?,
-            )
-            .map_err(|err| format!("delegate action could not be deserialized from borsh: {err}"))?,
-        })
+        let signed_delegate_action_borsh = near_primitives::serialize::from_base64(s).map_err(
+            |err| format!("parsing of signed delegate action failed due to base64 sequence being invalid: {err}"),
+        )?;
+        Self::from_borsh(&signed_delegate_action_borsh)
     }
 }
 
 impl std::fmt::Display for SignedDelegateActionAsBase64 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let base64_signed_delegate_action = near_primitives::serialize::to_base64(
-            &borsh::to_vec(&self.inner)
+            &self
+                .to_borsh()
                 .expect("Signed Delegate Action serialization to borsh is not expected to fail"),
         );
         write!(f, "{base64_signed_delegate_action}")
@@ -81,14 +127,74 @@ impl From<near_primitives::action::delegate::SignedDelegateAction>
     for SignedDelegateActionAsBase64
 {
     fn from(value: near_primitives::action::delegate::SignedDelegateAction) -> Self {
-        Self { inner: value }
+        Self::V1(value)
     }
 }
 
-impl From<SignedDelegateActionAsBase64>
-    for near_primitives::action::delegate::SignedDelegateAction
+impl From<near_primitives::action::delegate::VersionedSignedDelegateAction>
+    for SignedDelegateActionAsBase64
 {
-    fn from(signed_delegate_action: SignedDelegateActionAsBase64) -> Self {
-        signed_delegate_action.inner
+    fn from(value: near_primitives::action::delegate::VersionedSignedDelegateAction) -> Self {
+        Self::V2(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use near_crypto::{KeyType, PublicKey, Signature};
+    use near_primitives::action::delegate::{
+        DelegateAction, DelegateActionV2, SignedDelegateAction, VersionedDelegateActionPayload,
+        VersionedSignedDelegateAction,
+    };
+
+    fn sample_v1() -> SignedDelegateActionAsBase64 {
+        SignedDelegateActionAsBase64::V1(SignedDelegateAction {
+            delegate_action: DelegateAction {
+                sender_id: "alice.near".parse().unwrap(),
+                receiver_id: "bob.near".parse().unwrap(),
+                actions: vec![],
+                nonce: 1,
+                max_block_height: 1000,
+                public_key: PublicKey::empty(KeyType::ED25519),
+            },
+            signature: Signature::empty(KeyType::ED25519),
+        })
+    }
+
+    fn sample_v2() -> SignedDelegateActionAsBase64 {
+        SignedDelegateActionAsBase64::V2(VersionedSignedDelegateAction {
+            delegate_action: VersionedDelegateActionPayload::V2(DelegateActionV2 {
+                sender_id: "alice.near".parse().unwrap(),
+                receiver_id: "bob.near".parse().unwrap(),
+                actions: vec![],
+                nonce: near_primitives::transaction::TransactionNonce::from_nonce_and_index(1, 3),
+                max_block_height: 1000,
+                public_key: PublicKey::empty(KeyType::ED25519),
+            }),
+            signature: Signature::empty(KeyType::ED25519),
+        })
+    }
+
+    #[test]
+    fn v1_base64_round_trips_as_v1() {
+        let encoded = sample_v1().to_string();
+        let decoded: SignedDelegateActionAsBase64 = encoded.parse().unwrap();
+        assert!(
+            matches!(decoded, SignedDelegateActionAsBase64::V1(_)),
+            "a V1 blob must decode back to V1, not V2"
+        );
+        assert_eq!(decoded.to_string(), encoded);
+    }
+
+    #[test]
+    fn v2_base64_round_trips_as_v2() {
+        let encoded = sample_v2().to_string();
+        let decoded: SignedDelegateActionAsBase64 = encoded.parse().unwrap();
+        assert!(
+            matches!(decoded, SignedDelegateActionAsBase64::V2(_)),
+            "a V2 blob must decode back to V2, not V1"
+        );
+        assert_eq!(decoded.to_string(), encoded);
     }
 }


### PR DESCRIPTION
Signing a meta-transaction (`--sign-as-delegate-action`) with a gas key was blocked: a V1 `DelegateAction` only has a plain `nonce`, so it can't carry a gas key's nonce index. This PR signs those as NEP-611 `DelegateV2` instead. Ordinary access keys are unchanged (still V1, NEP-366).

## What changes

- **Signing** — `get_signed_delegate_action` branches on the nonce: plain nonce → V1 `SignedDelegateAction` as before; gas-key nonce → `DelegateActionV2` signed under the `DelegateActionV2` domain, returned as `VersionedSignedDelegateAction`.
- **`SignedDelegateActionAsBase64`** — now a `V1 | V2` enum. Encodes each to its own borsh wire format; decoding tries V1 then V2 (the encodings can't collide: V2 starts with discriminant `0x00`, V1 with an account-id length ≥ 2). Every consumer handles both: `display`, `save-to-file`, relayer `send`, `send-meta-transaction`, and the `add-key` keychain callbacks.
- **`reconstruct-transaction`** — unwraps a lone `Action::DelegateV2` like it already does for `Action::Delegate`.
- **Ledger** — still refuses gas-key meta-transactions, now with a Ledger-specific error. The Ledger app only implements NEP-366 (V1) delegate signing; every software signer supports V2.

No new dependencies — `near-primitives 0.37` already has all the types.

## Tests

`cargo test --all-features` passes; new unit tests cover: gas key → V2 with the nonce index preserved and a valid signature; ordinary key → V1 with a valid signature; Ledger guard; base64 round-trip of both versions. Full CI gate (fmt, clippy `-D warnings`, `--no-default-features` and `ledger` checks) is green locally.
