### PR TITLE
fix: reject invalid restricted function names

### DIFF
--- a/src/commands/account/add_key/access_key_type/mod.rs
+++ b/src/commands/account/add_key/access_key_type/mod.rs
@@ -1,5 +1,3 @@
-use std::str::FromStr;
-
 use inquire::{CustomType, Select, Text};
 
 #[derive(Debug, Clone)]
@@ -124,18 +122,13 @@ impl FunctionCallType {
         )
         .prompt()?;
         if let ConfirmOptions::Yes = select_choose_input {
-            let mut input_function_names = Text::new("Enter a comma-separated list of function names that will be allowed to be called in a transaction signed by this access key:")
+            let input_function_names = Text::new("Enter a comma-separated list of function names that will be allowed to be called in a transaction signed by this access key:")
                     .prompt()?;
-            if input_function_names.contains('\"') {
-                input_function_names.clear()
-            };
-            if input_function_names.is_empty() {
-                Ok(Some(crate::types::vec_string::VecString(vec![])))
-            } else {
-                Ok(Some(crate::types::vec_string::VecString::from_str(
+            Ok(Some(
+                crate::types::vec_string::VecString::parse_restricted_function_names(
                     &input_function_names,
-                )?))
-            }
+                )?,
+            ))
         } else {
             Ok(Some(crate::types::vec_string::VecString(vec![])))
         }

--- a/src/commands/account/add_key/access_key_type/mod.rs
+++ b/src/commands/account/add_key/access_key_type/mod.rs
@@ -57,7 +57,8 @@ pub struct FunctionCallType {
     contract_account_id: crate::types::account_id::AccountId,
     #[interactive_clap(long)]
     #[interactive_clap(skip_default_input_arg)]
-    function_names: crate::types::vec_string::VecString,
+    /// Comma-separated function names this key may call. Pass an empty value to allow any function.
+    function_names: crate::types::function_names::FunctionNames,
     #[interactive_clap(subcommand)]
     access_key_mode: super::AccessKeyMode,
 }
