### PR TITLE
docs: document Homebrew installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,14 @@ Just run `near` and let it guide you through!
 Visit [Releases page](https://github.com/near/near-cli-rs/releases/) to see the latest updates.
 
 <details>
+  <summary>Install via Homebrew (macOS and Linux)</summary>
+
+```sh
+brew install near
+```
+</details>
+
+<details>
   <summary>Install via Windows Installer (Windows)</summary>
 
   


### PR DESCRIPTION
## Summary

- add `brew install near` to the README install options

## Why

`near` is published in homebrew-core (https://formulae.brew.sh/formula/near) with bottles for macOS and Linux, and Homebrew autobumps it on new releases. That makes the `near/homebrew-tap` publisher from #632 unnecessary, so this replaces that PR with just the docs change.