### PR TITLE
chore: release v0.30.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.1](https://github.com/near/near-cli-rs/compare/v0.30.0...v0.30.1) - 2026-09-02
+
+### Added
+
+- make global hash deployment retry-safe ([#658](https://github.com/near/near-cli-rs/pull/658))
+
+### Fixed
+
+- For the testnet, display all fungible tokens ([#646](https://github.com/near/near-cli-rs/pull/646))
+
+### Other
+
+- `account import-account` command ([#645](https://github.com/near/near-cli-rs/pull/645))
+
 ## [0.30.0](https://github.com/near/near-cli-rs/compare/v0.29.0...v0.30.0) - 2026-08-17
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2532,7 +2532,7 @@ dependencies = [
 
 [[package]]
 name = "near-cli-rs"
-version = "0.30.0"
+version = "0.30.1"
 dependencies = [
  "bip39",
  "borsh",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "near-cli-rs"
-version = "0.30.0"
+version = "0.30.1"
 authors = ["FroVolod <frol_off@meta.ua>", "Near Inc <hello@nearprotocol.com>"]
 license = "MIT OR Apache-2.0"
 edition = "2024"


### PR DESCRIPTION



## 🤖 New release

* `near-cli-rs`: 0.30.0 -> 0.30.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.30.1](https://github.com/near/near-cli-rs/compare/v0.30.0...v0.30.1) - 2026-09-02

### Added

- make global hash deployment retry-safe ([#658](https://github.com/near/near-cli-rs/pull/658))

### Fixed

- For the testnet, display all fungible tokens ([#646](https://github.com/near/near-cli-rs/pull/646))

### Other

- `account import-account` command ([#645](https://github.com/near/near-cli-rs/pull/645))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).