### PR TITLE
fix: secure implicit account key files

### DIFF
--- a/src/commands/account/create_account/create_implicit_account/mod.rs
+++ b/src/commands/account/create_account/create_implicit_account/mod.rs
@@ -1,4 +1,5 @@
 use inquire::CustomType;
+use std::io::Write;
 use strum::{EnumDiscriminants, EnumIter, EnumMessage};
 
 mod use_auto_generation;
@@ -82,4 +83,42 @@ pub type OnAfterGettingFolderPathCallback =
 pub struct SaveImplicitAccountContext {
     config: crate::config::Config,
     on_after_getting_folder_path_callback: OnAfterGettingFolderPathCallback,
+}
+
+fn write_secret_key_file(file_path: &std::path::Path, contents: &[u8]) -> std::io::Result<()> {
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create(true).truncate(true);
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
+
+        options.mode(0o600);
+        let mut file = options.open(file_path)?;
+        file.set_permissions(std::fs::Permissions::from_mode(0o600))?;
+        file.write_all(contents)
+    }
+
+    #[cfg(not(unix))]
+    options.open(file_path)?.write_all(contents)
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+    #[test]
+    fn secret_key_file_is_owner_only() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let file_path = temp_dir.path().join("implicit-account.json");
+
+        super::write_secret_key_file(&file_path, b"first").unwrap();
+        assert_eq!(file_path.metadata().unwrap().mode() & 0o777, 0o600);
+
+        std::fs::set_permissions(&file_path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        super::write_secret_key_file(&file_path, b"replacement").unwrap();
+
+        assert_eq!(std::fs::read(&file_path).unwrap(), b"replacement");
+        assert_eq!(file_path.metadata().unwrap().mode() & 0o777, 0o600);
+    }
 }

--- a/src/commands/account/create_account/create_implicit_account/use_auto_generation.rs
+++ b/src/commands/account/create_account/create_implicit_account/use_auto_generation.rs
@@ -1,5 +1,3 @@
-use std::io::Write;
-
 use color_eyre::eyre::Context;
 
 #[derive(Debug, Clone, interactive_clap::InteractiveClap)]
@@ -38,9 +36,7 @@ impl SaveWithUseAutoGenerationContext {
 
                     std::fs::create_dir_all(&file_path)?;
                     file_path.push(file_name);
-                    std::fs::File::create(&file_path)
-                        .wrap_err_with(|| format!("Failed to create file: {file_path:?}"))?
-                        .write(buf.as_bytes())
+                    super::write_secret_key_file(&file_path, buf.as_bytes())
                         .wrap_err_with(|| format!("Failed to write to file: {folder_path:?}"))?;
 
                     if let crate::Verbosity::Interactive | crate::Verbosity::TeachMe =

--- a/src/commands/account/create_account/create_implicit_account/use_seed_phrase.rs
+++ b/src/commands/account/create_account/create_implicit_account/use_seed_phrase.rs
@@ -1,5 +1,3 @@
-use std::io::Write;
-
 use color_eyre::eyre::Context;
 
 #[derive(Debug, Clone, interactive_clap::InteractiveClap)]
@@ -47,9 +45,7 @@ impl SaveWithSeedPhraseContext {
 
                     std::fs::create_dir_all(&file_path)?;
                     file_path.push(file_name);
-                    std::fs::File::create(&file_path)
-                        .wrap_err_with(|| format!("Failed to create file: {file_path:?}"))?
-                        .write(buf.as_bytes())
+                    super::write_secret_key_file(&file_path, buf.as_bytes())
                         .wrap_err_with(|| format!("Failed to write to file: {file_path:?}"))?;
 
                     if let crate::Verbosity::Interactive | crate::Verbosity::TeachMe =


### PR DESCRIPTION
## What changed

- write secret-bearing implicit-account JSON through one helper
- create and normalize those files to `0600` on Unix, including existing destinations
- use `write_all` so successful writes include the complete JSON buffer

The Ledger path is unchanged because its file contains only public data.

## Why

Both auto-generation and seed-phrase modes save a seed phrase and private key. With a normal `022` umask, the previous `File::create` path produced a `0644` file.

Fixes #609

## Testing

- `cargo fmt --all -- --check`
- `cargo test --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- real CLI run with dummy data under `umask 022`; generated file reported `-rw------- (600)`

## Manual verification

![Generated key file reports 0600 under umask 022](https://github.com/user-attachments/assets/b4684fe2-32de-49cb-b019-ad4e4131a5cc)

Real CLI run with dummy data; no private key or seed phrase is shown.
