### PR TITLE
chore: release v0.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.29.0](https://github.com/near/near-cli-rs/compare/v0.28.0...v0.29.0) - 2026-07-17
+
+### Other
+
+- remove the standalone generate-keypair command ([#623](https://github.com/near/near-cli-rs/pull/623))
+
 ## [0.28.0](https://github.com/near/near-cli-rs/compare/v0.27.0...v0.28.0) - 2026-07-09
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2569,7 +2569,7 @@ dependencies = [
 
 [[package]]
 name = "near-cli-rs"
-version = "0.28.0"
+version = "0.29.0"
 dependencies = [
  "bip39",
  "borsh",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-cli-rs"
-version = "0.28.0"
+version = "0.29.0"
 authors = ["FroVolod <frol_off@meta.ua>", "Near Inc <hello@nearprotocol.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2024"


### PR DESCRIPTION



## 🤖 New release

* `near-cli-rs`: 0.28.0 -> 0.29.0 (⚠ API breaking changes)

### ⚠ `near-cli-rs` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_missing.ron

Failed in:
  enum near_cli_rs::commands::generate_keypair::OutputMode, previously in file /tmp/.tmpLnZAIQ/near-cli-rs/src/commands/generate_keypair/mod.rs:48
  enum near_cli_rs::commands::generate_keypair::CliOutputMode, previously in file /tmp/.tmpLnZAIQ/near-cli-rs/src/commands/generate_keypair/mod.rs:44
  enum near_cli_rs::commands::generate_keypair::OutputModeDiscriminants, previously in file /tmp/.tmpLnZAIQ/near-cli-rs/src/commands/generate_keypair/mod.rs:44
  enum near_cli_rs::commands::generate_keypair::InteractiveClapContextScopeForOutputMode, previously in file /tmp/.tmpLnZAIQ/near-cli-rs/src/commands/generate_keypair/mod.rs:44

--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant TopLevelCommandDiscriminants::Extensions 8 -> 7 in /tmp/.tmpzRAr67/near-cli-rs/src/commands/mod.rs:54
  variant TopLevelCommandDiscriminants::Extensions 8 -> 7 in /tmp/.tmpzRAr67/near-cli-rs/src/commands/mod.rs:54

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/enum_variant_missing.ron

Failed in:
  variant CliTopLevelCommand::GenerateKeypair, previously in file /tmp/.tmpLnZAIQ/near-cli-rs/src/commands/mod.rs:16
  variant TopLevelCommand::GenerateKeypair, previously in file /tmp/.tmpLnZAIQ/near-cli-rs/src/commands/mod.rs:56
  variant TopLevelCommandDiscriminants::GenerateKeypair, previously in file /tmp/.tmpLnZAIQ/near-cli-rs/src/commands/mod.rs:56
  variant TopLevelCommandDiscriminants::GenerateKeypair, previously in file /tmp/.tmpLnZAIQ/near-cli-rs/src/commands/mod.rs:56

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/module_missing.ron

Failed in:
  mod near_cli_rs::commands::generate_keypair, previously in file /tmp/.tmpLnZAIQ/near-cli-rs/src/commands/generate_keypair/mod.rs:1

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/struct_missing.ron

Failed in:
  struct near_cli_rs::commands::generate_keypair::CliSaveToFile, previously in file /tmp/.tmpLnZAIQ/near-cli-rs/src/commands/generate_keypair/mod.rs:79
  struct near_cli_rs::commands::generate_keypair::CliPrintToTerminal, previously in file /tmp/.tmpLnZAIQ/near-cli-rs/src/commands/generate_keypair/mod.rs:61
  struct near_cli_rs::commands::generate_keypair::CliGenerateKeypairCommand, previously in file /tmp/.tmpLnZAIQ/near-cli-rs/src/commands/generate_keypair/mod.rs:8
  struct near_cli_rs::commands::generate_keypair::PrintToTerminal, previously in file /tmp/.tmpLnZAIQ/near-cli-rs/src/commands/generate_keypair/mod.rs:64
  struct near_cli_rs::commands::generate_keypair::GenerateKeypairContext, previously in file /tmp/.tmpLnZAIQ/near-cli-rs/src/commands/generate_keypair/mod.rs:21
  struct near_cli_rs::commands::generate_keypair::InteractiveClapContextScopeForPrintToTerminal, previously in file /tmp/.tmpLnZAIQ/near-cli-rs/src/commands/generate_keypair/mod.rs:61
  struct near_cli_rs::commands::generate_keypair::InteractiveClapContextScopeForSaveToFile, previously in file /tmp/.tmpLnZAIQ/near-cli-rs/src/commands/generate_keypair/mod.rs:79
  struct near_cli_rs::commands::generate_keypair::GenerateKeypairCommand, previously in file /tmp/.tmpLnZAIQ/near-cli-rs/src/commands/generate_keypair/mod.rs:11
  struct near_cli_rs::commands::generate_keypair::SaveToFileContext, previously in file /tmp/.tmpLnZAIQ/near-cli-rs/src/commands/generate_keypair/mod.rs:89
  struct near_cli_rs::commands::generate_keypair::InteractiveClapContextScopeForGenerateKeypairCommand, previously in file /tmp/.tmpLnZAIQ/near-cli-rs/src/commands/generate_keypair/mod.rs:8
  struct near_cli_rs::commands::generate_keypair::SaveToFile, previously in file /tmp/.tmpLnZAIQ/near-cli-rs/src/commands/generate_keypair/mod.rs:82
  struct near_cli_rs::commands::generate_keypair::OutputModeDiscriminantsIter, previously in file /tmp/.tmpLnZAIQ/near-cli-rs/src/commands/generate_keypair/mod.rs:46
  struct near_cli_rs::commands::generate_keypair::PrintToTerminalContext, previously in file /tmp/.tmpLnZAIQ/near-cli-rs/src/commands/generate_keypair/mod.rs:67
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.29.0](https://github.com/near/near-cli-rs/compare/v0.28.0...v0.29.0) - 2026-07-17

### Other

- remove the standalone generate-keypair command ([#623](https://github.com/near/near-cli-rs/pull/623))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).