### PR TITLE
fix: paginate view_state queries so large contract state can be read

### DIFF
--- a/src/commands/contract/view_storage/output_format/as_json.rs
+++ b/src/commands/contract/view_storage/output_format/as_json.rs
@@ -20,17 +20,9 @@ impl AsJsonContext {
             let prefix = previous_context.prefix;
 
             move |network_config, block_reference| {
-                let query_view_method_response =
+                let values =
                     super::get_contract_state(&contract_account_id, prefix.clone(), network_config, block_reference.clone())?;
-
-                if let near_jsonrpc_primitives::types::query::QueryResponseKind::ViewState(result) =
-                    query_view_method_response.kind
-                {
-                    println!("Contract state (values):\n{}\n", serde_json::to_string_pretty(&result.values)?);
-                    println!("Contract state (proof):\n{:#?}\n", result.proof);
-                } else {
-                    return Err(color_eyre::Report::msg("Error call result".to_string()));
-                };
+                println!("Contract state (values):\n{}\n", serde_json::to_string_pretty(&values)?);
                 Ok(())
             }
         });

--- a/src/commands/contract/view_storage/output_format/as_text.rs
+++ b/src/commands/contract/view_storage/output_format/as_text.rs
@@ -22,23 +22,15 @@ impl AsTextContext {
             let prefix = previous_context.prefix;
 
             move |network_config, block_reference| {
-                let query_view_method_response =
+                let values =
                     super::get_contract_state(&contract_account_id, prefix.clone(), network_config, block_reference.clone())?;
-
-                if let near_jsonrpc_primitives::types::query::QueryResponseKind::ViewState(result) =
-                    query_view_method_response.kind
-                {
-                    let mut info_str = String::new();
-                    for value in &result.values {
-                        info_str.push_str(&format!("\n\tkey:   {}", key_value_to_string(&value.key)?.green()));
-                        info_str.push_str(&format!("\n\tvalue: {}", key_value_to_string(&value.value)?.yellow()));
-                        info_str.push_str("\n\t--------------------------------");
-                    }
-                    println!("Contract state (values):{info_str}\n");
-                    println!("Contract state (proof):\n{:#?}\n", result.proof);
-                } else {
-                    return Err(color_eyre::Report::msg("Error call result".to_string()));
-                };
+                let mut info_str = String::new();
+                for value in &values {
+                    info_str.push_str(&format!("\n\tkey:   {}", key_value_to_string(&value.key)?.green()));
+                    info_str.push_str(&format!("\n\tvalue: {}", key_value_to_string(&value.value)?.yellow()));
+                    info_str.push_str("\n\t--------------------------------");
+                }
+                println!("Contract state (values):{info_str}\n");
                 Ok(())
             }
         });

--- a/src/commands/contract/view_storage/output_format/mod.rs
+++ b/src/commands/contract/view_storage/output_format/mod.rs
@@ -1,8 +1,6 @@
 use color_eyre::eyre::Context;
 use strum::{EnumDiscriminants, EnumIter, EnumMessage};
 
-use crate::common::JsonRpcClientExt;
-
 mod as_json;
 mod as_text;
 
@@ -27,24 +25,18 @@ pub fn get_contract_state(
     prefix: near_primitives::types::StoreKey,
     network_config: &crate::config::NetworkConfig,
     block_reference: near_primitives::types::BlockReference,
-) -> color_eyre::eyre::Result<near_jsonrpc_client::methods::query::RpcQueryResponse> {
+) -> color_eyre::eyre::Result<Vec<near_primitives::views::StateItem>> {
     tracing::info!(target: "near_teach_me", "Obtaining the state of the contract ...");
-    network_config
-        .json_rpc_client()
-        .blocking_call(near_jsonrpc_client::methods::query::RpcQueryRequest {
-            block_reference,
-            request: near_primitives::views::QueryRequest::ViewState {
-                account_id: contract_account_id.clone(),
-                prefix,
-                include_proof: false,
-                after_key: None,
-                limit: None,
-            },
-        })
-        .wrap_err_with(|| {
-            format!(
-                "Failed to fetch query ViewState for <{contract_account_id}> on network <{}>",
-                network_config.network_name
-            )
-        })
+    crate::common::fetch_contract_state(
+        &network_config.json_rpc_client(),
+        contract_account_id,
+        prefix,
+        block_reference,
+    )
+    .wrap_err_with(|| {
+        format!(
+            "Failed to fetch query ViewState for <{contract_account_id}> on network <{}>",
+            network_config.network_name
+        )
+    })
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -2690,35 +2690,77 @@ pub fn fetch_historically_delegated_staking_pools(
         .collect())
 }
 
