### PR TITLE
chore: release v0.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.0](https://github.com/near/near-cli-rs/compare/v0.29.0...v0.30.0) - 2026-08-17
+
+### Added
+
+- fetch gas keys from network and allow user to choose them ([#641](https://github.com/near/near-cli-rs/pull/641))
+- display `ml-dsa-65-hash` when displaying ml-dsa-65 pubkey ([#640](https://github.com/near/near-cli-rs/pull/640))
+- Added the ability to view FT for all contracts in the account ([#620](https://github.com/near/near-cli-rs/pull/620))
+
+### Other
+
+- document Homebrew installation ([#642](https://github.com/near/near-cli-rs/pull/642))
+- bump actions/checkout ([#639](https://github.com/near/near-cli-rs/pull/639))
+- *(ci)* fix workflows and upd deps ([#638](https://github.com/near/near-cli-rs/pull/638))
+
 ## [0.29.0](https://github.com/near/near-cli-rs/compare/v0.28.0...v0.29.0) - 2026-07-17
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2532,7 +2532,7 @@ dependencies = [
 
 [[package]]
 name = "near-cli-rs"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "bip39",
  "borsh",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-cli-rs"
-version = "0.29.0"
+version = "0.30.0"
 authors = ["FroVolod <frol_off@meta.ua>", "Near Inc <hello@nearprotocol.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2024"


### PR DESCRIPTION



## 🤖 New release

* `near-cli-rs`: 0.29.0 -> 0.30.0 (⚠ API breaking changes)

### ⚠ `near-cli-rs` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.48.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field NetworkConfig.nearblocks_url in /tmp/.tmpb8UOBD/near-cli-rs/src/config/mod.rs:257
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.30.0](https://github.com/near/near-cli-rs/compare/v0.29.0...v0.30.0) - 2026-08-17

### Added

- fetch gas keys from network and allow user to choose them ([#641](https://github.com/near/near-cli-rs/pull/641))
- display `ml-dsa-65-hash` when displaying ml-dsa-65 pubkey ([#640](https://github.com/near/near-cli-rs/pull/640))
- Added the ability to view FT for all contracts in the account ([#620](https://github.com/near/near-cli-rs/pull/620))

### Other

- document Homebrew installation ([#642](https://github.com/near/near-cli-rs/pull/642))
- bump actions/checkout ([#639](https://github.com/near/near-cli-rs/pull/639))
- *(ci)* fix workflows and upd deps ([#638](https://github.com/near/near-cli-rs/pull/638))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).