### PR TITLE
fix: hide NEP-413 private key input

### DIFF
--- a/src/commands/message/sign_nep413/signature_options/sign_with_private_key.rs
+++ b/src/commands/message/sign_nep413/signature_options/sign_with_private_key.rs
@@ -2,12 +2,31 @@
 #[interactive_clap(input_context = super::super::FinalSignNep413Context)]
 #[interactive_clap(output_context = SignPrivateKeyContext)]
 pub struct SignPrivateKey {
+    #[interactive_clap(skip_default_input_arg)]
     /// Enter your private (secret) key:
     pub private_key: crate::types::secret_key::SecretKey,
 }
 
 #[derive(Debug, Clone)]
 pub struct SignPrivateKeyContext;
+
+impl SignPrivateKey {
+    fn input_private_key(
+        _context: &super::super::FinalSignNep413Context,
+    ) -> color_eyre::eyre::Result<Option<crate::types::secret_key::SecretKey>> {
+        match inquire::Password::new("Enter your private (secret) key:")
+            .without_confirmation()
+            .prompt()
+        {
+            Ok(private_key) => Ok(Some(private_key.parse()?)),
+            Err(
+                inquire::error::InquireError::OperationCanceled
+                | inquire::error::InquireError::OperationInterrupted,
+            ) => Ok(None),
+            Err(err) => Err(err.into()),
+        }
+    }
+}
 
 impl SignPrivateKeyContext {
     pub fn from_previous_context(

--- a/src/types/secret_key.rs
+++ b/src/types/secret_key.rs
@@ -3,7 +3,7 @@ pub struct SecretKey(pub near_crypto::SecretKey);
 
 impl std::fmt::Display for SecretKey {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        self.0.fmt(f)
+        f.write_str("[REDACTED]")
     }
 }
 
@@ -24,4 +24,18 @@ impl From<SecretKey> for near_crypto::SecretKey {
 
 impl interactive_clap::ToCli for SecretKey {
     type CliVariant = SecretKey;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SecretKey;
+
+    #[test]
+    fn display_redacts_the_secret_key() {
+        let secret_key: SecretKey = "ed25519:3D4YudUahN1nawWogh8pAKSj92sUNMdbZGjn7kERKzYoTy8tnFQuwoGUC51DowKqorvkr2pytJSnwuSbsNVfqygr"
+            .parse()
+            .unwrap();
+
+        assert_eq!(secret_key.to_string(), "[REDACTED]");
+    }
 }


### PR DESCRIPTION
## What changed

- use `inquire::Password` when the NEP-413 private key is entered interactively
- keep the existing explicit CLI argument behavior unchanged
- redact secret keys when reconstructing commands for terminal output and CLI history

## Why

The generated `interactive_clap` input path used `inquire::CustomType`, which rendered the private key as it was typed or pasted. The dedicated password prompt hides the input.

A full interactive signing test also showed that the CLI's generated replay command printed the private key after signing and persisted it through the command-history path. Redacting `SecretKey`'s display representation prevents both exposures while leaving parsing and signing unchanged.

This intentionally does not add speculative zeroization or refactor key ownership; the reported clone is required by the generated context scope and no memory-disclosure path was demonstrated.

## Validation

- `cargo fmt --check`
- `cargo check --all-targets`
- `cargo test --all-targets`
- successful NEP-413 signing through the interactive prompt with Terminal Control; input remained hidden and the replay command contained `[REDACTED]`

Fixes #621.