+/// Number of entries requested per `view_state` page. The node additionally caps
+/// every page at ~50 KB, so the effective page size is usually smaller.
+const VIEW_STATE_PAGE_ITEMS: std::num::NonZeroU32 = std::num::NonZeroU32::new(10_000).unwrap();
+
+/// Fetches the contract state of `account_id` under `prefix`, transparently
+/// following the `view_state` pagination cursor.
+///
+/// A non-paginated `view_state` request is rejected by most RPC nodes once the
+/// account's state exceeds ~50 KB (`TOO_LARGE_CONTRACT_STATE`). Paginated
+/// requests (nearcore 2.13+) skip that limit, so this helper always requests
+/// pages and follows `last_key` until the listing is complete. Every page after
+/// the first is read at the block the first page resolved to, so the result is a
+/// consistent snapshot even when `block_reference` is a moving finality.
+///
+/// Nodes that predate pagination ignore the paging fields and return the whole
+/// (size-capped) state without a cursor, so the loop ends after the first page.
+pub fn fetch_contract_state(
+    json_rpc_client: &near_jsonrpc_client::JsonRpcClient,
+    account_id: &near_primitives::types::AccountId,
+    prefix: near_primitives::types::StoreKey,
+    block_reference: near_primitives::types::BlockReference,
+) -> color_eyre::Result<Vec<near_primitives::views::StateItem>> {
+    let mut block_reference = block_reference;
+    let mut after_key = None;
+    let mut values = Vec::new();
+    loop {
+        let response = json_rpc_client
+            .blocking_call(near_jsonrpc_client::methods::query::RpcQueryRequest {
+                block_reference: block_reference.clone(),
+                request: near_primitives::views::QueryRequest::ViewState {
+                    account_id: account_id.clone(),
+                    prefix: prefix.clone(),
+                    include_proof: false,
+                    after_key,
+                    limit: Some(VIEW_STATE_PAGE_ITEMS),
+                },
+            })
+            .wrap_err_with(|| format!("Failed to fetch query ViewState for <{account_id}>"))?;
+        let near_jsonrpc_primitives::types::query::QueryResponseKind::ViewState(page) =
+            response.kind
+        else {
+            return Err(color_eyre::Report::msg("Error call result".to_string()));
+        };
+        values.extend(page.values);
+        match page.last_key {
+            Some(last_key) => {
+                after_key = Some(last_key);
+                block_reference = near_primitives::types::BlockReference::BlockId(
+                    near_primitives::types::BlockId::Hash(response.block_hash),
+                );
+            }
+            None => return Ok(values),
+        }
+    }
+}
+
 #[tracing::instrument(name = "Getting currently active staking pools ...", skip_all)]
 pub fn fetch_currently_active_staking_pools(
     json_rpc_client: &near_jsonrpc_client::JsonRpcClient,
     staking_pools_factory_account_id: &near_primitives::types::AccountId,
 ) -> color_eyre::Result<std::collections::BTreeSet<near_primitives::types::AccountId>> {
     tracing::info!(target: "near_teach_me", "Getting currently active staking pools ...");
-    let query_view_method_response = json_rpc_client
-        .blocking_call(near_jsonrpc_client::methods::query::RpcQueryRequest {
-            block_reference: near_primitives::types::Finality::Final.into(),
-            request: near_primitives::views::QueryRequest::ViewState {
-                account_id: staking_pools_factory_account_id.clone(),
-                prefix: near_primitives::types::StoreKey::from(b"se".to_vec()),
-                include_proof: false,
-                after_key: None,
-                limit: None,
-            },
-        })
-        .map_err(color_eyre::Report::msg)?;
-    if let near_jsonrpc_primitives::types::query::QueryResponseKind::ViewState(result) =
-        query_view_method_response.kind
-    {
-        Ok(result
-            .values
-            .into_iter()
-            .filter_map(|item| near_primitives::borsh::from_slice(&item.value).ok())
-            .collect())
-    } else {
-        Err(color_eyre::Report::msg("Error call result".to_string()))
-    }
+    Ok(fetch_contract_state(
+        json_rpc_client,
+        staking_pools_factory_account_id,
+        near_primitives::types::StoreKey::from(b"se".to_vec()),
+        near_primitives::types::Finality::Final.into(),
+    )?
+    .into_iter()
+    .filter_map(|item| near_primitives::borsh::from_slice(&item.value).ok())
+    .collect())
 }
 
 #[tracing::instrument(name = "Getting a stake of validators ...", skip_all)]


### PR DESCRIPTION
`near contract view-storage` fails with `TOO_LARGE_CONTRACT_STATE` on any account whose state exceeds the ~50 KB `view_state` cap that public RPCs enforce (`trie_viewer_state_size_limit`). The same one-shot query is used to list active staking pools for `near account view-account-summary` when no `fastnear_url` is configured, and `poolv1.near` is well past that cap, so that fallback fails too.

nearcore 2.13 added pagination to `view_state` (`limit` / `after_key_base64` → `last_key`), and paginated requests are not subject to the size cap. This adds `common::fetch_contract_state`, which always requests pages and follows the cursor until the listing is complete, and uses it from both call sites. Pages after the first are read at the block hash the first page resolved to, so `now` still yields a consistent snapshot. Older RPC nodes ignore the paging fields and return the whole (capped) state without a cursor, so behaviour there is unchanged.

Since `include_proof` was already hard-coded to `false`, the always-empty `Contract state (proof)` line is dropped from the `view-storage` output.

Verified against mainnet: `view-storage farm.berryclub.ek.near all` (7 pages, 2,799 entries, matches a raw paginated RPC walk) and `usn` (3,391 entries), both of which fail on the current release; `view-account-summary` without `fastnear_url` now lists all 556 `poolv1.near` pools.