@@ -68,7 +69,7 @@ pub struct FunctionCallTypeContext {
     signer_account_id: near_primitives::types::AccountId,
     allowance: Option<crate::types::near_token::NearToken>,
     contract_account_id: crate::types::account_id::AccountId,
-    function_names: crate::types::vec_string::VecString,
+    function_names: crate::types::function_names::FunctionNames,
 }
 
 impl FunctionCallTypeContext {
@@ -105,7 +106,7 @@ impl From<FunctionCallTypeContext> for AccessTypeContext {
 impl FunctionCallType {
     pub fn input_function_names(
         _context: &super::AddKeyCommandContext,
-    ) -> color_eyre::eyre::Result<Option<crate::types::vec_string::VecString>> {
+    ) -> color_eyre::eyre::Result<Option<crate::types::function_names::FunctionNames>> {
         #[derive(strum_macros::Display)]
         enum ConfirmOptions {
             #[strum(
@@ -125,12 +126,12 @@ impl FunctionCallType {
             let input_function_names = Text::new("Enter a comma-separated list of function names that will be allowed to be called in a transaction signed by this access key:")
                     .prompt()?;
             Ok(Some(
-                crate::types::vec_string::VecString::parse_restricted_function_names(
+                crate::types::function_names::FunctionNames::parse_restricted(
                     &input_function_names,
                 )?,
             ))
         } else {
-            Ok(Some(crate::types::vec_string::VecString(vec![])))
+            Ok(Some(crate::types::function_names::FunctionNames(vec![])))
         }
     }
 
@@ -245,7 +246,8 @@ pub struct GasKeyFunctionCallType {
     contract_account_id: crate::types::account_id::AccountId,
     #[interactive_clap(long)]
     #[interactive_clap(skip_default_input_arg)]
-    function_names: crate::types::vec_string::VecString,
+    /// Comma-separated function names this key may call. Pass an empty value to allow any function.
+    function_names: crate::types::function_names::FunctionNames,
     #[interactive_clap(subcommand)]
     access_key_mode: super::AccessKeyMode,
 }
@@ -303,7 +305,7 @@ impl GasKeyFunctionCallType {
 
     pub fn input_function_names(
         context: &super::AddKeyCommandContext,
-    ) -> color_eyre::eyre::Result<Option<crate::types::vec_string::VecString>> {
+    ) -> color_eyre::eyre::Result<Option<crate::types::function_names::FunctionNames>> {
         FunctionCallType::input_function_names(context)
     }
 }

--- a/src/commands/transaction/construct_transaction/add_action_1/add_action/add_key/access_key_type/mod.rs
+++ b/src/commands/transaction/construct_transaction/add_action_1/add_action/add_key/access_key_type/mod.rs
@@ -1,5 +1,3 @@
-use std::str::FromStr;
-
 use inquire::{CustomType, Select, Text};
 
 #[derive(Debug, Clone)]
@@ -113,19 +111,14 @@ impl FunctionCallType {
         )
         .prompt()?;
         if let ConfirmOptions::Yes = select_choose_input {
-            let mut input_function_names =
+            let input_function_names =
                     Text::new("Enter a comma-separated list of function names that will be allowed to be called in a transaction signed by this access key:")
                         .prompt()?;
-            if input_function_names.contains('\"') {
-                input_function_names.clear()
-            };
-            if input_function_names.is_empty() {
-                Ok(Some(crate::types::vec_string::VecString(vec![])))
-            } else {
-                Ok(Some(crate::types::vec_string::VecString::from_str(
+            Ok(Some(
+                crate::types::vec_string::VecString::parse_restricted_function_names(
                     &input_function_names,
-                )?))
-            }
+                )?,
+            ))
         } else {
             Ok(Some(crate::types::vec_string::VecString(vec![])))
         }

--- a/src/commands/transaction/construct_transaction/add_action_1/add_action/add_key/access_key_type/mod.rs
+++ b/src/commands/transaction/construct_transaction/add_action_1/add_action/add_key/access_key_type/mod.rs
@@ -55,7 +55,8 @@ pub struct FunctionCallType {
     contract_account_id: crate::types::account_id::AccountId,
     #[interactive_clap(long)]
     #[interactive_clap(skip_default_input_arg)]
-    function_names: crate::types::vec_string::VecString,
+    /// Comma-separated function names this key may call. Pass an empty value to allow any function.
+    function_names: crate::types::function_names::FunctionNames,
     #[interactive_clap(subcommand)]
     access_key_mode: super::AccessKeyMode,
 }
@@ -95,7 +96,7 @@ impl From<FunctionCallTypeContext> for AccessKeyPermissionContext {
 impl FunctionCallType {
     pub fn input_function_names(
         _context: &super::super::super::super::ConstructTransactionContext,
-    ) -> color_eyre::eyre::Result<Option<crate::types::vec_string::VecString>> {
+    ) -> color_eyre::eyre::Result<Option<crate::types::function_names::FunctionNames>> {
         #[derive(strum_macros::Display)]
         enum ConfirmOptions {
             #[strum(
@@ -115,12 +116,12 @@ impl FunctionCallType {
                     Text::new("Enter a comma-separated list of function names that will be allowed to be called in a transaction signed by this access key:")
                         .prompt()?;
             Ok(Some(
-                crate::types::vec_string::VecString::parse_restricted_function_names(
+                crate::types::function_names::FunctionNames::parse_restricted(
                     &input_function_names,
                 )?,
             ))
         } else {
-            Ok(Some(crate::types::vec_string::VecString(vec![])))
+            Ok(Some(crate::types::function_names::FunctionNames(vec![])))
         }
     }
 

--- a/src/commands/transaction/construct_transaction/add_action_2/add_action/add_key/access_key_type/mod.rs
+++ b/src/commands/transaction/construct_transaction/add_action_2/add_action/add_key/access_key_type/mod.rs
@@ -1,5 +1,3 @@
-use std::str::FromStr;
-
 use inquire::{CustomType, Select, Text};
 
 #[derive(Debug, Clone)]
@@ -113,19 +111,14 @@ impl FunctionCallType {
         )
         .prompt()?;
         if let ConfirmOptions::Yes = select_choose_input {
-            let mut input_function_names =
+            let input_function_names =
                     Text::new("Enter a comma-separated list of function names that will be allowed to be called in a transaction signed by this access key:")
                         .prompt()?;
-            if input_function_names.contains('\"') {
-                input_function_names.clear()
-            };
-            if input_function_names.is_empty() {
-                Ok(Some(crate::types::vec_string::VecString(vec![])))
-            } else {
-                Ok(Some(crate::types::vec_string::VecString::from_str(
+            Ok(Some(
+                crate::types::vec_string::VecString::parse_restricted_function_names(
                     &input_function_names,
-                )?))
-            }
+                )?,
+            ))
         } else {
             Ok(Some(crate::types::vec_string::VecString(vec![])))
         }

--- a/src/commands/transaction/construct_transaction/add_action_2/add_action/add_key/access_key_type/mod.rs
+++ b/src/commands/transaction/construct_transaction/add_action_2/add_action/add_key/access_key_type/mod.rs
@@ -55,7 +55,8 @@ pub struct FunctionCallType {
     contract_account_id: crate::types::account_id::AccountId,
     #[interactive_clap(long)]
     #[interactive_clap(skip_default_input_arg)]
-    function_names: crate::types::vec_string::VecString,
+    /// Comma-separated function names this key may call. Pass an empty value to allow any function.
+    function_names: crate::types::function_names::FunctionNames,
     #[interactive_clap(subcommand)]
     access_key_mode: super::AccessKeyMode,
 }
@@ -95,7 +96,7 @@ impl From<FunctionCallTypeContext> for AccessKeyPermissionContext {
 impl FunctionCallType {
     pub fn input_function_names(
         _context: &super::super::super::super::ConstructTransactionContext,
-    ) -> color_eyre::eyre::Result<Option<crate::types::vec_string::VecString>> {
+    ) -> color_eyre::eyre::Result<Option<crate::types::function_names::FunctionNames>> {
         #[derive(strum_macros::Display)]
         enum ConfirmOptions {
             #[strum(
@@ -115,12 +116,12 @@ impl FunctionCallType {
                     Text::new("Enter a comma-separated list of function names that will be allowed to be called in a transaction signed by this access key:")
                         .prompt()?;
             Ok(Some(
-                crate::types::vec_string::VecString::parse_restricted_function_names(
+                crate::types::function_names::FunctionNames::parse_restricted(
                     &input_function_names,
                 )?,
             ))
         } else {
-            Ok(Some(crate::types::vec_string::VecString(vec![])))
+            Ok(Some(crate::types::function_names::FunctionNames(vec![])))
         }
     }
 

--- a/src/commands/transaction/construct_transaction/add_action_3/add_action/add_key/access_key_type/mod.rs
+++ b/src/commands/transaction/construct_transaction/add_action_3/add_action/add_key/access_key_type/mod.rs
@@ -1,5 +1,3 @@
-use std::str::FromStr;
-
 use inquire::{CustomType, Select, Text};
 
 #[derive(Debug, Clone)]
@@ -113,19 +111,14 @@ impl FunctionCallType {
         )
         .prompt()?;
         if let ConfirmOptions::Yes = select_choose_input {
-            let mut input_function_names =
+            let input_function_names =
                     Text::new("Enter a comma-separated list of function names that will be allowed to be called in a transaction signed by this access key:")
                         .prompt()?;
-            if input_function_names.contains('\"') {
-                input_function_names.clear()
-            };
-            if input_function_names.is_empty() {
-                Ok(Some(crate::types::vec_string::VecString(vec![])))
-            } else {
-                Ok(Some(crate::types::vec_string::VecString::from_str(
+            Ok(Some(
+                crate::types::vec_string::VecString::parse_restricted_function_names(
                     &input_function_names,
-                )?))
-            }
+                )?,
+            ))
         } else {
             Ok(Some(crate::types::vec_string::VecString(vec![])))
         }

--- a/src/commands/transaction/construct_transaction/add_action_3/add_action/add_key/access_key_type/mod.rs
+++ b/src/commands/transaction/construct_transaction/add_action_3/add_action/add_key/access_key_type/mod.rs
@@ -55,7 +55,8 @@ pub struct FunctionCallType {
     contract_account_id: crate::types::account_id::AccountId,
     #[interactive_clap(long)]
     #[interactive_clap(skip_default_input_arg)]
-    function_names: crate::types::vec_string::VecString,
+    /// Comma-separated function names this key may call. Pass an empty value to allow any function.
+    function_names: crate::types::function_names::FunctionNames,
     #[interactive_clap(subcommand)]
     access_key_mode: super::AccessKeyMode,
 }
@@ -95,7 +96,7 @@ impl From<FunctionCallTypeContext> for AccessKeyPermissionContext {
 impl FunctionCallType {
     pub fn input_function_names(
         _context: &super::super::super::super::ConstructTransactionContext,
-    ) -> color_eyre::eyre::Result<Option<crate::types::vec_string::VecString>> {
+    ) -> color_eyre::eyre::Result<Option<crate::types::function_names::FunctionNames>> {
         #[derive(strum_macros::Display)]
         enum ConfirmOptions {
             #[strum(
@@ -115,12 +116,12 @@ impl FunctionCallType {
                     Text::new("Enter a comma-separated list of function names that will be allowed to be called in a transaction signed by this access key:")
                         .prompt()?;
             Ok(Some(
-                crate::types::vec_string::VecString::parse_restricted_function_names(
+                crate::types::function_names::FunctionNames::parse_restricted(
                     &input_function_names,
                 )?,
             ))
         } else {
-            Ok(Some(crate::types::vec_string::VecString(vec![])))
+            Ok(Some(crate::types::function_names::FunctionNames(vec![])))
         }
     }
 

--- a/src/commands/transaction/reconstruct_transaction/mod.rs
+++ b/src/commands/transaction/reconstruct_transaction/mod.rs
@@ -397,7 +397,7 @@ fn get_access_key_permission(
                         }
                     },
                     contract_account_id: Some(receiver_id.parse()?),
-                    function_names: Some(crate::types::vec_string::VecString(method_names)),
+                    function_names: Some(method_names.into()),
                     access_key_mode: Some(add_key::CliAccessKeyMode::UseManuallyProvidedPublicKey(
                         add_key::use_public_key::CliAddAccessKeyAction {
                             public_key: Some(public_key.into()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -289,3 +289,58 @@ fn try_rewrite_construct_transaction_args() -> Option<Vec<String>> {
     rewritten.insert(receiver_idx, "receiver-id".to_string());
     Some(rewritten)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Cmd;
+
+    fn add_key_command(function_names: &str) -> Vec<&str> {
+        vec![
+            "near",
+            "account",
+            "add-key",
+            "alice.testnet",
+            "grant-function-call-access",
+            "--allowance",
+            "unlimited",
+            "--contract-account-id",
+            "contract.testnet",
+            "--function-names",
+            function_names,
+        ]
+    }
+
+    fn construct_transaction_command(function_names: &str) -> Vec<&str> {
+        vec![
+            "near",
+            "transaction",
+            "construct-transaction",
+            "alice.testnet",
+            "receiver-id",
+            "contract.testnet",
+            "add-action",
+            "add-key",
+            "grant-function-call-access",
+            "--allowance",
+            "unlimited",
+            "--contract-account-id",
+            "contract.testnet",
+            "--function-names",
+            function_names,
+        ]
+    }
+
+    #[test]
+    fn function_names_cli_accepts_empty_for_unrestricted_access() {
+        assert!(Cmd::try_parse_from(add_key_command("")).is_ok());
+        assert!(Cmd::try_parse_from(construct_transaction_command("")).is_ok());
+    }
+
+    #[test]
+    fn function_names_cli_rejects_malformed_lists() {
+        for function_names in [" ", "ft_transfer,", ",ft_transfer", "\"ft_transfer\""] {
+            assert!(Cmd::try_parse_from(add_key_command(function_names)).is_err());
+            assert!(Cmd::try_parse_from(construct_transaction_command(function_names)).is_err());
+        }
+    }
+}

--- a/src/types/function_names.rs
+++ b/src/types/function_names.rs
@@ -1,0 +1,89 @@
+#[derive(Debug, Default, Clone)]
+pub struct FunctionNames(pub Vec<String>);
+
+impl FunctionNames {
+    pub fn parse_restricted(input: &str) -> color_eyre::eyre::Result<Self> {
+        color_eyre::eyre::ensure!(
+            !input.contains('"'),
+            "Function names must not contain double quotes"
+        );
+
+        let function_names = input
+            .split(',')
+            .map(|name| name.trim().to_string())
+            .collect::<Vec<_>>();
+        color_eyre::eyre::ensure!(
+            function_names.iter().all(|name| !name.is_empty()),
+            "Function names must not contain empty entries"
+        );
+
+        Ok(Self(function_names))
+    }
+}
+
+impl std::fmt::Display for FunctionNames {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "{}", self.0.join(","))
+    }
+}
+
+impl std::str::FromStr for FunctionNames {
+    type Err = color_eyre::eyre::ErrReport;
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        if input.is_empty() {
+            return Ok(Self(vec![]));
+        }
+        Self::parse_restricted(input)
+    }
+}
+
+impl From<FunctionNames> for Vec<String> {
+    fn from(item: FunctionNames) -> Self {
+        item.0
+    }
+}
+
+impl From<Vec<String>> for FunctionNames {
+    fn from(item: Vec<String>) -> Self {
+        Self(item)
+    }
+}
+
+impl interactive_clap::ToCli for FunctionNames {
+    type CliVariant = FunctionNames;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FunctionNames;
+
+    #[test]
+    fn parses_function_names() {
+        let function_names: FunctionNames = "storage_deposit, ft_transfer".parse().unwrap();
+
+        assert_eq!(function_names.0, vec!["storage_deposit", "ft_transfer"]);
+    }
+
+    #[test]
+    fn parses_empty_function_names_as_unrestricted() {
+        assert!("".parse::<FunctionNames>().unwrap().0.is_empty());
+    }
+
+    #[test]
+    fn rejects_quoted_function_names() {
+        assert!("\"ft_transfer\"".parse::<FunctionNames>().is_err());
+    }
+
+    #[test]
+    fn rejects_empty_function_name_entries() {
+        assert!("  ".parse::<FunctionNames>().is_err());
+        assert!("ft_transfer,".parse::<FunctionNames>().is_err());
+        assert!(",ft_transfer".parse::<FunctionNames>().is_err());
+    }
+
+    #[test]
+    fn restricted_parser_rejects_an_empty_list() {
+        assert!(FunctionNames::parse_restricted("").is_err());
+    }
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -6,6 +6,7 @@ pub mod contract_properties;
 pub mod crypto_hash;
 pub mod file_bytes;
 pub mod ft_properties;
+pub mod function_names;
 pub mod json;
 pub mod near_allowance;
 pub mod near_token;

--- a/src/types/vec_string.rs
+++ b/src/types/vec_string.rs
@@ -19,6 +19,23 @@ impl std::str::FromStr for VecString {
     }
 }
 
+impl VecString {
+    pub fn parse_restricted_function_names(input: &str) -> color_eyre::eyre::Result<Self> {
+        color_eyre::eyre::ensure!(
+            !input.contains('"'),
+            "Function names must not contain double quotes"
+        );
+
+        let function_names: Self = input.parse()?;
+        color_eyre::eyre::ensure!(
+            !function_names.0.is_empty() && function_names.0.iter().all(|name| !name.is_empty()),
+            "Enter at least one function name, or choose unrestricted function access"
+        );
+
+        Ok(function_names)
+    }
+}
+
 impl From<VecString> for Vec<String> {
     fn from(item: VecString) -> Self {
         item.0
@@ -33,4 +50,29 @@ impl From<Vec<String>> for VecString {
 
 impl interactive_clap::ToCli for VecString {
     type CliVariant = VecString;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::VecString;
+
+    #[test]
+    fn parses_restricted_function_names() {
+        let function_names =
+            VecString::parse_restricted_function_names("storage_deposit, ft_transfer").unwrap();
+
+        assert_eq!(function_names.0, vec!["storage_deposit", "ft_transfer"]);
+    }
+
+    #[test]
+    fn rejects_quoted_function_names() {
+        assert!(VecString::parse_restricted_function_names("\"ft_transfer\"").is_err());
+    }
+
+    #[test]
+    fn rejects_empty_function_names() {
+        assert!(VecString::parse_restricted_function_names("").is_err());
+        assert!(VecString::parse_restricted_function_names("  ").is_err());
+        assert!(VecString::parse_restricted_function_names("ft_transfer,").is_err());
+    }
 }

--- a/src/types/vec_string.rs
+++ b/src/types/vec_string.rs
@@ -19,23 +19,6 @@ impl std::str::FromStr for VecString {
     }
 }
 
-impl VecString {
-    pub fn parse_restricted_function_names(input: &str) -> color_eyre::eyre::Result<Self> {
-        color_eyre::eyre::ensure!(
-            !input.contains('"'),
-            "Function names must not contain double quotes"
-        );
-
-        let function_names: Self = input.parse()?;
-        color_eyre::eyre::ensure!(
-            !function_names.0.is_empty() && function_names.0.iter().all(|name| !name.is_empty()),
-            "Enter at least one function name, or choose unrestricted function access"
-        );
-
-        Ok(function_names)
-    }
-}
-
 impl From<VecString> for Vec<String> {
     fn from(item: VecString) -> Self {
         item.0
@@ -50,29 +33,4 @@ impl From<Vec<String>> for VecString {
 
 impl interactive_clap::ToCli for VecString {
     type CliVariant = VecString;
-}
-
-#[cfg(test)]
-mod tests {
-    use super::VecString;
-
-    #[test]
-    fn parses_restricted_function_names() {
-        let function_names =
-            VecString::parse_restricted_function_names("storage_deposit, ft_transfer").unwrap();
-
-        assert_eq!(function_names.0, vec!["storage_deposit", "ft_transfer"]);
-    }
-
-    #[test]
-    fn rejects_quoted_function_names() {
-        assert!(VecString::parse_restricted_function_names("\"ft_transfer\"").is_err());
-    }
-
-    #[test]
-    fn rejects_empty_function_names() {
-        assert!(VecString::parse_restricted_function_names("").is_err());
-        assert!(VecString::parse_restricted_function_names("  ").is_err());
-        assert!(VecString::parse_restricted_function_names("ft_transfer,").is_err());
-    }
 }


### PR DESCRIPTION
## What changed

- reject quoted or empty function-name lists when the user chooses restricted access
- use the same validation in the account add-key flow and all three construct-transaction paths

## Why

Quoted input was silently cleared and converted to an empty method list, which means unrestricted function access. Invalid input now fails instead of broadening the key's permissions.

## Testing

- `cargo fmt --check`
- `cargo check --all-targets`
- `cargo test --all-targets`

Fixes #618.
