### PR TITLE
feat: publish Homebrew formula

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -287,6 +287,52 @@ jobs:
 
           gh release create "${{ needs.plan.outputs.tag }}" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
 
+  publish-homebrew-formula:
+    needs:
+      - plan
+      - host
+    runs-on: "ubuntu-22.04"
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PLAN: ${{ needs.plan.outputs.val }}
+      GITHUB_USER: "near-cli-rs release bot"
+      GITHUB_EMAIL: "github-actions[bot]@users.noreply.github.com"
+    if: ${{ !fromJson(needs.plan.outputs.val).announcement_is_prerelease || fromJson(needs.plan.outputs.val).publish_prereleases }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: true
+          repository: "near/homebrew-tap"
+          ssh-key: ${{ secrets.HOMEBREW_TAP_DEPLOY_KEY }}
+      # So we have access to the formula
+      - name: Fetch homebrew formulae
+        uses: actions/download-artifact@v8
+        with:
+          pattern: artifacts-*
+          path: Formula/
+          merge-multiple: true
+      # This is extra complex because you can make your Formula name not match your app name
+      # so we need to find releases with a *.rb file, and publish with that filename.
+      - name: Commit formula files
+        run: |
+          git config --global user.name "${GITHUB_USER}"
+          git config --global user.email "${GITHUB_EMAIL}"
+
+          for release in $(echo "$PLAN" | jq --compact-output '.releases[] | select([.artifacts[] | endswith(".rb")] | any)'); do
+            filename=$(echo "$release" | jq '.artifacts[] | select(endswith(".rb"))' --raw-output)
+            name=$(echo "$filename" | sed "s/\.rb$//")
+            version=$(echo "$release" | jq .app_version --raw-output)
+
+            export PATH="/home/linuxbrew/.linuxbrew/bin:$PATH"
+            brew update
+            # We avoid reformatting user-provided data such as the app description and homepage.
+            brew style --except-cops FormulaAudit/Homepage,FormulaAudit/Desc,FormulaAuditStrict --fix "Formula/${filename}" || true
+
+            git add "Formula/${filename}"
+            git commit -m "${name} ${version}"
+          done
+          git push
+
   publish-npm:
     needs:
       - plan
@@ -321,11 +367,12 @@ jobs:
     needs:
       - plan
       - host
+      - publish-homebrew-formula
       - publish-npm
     # use "always() && ..." to allow us to wait for all publish jobs while
     # still allowing individual publish jobs to skip themselves (for prereleases).
     # "host" however must run to completion, no skipping allowed!
-    if: ${{ always() && needs.host.result == 'success' && (needs.publish-npm.result == 'skipped' || needs.publish-npm.result == 'success') }}
+    if: ${{ always() && needs.host.result == 'success' && (needs.publish-homebrew-formula.result == 'skipped' || needs.publish-homebrew-formula.result == 'success') && (needs.publish-npm.result == 'skipped' || needs.publish-npm.result == 'success') }}
     runs-on: "ubuntu-22.04"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -159,9 +159,11 @@ allow-dirty = ["ci"]
 # CI backends to support
 ci = "github"
 # The installers to generate for each app
-installers = ["shell", "powershell", "npm", "msi"]
+installers = ["shell", "powershell", "npm", "homebrew", "msi"]
 # Publish jobs to run in CI
-publish-jobs = ["npm"]
+publish-jobs = ["npm", "homebrew"]
+# A GitHub repo to push Homebrew formulas to
+tap = "near/homebrew-tap"
 # Target platforms to build apps for (Rust target-triple syntax)
 targets = [
     "aarch64-apple-darwin",
@@ -181,6 +183,10 @@ pr-run-mode = "upload"
 install-path = "CARGO_HOME"
 # Whether to install an updater program
 install-updater = false
+
+[package.metadata.dist]
+# Match the installed binary and the public Homebrew package name
+formula = "near"
 
 [workspace.metadata.dist.github-custom-runners]
 aarch64-unknown-linux-gnu = "ubuntu-24.04-arm"

--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ Just run `near` and let it guide you through!
 Visit [Releases page](https://github.com/near/near-cli-rs/releases/) to see the latest updates.
 
 <details>
+  <summary>Install via Homebrew (macOS and Linux)</summary>
+
+```sh
+brew install near/tap/near
+```
+</details>
+
+<details>
   <summary>Install via Windows Installer (Windows)</summary>
 
   


### PR DESCRIPTION
## Summary

- generate a Homebrew formula named `near` with cargo-dist
- publish release formula updates to `near/homebrew-tap`
- document the Homebrew installation command

## Why

This provides an upstream-managed Homebrew package for macOS and Linux. The tap is initialized in https://github.com/near/homebrew-tap/pull/1.

The publisher authenticates with a write-enabled deploy key scoped only to `near/homebrew-tap`; the private key is stored as the `HOMEBREW_TAP_DEPLOY_KEY` Actions secret.

## Validation

- cargo-dist 0.32.0 generated `near.rb` for v0.29.0
- `dist plan` includes the Homebrew artifact and publisher
- `cargo metadata --no-deps --format-version=1`
- `actionlint` (no workflow/expression errors; generated shell snippets retain existing informational ShellCheck findings)
- `git diff --check`
