### PR TITLE
feat: fetch gas keys from network and allow user to choose them

### DIFF
--- a/src/commands/account/delete_key/public_keys_to_delete.rs
+++ b/src/commands/account/delete_key/public_keys_to_delete.rs
@@ -1,9 +1,7 @@
-use color_eyre::owo_colors::OwoColorize;
 use inquire::ui::{Color, RenderConfig, Styled};
 use inquire::{CustomType, MultiSelect, formatter::MultiOptionFormatter};
 
-use crate::common::JsonRpcClientExt;
-use crate::common::RpcQueryResponseExt;
+use crate::common::AccessKeyInfo;
 
 #[derive(Debug, Clone, interactive_clap::InteractiveClap)]
 #[interactive_clap(input_context = super::DeleteKeysCommandContext)]
@@ -95,45 +93,11 @@ impl PublicKeyList {
         if context.global_context.offline {
             return Self::input_public_keys_manually();
         }
-        let mut access_key_list: Vec<AccessKeyInfo> = vec![];
-        let mut processed_network: Vec<String> = vec![];
-        let mut errors: Vec<String> = vec![];
-        for (_, network_config) in context.global_context.config.network_connection.iter() {
-            if processed_network.contains(&network_config.network_name) {
-                continue;
-            }
-            match network_config
-                .json_rpc_client()
-                .blocking_call_view_access_key_list(
-                    &context.owner_account_id,
-                    near_primitives::types::Finality::Final.into(),
-                ) {
-                Ok(rpc_query_response) => {
-                    let access_key_list_for_network = rpc_query_response.access_key_list_view()?;
-                    access_key_list.extend(access_key_list_for_network.keys.iter().filter_map(
-                        |access_key_info_view| {
-                            // In 2.13 the access-key list returns a `PublicKeyHandle`.
-                            // ML-DSA-65 keys are stored on-chain only as a hash, so the
-                            // full public key needed to build a DeleteKey action can't be
-                            // recovered here; `full_pubkey()` returns `None` for them and
-                            // they are skipped from the interactive picker.
-                            access_key_info_view
-                                .public_key
-                                .full_pubkey()
-                                .map(|public_key| AccessKeyInfo {
-                                    public_key,
-                                    permission: access_key_info_view.access_key.permission.clone(),
-                                    network_name: network_config.network_name.clone(),
-                                })
-                        },
-                    ));
-                    processed_network.push(network_config.network_name.to_string());
-                }
-                Err(err) => {
-                    errors.push(err.to_string());
-                }
-            }
-        }
+
+        let (access_key_list, errors) = crate::common::get_public_keys_from_network_config(
+            &context.global_context,
+            &context.owner_account_id,
+        )?;
 
         if access_key_list.is_empty() {
             for error in errors {
@@ -180,97 +144,6 @@ impl PublicKeyList {
         .collect::<Vec<_>>();
 
         Ok(Some(selected_public_keys.into()))
-    }
-}
-
-#[derive(Debug, Clone)]
-struct AccessKeyInfo {
-    public_key: near_crypto::PublicKey,
-    permission: near_primitives::views::AccessKeyPermissionView,
-    network_name: String,
-}
-
-impl std::fmt::Display for AccessKeyInfo {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match &self.permission {
-            near_primitives::views::AccessKeyPermissionView::FullAccess => {
-                write!(
-                    f,
-                    "{} {}\t{}",
-                    self.network_name.blue(),
-                    self.public_key.yellow(),
-                    "full access".yellow()
-                )
-            }
-            near_primitives::views::AccessKeyPermissionView::FunctionCall {
-                allowance,
-                receiver_id,
-                method_names,
-            } => {
-                let allowance_message = match allowance {
-                    Some(amount) => format!("with a remaining fee allowance of {amount}"),
-                    None => "with no limit".to_string(),
-                };
-                if method_names.is_empty() {
-                    write!(
-                        f,
-                        "{} {}\t{} {} {}",
-                        self.network_name.blue(),
-                        self.public_key.green(),
-                        "call any function on".green(),
-                        receiver_id.green(),
-                        allowance_message.green()
-                    )
-                } else {
-                    write!(
-                        f,
-                        "{} {}\t{} {:?} {} {} {}",
-                        self.network_name.blue(),
-                        self.public_key.green(),
-                        "call".green(),
-                        method_names.green(),
-                        "function(s) on".green(),
-                        receiver_id.green(),
-                        allowance_message.green()
-                    )
-                }
-            }
-            near_primitives::views::AccessKeyPermissionView::GasKeyFunctionCall {
-                balance,
-                receiver_id,
-                method_names,
-                ..
-            } => {
-                let methods = if method_names.is_empty() {
-                    "any methods".to_string()
-                } else {
-                    format!("{method_names:?}")
-                };
-                write!(
-                    f,
-                    "{} {}\t{} ({}, {})",
-                    self.network_name.blue(),
-                    self.public_key.cyan(),
-                    "gas key for function calls".cyan(),
-                    format!("on {receiver_id} {methods}").cyan(),
-                    format!("balance: {}", balance.exact_amount_display()).cyan()
-                )
-            }
-            near_primitives::views::AccessKeyPermissionView::GasKeyFullAccess {
-                balance,
-                num_nonces,
-            } => {
-                write!(
-                    f,
-                    "{} {}\t{} ({}, {})",
-                    self.network_name.blue(),
-                    self.public_key.cyan(),
-                    "gas key with full access".cyan(),
-                    format!("balance: {}", balance.exact_amount_display()).cyan(),
-                    format!("nonces: {num_nonces}").cyan()
-                )
-            }
-        }
     }
 }
 

--- a/src/commands/account/fund_gas_key/mod.rs
+++ b/src/commands/account/fund_gas_key/mod.rs
@@ -99,7 +99,23 @@ impl FundGasKeyDetails {
             &context.owner_account_id,
         )?;
 
-        let access_key_list: Vec<AccessKeyInfo> = access_key_list
+        if access_key_list.is_empty() {
+            if errors.is_empty() {
+                return Err(color_eyre::eyre::eyre!(
+                    "No access keys found for <{}> on [{}] network(s).",
+                    context.owner_account_id,
+                    context.global_context.config.network_names().join(", ")
+                ));
+            }
+            return Err(color_eyre::eyre::eyre!(
+                "Failed to fetch access keys for <{}> on [{}] network(s):\n{}",
+                context.owner_account_id,
+                context.global_context.config.network_names().join(", "),
+                errors.join("\n")
+            ));
+        }
+
+        let filtered_access_key_list: Vec<AccessKeyInfo> = access_key_list
             .iter()
             .filter(|info| {
                 matches!(
@@ -111,12 +127,12 @@ impl FundGasKeyDetails {
             .cloned()
             .collect();
 
-        if access_key_list.is_empty() {
+        if filtered_access_key_list.is_empty() {
             for error in errors {
                 println!("WARNING! {error}");
             }
             println!(
-                "Automatic search of gas keys for <{}> is not possible on [{}] network(s).\nYou can enter gas key to fund manually.",
+                "No gas keys found for <{}> on [{}] network(s).\nYou can enter a gas key to fund manually.",
                 context.owner_account_id,
                 context.global_context.config.network_names().join(", ")
             );
@@ -125,10 +141,12 @@ impl FundGasKeyDetails {
 
         let formatter: OptionFormatter<'_, AccessKeyInfo> = &|a| a.to_string();
 
-        let selected_public_key =
-            Select::new("Select the GasKey you want to fund:", access_key_list)
-                .with_formatter(formatter)
-                .prompt()?;
+        let selected_public_key = Select::new(
+            "Select the GasKey you want to fund:",
+            filtered_access_key_list,
+        )
+        .with_formatter(formatter)
+        .prompt()?;
 
         Ok(Some(selected_public_key.public_key.clone().into()))
     }

--- a/src/commands/account/fund_gas_key/mod.rs
+++ b/src/commands/account/fund_gas_key/mod.rs
@@ -1,28 +1,37 @@
+use inquire::{CustomType, Select, formatter::OptionFormatter};
+
+use crate::common::AccessKeyInfo;
+
 #[derive(Debug, Clone, interactive_clap::InteractiveClap)]
 #[interactive_clap(input_context = crate::GlobalContext)]
-#[interactive_clap(output_context = FundGasKeyContext)]
+#[interactive_clap(output_context = FundGasKeyCommandContext)]
 pub struct FundGasKeyCommand {
     #[interactive_clap(skip_default_input_arg)]
     /// Which account owns the gas key you want to fund?
     owner_account_id: crate::types::account_id::AccountId,
-    /// Enter the public key of the gas key:
-    public_key: crate::types::public_key::PublicKey,
-    /// How much NEAR do you want to transfer into the gas key balance? (example: 1 NEAR or 0.5 NEAR or 10000 yoctonear)
-    amount: crate::types::near_token::NearToken,
-    #[interactive_clap(named_arg)]
-    /// Select network
-    network_config: crate::network_for_transaction::NetworkForTransactionArgs,
+    #[interactive_clap(subargs)]
+    /// Input Fund GasKey details
+    fund_gas_key_details: FundGasKeyDetails,
 }
 
 #[derive(Debug, Clone)]
-pub struct FundGasKeyContext {
+pub struct FundGasKeyCommandContext {
     global_context: crate::GlobalContext,
     owner_account_id: near_primitives::types::AccountId,
-    public_key: crate::types::public_key::PublicKey,
-    amount: crate::types::near_token::NearToken,
 }
 
-impl FundGasKeyContext {
+impl FundGasKeyCommand {
+    pub fn input_owner_account_id(
+        context: &crate::GlobalContext,
+    ) -> color_eyre::eyre::Result<Option<crate::types::account_id::AccountId>> {
+        crate::common::input_signer_account_id_from_used_account_list(
+            &context.config.credentials_home_dir,
+            "Which account owns the gas key you want to fund?",
+        )
+    }
+}
+
+impl FundGasKeyCommandContext {
     pub fn from_previous_context(
         previous_context: crate::GlobalContext,
         scope: &<FundGasKeyCommand as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
@@ -30,14 +39,103 @@ impl FundGasKeyContext {
         Ok(Self {
             global_context: previous_context,
             owner_account_id: scope.owner_account_id.clone().into(),
-            public_key: scope.public_key.clone(),
+        })
+    }
+}
+
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(input_context = FundGasKeyCommandContext)]
+#[interactive_clap(output_context = FundGasKeyDetailsContext)]
+pub struct FundGasKeyDetails {
+    #[interactive_clap(skip_default_input_arg)]
+    /// Enter the public key of the gas key:
+    public_key: crate::types::public_key::PublicKey,
+
+    /// How much NEAR do you want to transfer into the gas key balance? (example: 1 NEAR or 0.5 NEAR or 10000 yoctonear)
+    amount: crate::types::near_token::NearToken,
+
+    #[interactive_clap(named_arg)]
+    /// Select network
+    network_config: crate::network_for_transaction::NetworkForTransactionArgs,
+}
+
+#[derive(Debug, Clone)]
+pub struct FundGasKeyDetailsContext {
+    global_context: crate::GlobalContext,
+    owner_account_id: near_primitives::types::AccountId,
+    public_key: near_crypto::PublicKey,
+    amount: crate::types::near_token::NearToken,
+}
+
+impl FundGasKeyDetailsContext {
+    pub fn from_previous_context(
+        previous_context: FundGasKeyCommandContext,
+        scope: &<FundGasKeyDetails as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+    ) -> color_eyre::Result<Self> {
+        Ok(Self {
+            global_context: previous_context.global_context,
+            owner_account_id: previous_context.owner_account_id,
+            public_key: scope.public_key.clone().into(),
             amount: scope.amount,
         })
     }
 }
 
-impl From<FundGasKeyContext> for crate::commands::ActionContext {
-    fn from(item: FundGasKeyContext) -> Self {
+impl FundGasKeyDetails {
+    pub fn input_public_key_manually()
+    -> color_eyre::eyre::Result<Option<crate::types::public_key::PublicKey>> {
+        Ok(Some(CustomType::new("Enter a GasKey public key you want to fund (for example, ed25519:FAXX...RUQa or ed25519:FgVF...oSWJ):").prompt()?))
+    }
+
+    pub fn input_public_key(
+        context: &FundGasKeyCommandContext,
+    ) -> color_eyre::eyre::Result<Option<crate::types::public_key::PublicKey>> {
+        if context.global_context.offline {
+            return Self::input_public_key_manually();
+        }
+
+        let (access_key_list, errors) = crate::common::get_public_keys_from_network_config(
+            &context.global_context,
+            &context.owner_account_id,
+        )?;
+
+        let access_key_list: Vec<AccessKeyInfo> = access_key_list
+            .iter()
+            .filter(|info| {
+                matches!(
+                    info.permission,
+                    near_primitives::views::AccessKeyPermissionView::GasKeyFunctionCall { .. }
+                        | near_primitives::views::AccessKeyPermissionView::GasKeyFullAccess { .. }
+                )
+            })
+            .cloned()
+            .collect();
+
+        if access_key_list.is_empty() {
+            for error in errors {
+                println!("WARNING! {error}");
+            }
+            println!(
+                "Automatic search of gas keys for <{}> is not possible on [{}] network(s).\nYou can enter gas key to fund manually.",
+                context.owner_account_id,
+                context.global_context.config.network_names().join(", ")
+            );
+            return Self::input_public_key_manually();
+        }
+
+        let formatter: OptionFormatter<'_, AccessKeyInfo> = &|a| a.to_string();
+
+        let selected_public_key =
+            Select::new("Select the GasKey you want to fund:", access_key_list)
+                .with_formatter(formatter)
+                .prompt()?;
+
+        Ok(Some(selected_public_key.public_key.clone().into()))
+    }
+}
+
+impl From<FundGasKeyDetailsContext> for crate::commands::ActionContext {
+    fn from(item: FundGasKeyDetailsContext) -> Self {
         let get_prepopulated_transaction_after_getting_network_callback: crate::commands::GetPrepopulatedTransactionAfterGettingNetworkCallback =
             std::sync::Arc::new({
                 let owner_account_id = item.owner_account_id.clone();
@@ -50,7 +148,7 @@ impl From<FundGasKeyContext> for crate::commands::ActionContext {
                         receiver_id: owner_account_id.clone(),
                         actions: vec![near_primitives::transaction::Action::TransferToGasKey(
                             Box::new(near_primitives::action::TransferToGasKeyAction {
-                                public_key: public_key.clone().into(),
+                                public_key: public_key.clone(),
                                 deposit: amount.into(),
                             }),
                         )],
@@ -74,16 +172,5 @@ impl From<FundGasKeyContext> for crate::commands::ActionContext {
             sign_as_delegate_action: false,
             on_sending_delegate_action_callback: None,
         }
-    }
-}
-
-impl FundGasKeyCommand {
-    pub fn input_owner_account_id(
-        context: &crate::GlobalContext,
-    ) -> color_eyre::eyre::Result<Option<crate::types::account_id::AccountId>> {
-        crate::common::input_signer_account_id_from_used_account_list(
-            &context.config.credentials_home_dir,
-            "Which account owns the gas key you want to fund?",
-        )
     }
 }

--- a/src/commands/account/withdraw_from_gas_key/mod.rs
+++ b/src/commands/account/withdraw_from_gas_key/mod.rs
@@ -1,28 +1,26 @@
+use inquire::{CustomType, Select, formatter::OptionFormatter};
+
+use crate::common::AccessKeyInfo;
+
 #[derive(Debug, Clone, interactive_clap::InteractiveClap)]
 #[interactive_clap(input_context = crate::GlobalContext)]
-#[interactive_clap(output_context = WithdrawFromGasKeyContext)]
+#[interactive_clap(output_context = WithdrawFromGasKeyCommandContext)]
 pub struct WithdrawFromGasKeyCommand {
     #[interactive_clap(skip_default_input_arg)]
     /// Which account owns the gas key you want to withdraw from?
     owner_account_id: crate::types::account_id::AccountId,
-    /// Enter the public key of the gas key:
-    public_key: crate::types::public_key::PublicKey,
-    /// How much NEAR do you want to withdraw from the gas key balance back to the account? (example: 1 NEAR or 0.5 NEAR or 10000 yoctonear)
-    amount: crate::types::near_token::NearToken,
-    #[interactive_clap(named_arg)]
-    /// Select network
-    network_config: crate::network_for_transaction::NetworkForTransactionArgs,
+    #[interactive_clap(subargs)]
+    /// Input Withdraw GasKey details
+    withdraw_gas_key_details: WithdrawFromGasKeyDetails,
 }
 
 #[derive(Debug, Clone)]
-pub struct WithdrawFromGasKeyContext {
+pub struct WithdrawFromGasKeyCommandContext {
     global_context: crate::GlobalContext,
     owner_account_id: near_primitives::types::AccountId,
-    public_key: crate::types::public_key::PublicKey,
-    amount: crate::types::near_token::NearToken,
 }
 
-impl WithdrawFromGasKeyContext {
+impl WithdrawFromGasKeyCommandContext {
     pub fn from_previous_context(
         previous_context: crate::GlobalContext,
         scope: &<WithdrawFromGasKeyCommand as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
@@ -30,14 +28,116 @@ impl WithdrawFromGasKeyContext {
         Ok(Self {
             global_context: previous_context,
             owner_account_id: scope.owner_account_id.clone().into(),
-            public_key: scope.public_key.clone(),
+        })
+    }
+}
+
+impl WithdrawFromGasKeyCommand {
+    pub fn input_owner_account_id(
+        context: &crate::GlobalContext,
+    ) -> color_eyre::eyre::Result<Option<crate::types::account_id::AccountId>> {
+        crate::common::input_signer_account_id_from_used_account_list(
+            &context.config.credentials_home_dir,
+            "Which account owns the gas key you want to withdraw from?",
+        )
+    }
+}
+
+#[derive(Debug, Clone, interactive_clap::InteractiveClap)]
+#[interactive_clap(input_context = WithdrawFromGasKeyCommandContext)]
+#[interactive_clap(output_context = WithdrawFromGasKeyDetailsContext)]
+pub struct WithdrawFromGasKeyDetails {
+    #[interactive_clap(skip_default_input_arg)]
+    /// Enter the public key of the gas key:
+    public_key: crate::types::public_key::PublicKey,
+
+    /// How much NEAR do you want to withdraw from the gas key balance back to the account? (example: 1 NEAR or 0.5 NEAR or 10000 yoctonear)
+    amount: crate::types::near_token::NearToken,
+
+    #[interactive_clap(named_arg)]
+    /// Select network
+    network_config: crate::network_for_transaction::NetworkForTransactionArgs,
+}
+
+#[derive(Debug, Clone)]
+pub struct WithdrawFromGasKeyDetailsContext {
+    global_context: crate::GlobalContext,
+    owner_account_id: near_primitives::types::AccountId,
+    public_key: near_crypto::PublicKey,
+    amount: crate::types::near_token::NearToken,
+}
+
+impl WithdrawFromGasKeyDetailsContext {
+    pub fn from_previous_context(
+        previous_context: WithdrawFromGasKeyCommandContext,
+        scope: &<WithdrawFromGasKeyDetails as interactive_clap::ToInteractiveClapContextScope>::InteractiveClapContextScope,
+    ) -> color_eyre::eyre::Result<Self> {
+        Ok(Self {
+            global_context: previous_context.global_context,
+            owner_account_id: previous_context.owner_account_id,
+            public_key: scope.public_key.clone().into(),
             amount: scope.amount,
         })
     }
 }
 
-impl From<WithdrawFromGasKeyContext> for crate::commands::ActionContext {
-    fn from(item: WithdrawFromGasKeyContext) -> Self {
+impl WithdrawFromGasKeyDetails {
+    pub fn input_public_key_manually()
+    -> color_eyre::eyre::Result<Option<crate::types::public_key::PublicKey>> {
+        Ok(Some(CustomType::new("Enter a GasKey public key you want to withdraw funds from (for example, ed25519:FAXX...RUQa or ed25519:FgVF...oSWJ):").prompt()?))
+    }
+
+    pub fn input_public_key(
+        context: &WithdrawFromGasKeyCommandContext,
+    ) -> color_eyre::eyre::Result<Option<crate::types::public_key::PublicKey>> {
+        if context.global_context.offline {
+            return Self::input_public_key_manually();
+        }
+
+        let (access_key_list, errors) = crate::common::get_public_keys_from_network_config(
+            &context.global_context,
+            &context.owner_account_id,
+        )?;
+
+        let access_key_list: Vec<AccessKeyInfo> = access_key_list
+            .iter()
+            .filter(|info| {
+                matches!(
+                    info.permission,
+                    near_primitives::views::AccessKeyPermissionView::GasKeyFunctionCall { .. }
+                        | near_primitives::views::AccessKeyPermissionView::GasKeyFullAccess { .. }
+                )
+            })
+            .cloned()
+            .collect();
+
+        if access_key_list.is_empty() {
+            for error in errors {
+                println!("WARNING! {error}");
+            }
+            println!(
+                "Automatic search of gas keys for <{}> is not possible on [{}] network(s).\nYou can enter gas key to withdraw funds from manually.",
+                context.owner_account_id,
+                context.global_context.config.network_names().join(", ")
+            );
+            return Self::input_public_key_manually();
+        }
+
+        let formatter: OptionFormatter<'_, AccessKeyInfo> = &|a| a.to_string();
+
+        let selected_public_key = Select::new(
+            "Select the GasKey you want to withdraw from:",
+            access_key_list,
+        )
+        .with_formatter(formatter)
+        .prompt()?;
+
+        Ok(Some(selected_public_key.public_key.clone().into()))
+    }
+}
+
+impl From<WithdrawFromGasKeyDetailsContext> for crate::commands::ActionContext {
+    fn from(item: WithdrawFromGasKeyDetailsContext) -> Self {
         let get_prepopulated_transaction_after_getting_network_callback: crate::commands::GetPrepopulatedTransactionAfterGettingNetworkCallback =
             std::sync::Arc::new({
                 let owner_account_id = item.owner_account_id.clone();
@@ -50,7 +150,7 @@ impl From<WithdrawFromGasKeyContext> for crate::commands::ActionContext {
                         receiver_id: owner_account_id.clone(),
                         actions: vec![near_primitives::transaction::Action::WithdrawFromGasKey(
                             Box::new(near_primitives::action::WithdrawFromGasKeyAction {
-                                public_key: public_key.clone().into(),
+                                public_key: public_key.clone(),
                                 amount: amount.into(),
                             }),
                         )],
@@ -74,16 +174,5 @@ impl From<WithdrawFromGasKeyContext> for crate::commands::ActionContext {
             sign_as_delegate_action: false,
             on_sending_delegate_action_callback: None,
         }
-    }
-}
-
-impl WithdrawFromGasKeyCommand {
-    pub fn input_owner_account_id(
-        context: &crate::GlobalContext,
-    ) -> color_eyre::eyre::Result<Option<crate::types::account_id::AccountId>> {
-        crate::common::input_signer_account_id_from_used_account_list(
-            &context.config.credentials_home_dir,
-            "Which account owns the gas key you want to withdraw from?",
-        )
     }
 }

--- a/src/commands/account/withdraw_from_gas_key/mod.rs
+++ b/src/commands/account/withdraw_from_gas_key/mod.rs
@@ -99,7 +99,23 @@ impl WithdrawFromGasKeyDetails {
             &context.owner_account_id,
         )?;
 
-        let access_key_list: Vec<AccessKeyInfo> = access_key_list
+        if access_key_list.is_empty() {
+            if errors.is_empty() {
+                return Err(color_eyre::eyre::eyre!(
+                    "No access keys found for <{}> on [{}] network(s).",
+                    context.owner_account_id,
+                    context.global_context.config.network_names().join(", ")
+                ));
+            }
+            return Err(color_eyre::eyre::eyre!(
+                "Failed to fetch access keys for <{}> on [{}] network(s):\n{}",
+                context.owner_account_id,
+                context.global_context.config.network_names().join(", "),
+                errors.join("\n")
+            ));
+        }
+
+        let filtered_access_key_list: Vec<AccessKeyInfo> = access_key_list
             .iter()
             .filter(|info| {
                 matches!(
@@ -111,12 +127,12 @@ impl WithdrawFromGasKeyDetails {
             .cloned()
             .collect();
 
-        if access_key_list.is_empty() {
+        if filtered_access_key_list.is_empty() {
             for error in errors {
                 println!("WARNING! {error}");
             }
             println!(
-                "Automatic search of gas keys for <{}> is not possible on [{}] network(s).\nYou can enter gas key to withdraw funds from manually.",
+                "No gas keys found for <{}> on [{}] network(s).\nYou can enter a gas key to withdraw from manually.",
                 context.owner_account_id,
                 context.global_context.config.network_names().join(", ")
             );
@@ -127,7 +143,7 @@ impl WithdrawFromGasKeyDetails {
 
         let selected_public_key = Select::new(
             "Select the GasKey you want to withdraw from:",
-            access_key_list,
+            filtered_access_key_list,
         )
         .with_formatter(formatter)
         .prompt()?;

--- a/src/common.rs
+++ b/src/common.rs
@@ -727,6 +727,160 @@ fn need_check_account(message: String) -> color_eyre::eyre::Result<bool> {
     Ok(select_choose_input == ConfirmOptions::Yes)
 }
 
+#[derive(Debug, Clone)]
+pub struct AccessKeyInfo {
+    pub public_key: near_crypto::PublicKey,
+    pub permission: near_primitives::views::AccessKeyPermissionView,
+    pub network_name: String,
+}
+
+impl std::fmt::Display for AccessKeyInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self.permission {
+            near_primitives::views::AccessKeyPermissionView::FullAccess => {
+                write!(
+                    f,
+                    "{} {}\t{}",
+                    self.network_name.blue(),
+                    self.public_key.yellow(),
+                    "full access".yellow()
+                )
+            }
+            near_primitives::views::AccessKeyPermissionView::FunctionCall {
+                allowance,
+                receiver_id,
+                method_names,
+            } => {
+                let allowance_message = match allowance {
+                    Some(amount) => format!("with a remaining fee allowance of {amount}"),
+                    None => "with no limit".to_string(),
+                };
+                if method_names.is_empty() {
+                    write!(
+                        f,
+                        "{} {}\t{} {} {}",
+                        self.network_name.blue(),
+                        self.public_key.green(),
+                        "call any function on".green(),
+                        receiver_id.green(),
+                        allowance_message.green()
+                    )
+                } else {
+                    write!(
+                        f,
+                        "{} {}\t{} {:?} {} {} {}",
+                        self.network_name.blue(),
+                        self.public_key.green(),
+                        "call".green(),
+                        method_names.green(),
+                        "function(s) on".green(),
+                        receiver_id.green(),
+                        allowance_message.green()
+                    )
+                }
+            }
+            near_primitives::views::AccessKeyPermissionView::GasKeyFunctionCall {
+                balance,
+                receiver_id,
+                method_names,
+                ..
+            } => {
+                let methods = if method_names.is_empty() {
+                    "any methods".to_string()
+                } else {
+                    format!("{method_names:?}")
+                };
+                write!(
+                    f,
+                    "{} {}\t{} ({}, {})",
+                    self.network_name.blue(),
+                    self.public_key.cyan(),
+                    "gas key for function calls".cyan(),
+                    format!("on {receiver_id} {methods}").cyan(),
+                    format!("balance: {}", balance.exact_amount_display()).cyan()
+                )
+            }
+            near_primitives::views::AccessKeyPermissionView::GasKeyFullAccess {
+                balance,
+                num_nonces,
+            } => {
+                write!(
+                    f,
+                    "{} {}\t{} ({}, {})",
+                    self.network_name.blue(),
+                    self.public_key.cyan(),
+                    "gas key with full access".cyan(),
+                    format!("balance: {}", balance.exact_amount_display()).cyan(),
+                    format!("nonces: {num_nonces}").cyan()
+                )
+            }
+        }
+    }
+}
+
+pub fn get_public_keys_from_network_config(
+    global_context: &crate::GlobalContext,
+    owner_account_id: &near_primitives::types::AccountId,
+) -> color_eyre::eyre::Result<(Vec<AccessKeyInfo>, Vec<String>)> {
+    if global_context.offline {
+        return Ok((
+            vec![],
+            vec!["Cannot fetch public keys in offline mode".to_string()],
+        ));
+    }
+
+    if global_context.config.network_connection.is_empty() {
+        return Ok((
+            vec![],
+            vec!["Network connection config is empty".to_string()],
+        ));
+    }
+
+    let mut access_key_list: Vec<AccessKeyInfo> = vec![];
+    let mut processed_networks: Vec<String> = vec![];
+    let mut errors: Vec<String> = vec![];
+
+    for (_, network_config) in global_context.config.network_connection.iter() {
+        if processed_networks.contains(&network_config.network_name) {
+            continue;
+        }
+
+        match network_config
+            .json_rpc_client()
+            .blocking_call_view_access_key_list(
+                owner_account_id,
+                near_primitives::types::Finality::Final.into(),
+            ) {
+            Ok(rpc_query_response) => {
+                let access_key_list_for_network = rpc_query_response.access_key_list_view()?;
+                access_key_list.extend(access_key_list_for_network.keys.iter().filter_map(
+                    |access_key_info_view| {
+                        // In 2.13 the access-key list returns a `PublicKeyHandle`.
+                        // ML-DSA-65 keys are stored on-chain only as a hash, so the
+                        // full public key needed to build a actions can't be
+                        // recovered here; `full_pubkey()` returns `None` for them and
+                        // they are skipped from the interactive picker.
+                        access_key_info_view
+                            .public_key
+                            .full_pubkey()
+                            .map(|public_key| AccessKeyInfo {
+                                public_key,
+                                permission: access_key_info_view.access_key.permission.clone(),
+                                network_name: network_config.network_name.clone(),
+                            })
+                    },
+                ));
+                processed_networks.push(network_config.network_name.to_string());
+            }
+            Err(err) => {
+                errors.push(err.to_string());
+            }
+        }
+    }
+
+    Ok((access_key_list, errors))
+}
+
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct KeyPairProperties {
     pub seed_phrase_hd_path: crate::types::slip10::BIP32Path,


### PR DESCRIPTION
`near account fund-gas-keys` and `near account withdraw-from-gas-key` previously required typing the gas key public key manually.

This PR reuses similar flow to `near account delete-keys` to allow user choosing gas key fetched from network instead of copy-pasting it.
